### PR TITLE
Fix: Use clippy on contract code too

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -38,4 +38,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: --no-default-features --features=contract -- -D warnings

--- a/.github/workflows/scheduled_lints.yml
+++ b/.github/workflows/scheduled_lints.yml
@@ -21,4 +21,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: --no-default-features --features=contract -- -D warnings

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ check-format:
 	$(CARGO) fmt -- --check
 
 check-clippy:
-	$(CARGO) +nightly clippy -- -D warnings
+	$(CARGO) +nightly clippy --no-default-features --features=$(FEATURES) -- -D warnings
 
 # test depends on release since `tests/test_upgrade.rs` includes `release.wasm`
 test: release

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -43,7 +43,7 @@ pub struct Engine {
 }
 
 // TODO: upgrade to Berlin HF
-const CONFIG: &'static Config = &Config::istanbul();
+const CONFIG: &Config = &Config::istanbul();
 
 /// Key for storing the state of the engine.
 const STATE_KEY: &[u8; 6] = b"\0STATE";


### PR DESCRIPTION
Previously `clippy` was not being used to check code gated behind the `contract` feature flag. I assume this is because it was failing due to the presence of `on_panic` and `on_alloc_error`. However, we can only include those functions when we compile to wasm, then `clippy` will work with the `contract` feature flag.

In this PR we change the Makefile and CI to have `clippy` check the code with the `contract` feature enabled (and with no-std since that is how we compile the contract).

`clippy` found one error in `engine.rs` and two in `lib.rs`. These are also corrected in this PR.