### PR TITLE
fix meta parsing test

### DIFF
--- a/src/meta_parsing.rs
+++ b/src/meta_parsing.rs
@@ -228,7 +228,7 @@ impl MethodAndTypes {
         let mut parsed_types = HashMap::new();
         let mut type_sequences = vec![];
         let (method, mut types) = Method::parse(method_def)?;
-        while types.is_empty() {
+        while !types.is_empty() {
             let (ty, remains) = Method::parse(types)?;
             type_sequences.push(ty.name.clone());
             parsed_types.insert(ty.name.clone(), ty);
@@ -543,8 +543,8 @@ pub fn parse_meta_call(
     let (msg, input) =
         prepare_meta_call_args(domain_separator, account_id, meta_tx.method_def, &result)?;
     let mut signature: [u8; 65] = [0; 65];
-    signature[0] = meta_tx.v;
-    signature[1..].copy_from_slice(&meta_tx.signature);
+    signature[64] = meta_tx.v;
+    signature[..64].copy_from_slice(&meta_tx.signature);
     match ecrecover(H256::from_slice(&msg), &signature) {
         Ok(sender) => {
             result.sender = sender;

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -19,7 +19,7 @@ pub struct NewCallArgs {
 }
 
 /// Borsh-encoded parameters for the `meta_call` function.
-#[derive(BorshSerialize, BorshDeserialize)]
+#[derive(Debug, BorshSerialize, BorshDeserialize)]
 pub struct MetaCallArgs {
     pub signature: [u8; 64],
     pub v: u8,

--- a/src/types.rs
+++ b/src/types.rs
@@ -16,6 +16,7 @@ pub type RawH256 = [u8; 32];
 pub const STORAGE_PRICE_PER_BYTE: u128 = 100_000_000_000_000_000_000; // 1e20yN, 0.0001N
 
 /// Internal args format for meta call.
+#[derive(Debug)]
 pub struct InternalMetaCallArgs {
     pub sender: Address,
     pub nonce: U256,

--- a/tests/test_meta_parsing.rs
+++ b/tests/test_meta_parsing.rs
@@ -45,7 +45,7 @@ pub fn encode_meta_call_function_args(
             MetaCallArgs {
                 signature,
                 // Add 27 to align eth-sig-util signature format
-                v: array[64] + 27,
+                v: 27,
                 nonce: u256_to_arr(&nonce),
                 fee_amount: u256_to_arr(&fee_amount),
                 fee_address: fee_address.0,
@@ -73,7 +73,6 @@ pub fn public_key_to_address(public_key: PublicKey) -> Address {
     }
 }
 
-#[ignore]
 #[test]
 fn test_meta_parsing() {
     let chain_id = 1313161555;
@@ -98,7 +97,7 @@ fn test_meta_parsing() {
     // assert signature same as eth-sig-util, which also implies msg before sign (constructed by prepare_meta_call_args, follow eip-712) same
     assert_eq!(hex::encode(&meta_tx[0..65]), "4066a42cf17d167d33ef62c8cee82d3748de0e804569212a839257dafdbb9d09084bd910f16ddb9643e98a0787cdf0137cad109687a00106c701e430657ae99a1b");
     let result = parse_meta_call(&domain_separator, "evm".as_bytes(), meta_tx)
-        .unwrap_or_else(|_| panic!("Fail"));
+        .unwrap_or_else(|_| panic!("Fail meta_tx"));
     assert_eq!(result.sender, signer_addr);
 
     let meta_tx3 = encode_meta_call_function_args(
@@ -115,6 +114,6 @@ fn test_meta_parsing() {
     );
     assert_eq!(hex::encode(&meta_tx3[0..65]), "d5fc0804e27c7ee36178b5ce1f0ef97e9f9317855743f16a38cc2ec81eb852dc58f76aaebb8f0264eeb6a61ba5d094a546fa95efcded4d507708c1d96a3c06561b");
     let result = parse_meta_call(&domain_separator, "evm".as_bytes(), meta_tx3)
-        .unwrap_or_else(|_| panic!("Fail"));
+        .unwrap_or_else(|_| panic!("Fail meta_tx3"));
     assert_eq!(result.sender, signer_addr);
 }


### PR DESCRIPTION
This was a bit of a pain to fix. I assumed the wrong parts of it were broken initially. After much frusteration and pulling my hair out and reading and re-reading ETH documentation, I knew full well about the extra byte and had assumed that certainly had to do with it. Finally, had an epiphany which helped progress. Unfortunately it was still failing. That was because of a new addition that I added which I originally thought would be part of the solution. There were two minor fixes that had solved this issue. Mostly, positioning of that extra byte. It just was not entirely obvious initially. The good news is that I feel quite well versed with ecrecovery now.