### PR TITLE
Fix: Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ check-format:
 	$(CARGO) fmt -- --check
 
 clippy:
-	$(CARGO) clippy -- -D warnings
+	$(CARGO) +nightly clippy -- -D warnings
 
 clean:
 	@rm -Rf *.wasm target *~

--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,17 @@ target/wasm32-unknown-unknown/debug/aurora_engine.wasm: Cargo.toml Cargo.lock $(
 deploy: release.wasm
 	$(NEAR) deploy --account-id=$(or $(NEAR_EVM_ACCOUNT),aurora.test.near) --wasm-file=$<
 
-check:
+check: test check-format
+
+# test depends on release since `tests/test_upgrade.rs` includes `release.wasm`
+test: release
 	$(CARGO) test
 
 format:
 	$(CARGO) fmt
+
+check-format:
+	$(CARGO) fmt -- --check
 
 clean:
 	@rm -Rf *.wasm target *~

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ target/wasm32-unknown-unknown/debug/aurora_engine.wasm: Cargo.toml Cargo.lock $(
 deploy: release.wasm
 	$(NEAR) deploy --account-id=$(or $(NEAR_EVM_ACCOUNT),aurora.test.near) --wasm-file=$<
 
-check: test check-format
+check: test clippy check-format
 
 # test depends on release since `tests/test_upgrade.rs` includes `release.wasm`
 test: release
@@ -40,6 +40,9 @@ format:
 
 check-format:
 	$(CARGO) fmt -- --check
+
+clippy:
+	$(CARGO) clippy -- -D warnings
 
 clean:
 	@rm -Rf *.wasm target *~


### PR DESCRIPTION
* `make check` includes running tests, running `clippy`, checking the code formatting
* `make test` depends on release since it needs the `release.wasm` artifact