### PR TITLE
Add twice weekly run of nightly clippy

### DIFF
--- a/.github/workflows/scheduled_lints.yml
+++ b/.github/workflows/scheduled_lints.yml
@@ -1,0 +1,24 @@
+---
+on:
+  schedule:
+    - cron: '27 8 * * 1,4'
+name: Scheduled_Lints
+jobs:
+  clippy:
+    name: Nightly_Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the repository
+        uses: actions/checkout@v2
+      - name: Install the toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+          components: clippy
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings


### PR DESCRIPTION
@joshuajbouw pointed out that there is value in running the nightly clippy, not just the one for our fixed toolchain, because there are new lints being added. This PR adds a regularly scheduled GitHub action to run nightly clippy. The reason to make it run on a schedule instead of modifying the lints which run on pushes/PRs is because we don't want failures to randomly happen if there is a new lint which flags code that was not changed by the commit/PR. The reason to make it run at a strange time (instead of on an hour or half hour) is to avoid congestion in the GitHub actions infrastructure.