### PR TITLE
Fix: clippy errors in eth-connector

### DIFF
--- a/src/connector.rs
+++ b/src/connector.rs
@@ -49,7 +49,7 @@ impl EthConnectorContract {
         #[cfg(feature = "log")]
         sdk::log("[init contract]".into());
         let args: InitCallArgs =
-            InitCallArgs::from(parse_json(&sdk::read_input()).expect(str_from_slice(FAILED_PARSE)));
+            InitCallArgs::from(parse_json(&sdk::read_input()).expect_utf8(FAILED_PARSE));
         let current_account_id = sdk::current_account_id();
         let owner_id = String::from_utf8(current_account_id).unwrap();
         let mut ft = FungibleToken::new();
@@ -314,7 +314,7 @@ impl EthConnectorContract {
         #[cfg(feature = "log")]
         sdk::log("Start withdraw NEAR".into());
         let args: WithdrawCallArgs = WithdrawCallArgs::from(
-            parse_json(&sdk::read_input()).expect(str_from_slice(FAILED_PARSE)),
+            parse_json(&sdk::read_input()).expect_utf8(FAILED_PARSE),
         );
         let recipient_address = validate_eth_address(args.recipient_id);
         let res = WithdrawResult {
@@ -339,7 +339,7 @@ impl EthConnectorContract {
         sdk::log("Start withdraw ETH".into());
 
         let args: WithdrawEthCallArgs = WithdrawEthCallArgs::from(
-            parse_json(&sdk::read_input()).expect(str_from_slice(FAILED_PARSE)),
+            parse_json(&sdk::read_input()).expect_utf8(FAILED_PARSE),
         );
         assert!(
             prover::verify_withdraw_eip712(
@@ -392,7 +392,7 @@ impl EthConnectorContract {
     /// Return balance of NEAR
     pub fn ft_balance_of(&self) {
         let args = BalanceOfCallArgs::from(
-            parse_json(&sdk::read_input()).expect(str_from_slice(FAILED_PARSE)),
+            parse_json(&sdk::read_input()).expect_utf8(FAILED_PARSE),
         );
         let balance = self.ft.ft_balance_of(&args.account_id);
         sdk::return_output(&balance.to_string().as_bytes());
@@ -406,7 +406,7 @@ impl EthConnectorContract {
     /// Return balance of ETH
     pub fn ft_balance_of_eth(&self) {
         let args = BalanceOfEthCallArgs::from(
-            parse_json(&sdk::read_input()).expect(str_from_slice(FAILED_PARSE)),
+            parse_json(&sdk::read_input()).expect_utf8(FAILED_PARSE),
         );
         let balance = self.ft.internal_unwrap_balance_of_eth(args.address);
         #[cfg(feature = "log")]
@@ -421,7 +421,7 @@ impl EthConnectorContract {
     /// Transfer between NEAR accounts
     pub fn ft_transfer(&mut self) {
         let args: TransferCallArgs = TransferCallArgs::from(
-            parse_json(&sdk::read_input()).expect(str_from_slice(FAILED_PARSE)),
+            parse_json(&sdk::read_input()).expect_utf8(FAILED_PARSE),
         );
 
         self.ft
@@ -438,7 +438,7 @@ impl EthConnectorContract {
     pub fn transfer_near(&mut self) {
         use crate::prover;
         let args: TransferNearCallArgs = TransferNearCallArgs::from(
-            parse_json(&sdk::read_input()).expect(str_from_slice(FAILED_PARSE)),
+            parse_json(&sdk::read_input()).expect_utf8(FAILED_PARSE),
         );
         assert!(
             prover::verify_transfer_eip712(
@@ -466,7 +466,7 @@ impl EthConnectorContract {
     /// Transfer tokens from NEAR account to ETH account
     pub fn transfer_eth(&mut self) {
         let args: TransferEthCallArgs = TransferEthCallArgs::from(
-            parse_json(&sdk::read_input()).expect(str_from_slice(FAILED_PARSE)),
+            parse_json(&sdk::read_input()).expect_utf8(FAILED_PARSE),
         );
 
         let predecessor_account_id = sdk::predecessor_account_id();
@@ -503,7 +503,7 @@ impl EthConnectorContract {
 
     pub fn ft_transfer_call(&mut self) {
         let args: TransferCallCallArgs = TransferCallCallArgs::from(
-            parse_json(&sdk::read_input()).expect(str_from_slice(FAILED_PARSE)),
+            parse_json(&sdk::read_input()).expect_utf8(FAILED_PARSE),
         );
         #[cfg(feature = "log")]
         sdk::log(format!(
@@ -517,7 +517,7 @@ impl EthConnectorContract {
 
     pub fn storage_deposit(&mut self) {
         let args: StorageDepositCallArgs = StorageDepositCallArgs::from(
-            parse_json(&sdk::read_input()).expect(str_from_slice(FAILED_PARSE)),
+            parse_json(&sdk::read_input()).expect_utf8(FAILED_PARSE),
         );
         let res = self
             .ft
@@ -530,7 +530,7 @@ impl EthConnectorContract {
 
     pub fn storage_withdraw(&mut self) {
         let args: StorageWithdrawCallArgs = StorageWithdrawCallArgs::from(
-            parse_json(&sdk::read_input()).expect(str_from_slice(FAILED_PARSE)),
+            parse_json(&sdk::read_input()).expect_utf8(FAILED_PARSE),
         );
         let res = self.ft.storage_withdraw(args.amount).try_to_vec().unwrap();
         self.save_contract();
@@ -539,7 +539,7 @@ impl EthConnectorContract {
 
     pub fn storage_balance_of(&self) {
         let args: StorageBalanceOfCallArgs = StorageBalanceOfCallArgs::from(
-            parse_json(&sdk::read_input()).expect(str_from_slice(FAILED_PARSE)),
+            parse_json(&sdk::read_input()).expect_utf8(FAILED_PARSE),
         );
         let res = self
             .ft

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -313,9 +313,8 @@ impl EthConnectorContract {
     pub fn withdraw_near(&mut self) {
         #[cfg(feature = "log")]
         sdk::log("Start withdraw NEAR".into());
-        let args: WithdrawCallArgs = WithdrawCallArgs::from(
-            parse_json(&sdk::read_input()).expect_utf8(FAILED_PARSE),
-        );
+        let args: WithdrawCallArgs =
+            WithdrawCallArgs::from(parse_json(&sdk::read_input()).expect_utf8(FAILED_PARSE));
         let recipient_address = validate_eth_address(args.recipient_id);
         let res = WithdrawResult {
             recipient_id: recipient_address,
@@ -338,9 +337,8 @@ impl EthConnectorContract {
         #[cfg(feature = "log")]
         sdk::log("Start withdraw ETH".into());
 
-        let args: WithdrawEthCallArgs = WithdrawEthCallArgs::from(
-            parse_json(&sdk::read_input()).expect_utf8(FAILED_PARSE),
-        );
+        let args: WithdrawEthCallArgs =
+            WithdrawEthCallArgs::from(parse_json(&sdk::read_input()).expect_utf8(FAILED_PARSE));
         assert!(
             prover::verify_withdraw_eip712(
                 args.sender,
@@ -391,9 +389,8 @@ impl EthConnectorContract {
 
     /// Return balance of NEAR
     pub fn ft_balance_of(&self) {
-        let args = BalanceOfCallArgs::from(
-            parse_json(&sdk::read_input()).expect_utf8(FAILED_PARSE),
-        );
+        let args =
+            BalanceOfCallArgs::from(parse_json(&sdk::read_input()).expect_utf8(FAILED_PARSE));
         let balance = self.ft.ft_balance_of(&args.account_id);
         sdk::return_output(&balance.to_string().as_bytes());
         #[cfg(feature = "log")]
@@ -405,9 +402,8 @@ impl EthConnectorContract {
 
     /// Return balance of ETH
     pub fn ft_balance_of_eth(&self) {
-        let args = BalanceOfEthCallArgs::from(
-            parse_json(&sdk::read_input()).expect_utf8(FAILED_PARSE),
-        );
+        let args =
+            BalanceOfEthCallArgs::from(parse_json(&sdk::read_input()).expect_utf8(FAILED_PARSE));
         let balance = self.ft.internal_unwrap_balance_of_eth(args.address);
         #[cfg(feature = "log")]
         sdk::log(format!(
@@ -420,9 +416,8 @@ impl EthConnectorContract {
 
     /// Transfer between NEAR accounts
     pub fn ft_transfer(&mut self) {
-        let args: TransferCallArgs = TransferCallArgs::from(
-            parse_json(&sdk::read_input()).expect_utf8(FAILED_PARSE),
-        );
+        let args: TransferCallArgs =
+            TransferCallArgs::from(parse_json(&sdk::read_input()).expect_utf8(FAILED_PARSE));
 
         self.ft
             .ft_transfer(&args.receiver_id, args.amount, &args.memo);
@@ -437,9 +432,8 @@ impl EthConnectorContract {
     /// Transfer tokens from ETH account to NEAR account
     pub fn transfer_near(&mut self) {
         use crate::prover;
-        let args: TransferNearCallArgs = TransferNearCallArgs::from(
-            parse_json(&sdk::read_input()).expect_utf8(FAILED_PARSE),
-        );
+        let args: TransferNearCallArgs =
+            TransferNearCallArgs::from(parse_json(&sdk::read_input()).expect_utf8(FAILED_PARSE));
         assert!(
             prover::verify_transfer_eip712(
                 args.sender,
@@ -465,9 +459,8 @@ impl EthConnectorContract {
 
     /// Transfer tokens from NEAR account to ETH account
     pub fn transfer_eth(&mut self) {
-        let args: TransferEthCallArgs = TransferEthCallArgs::from(
-            parse_json(&sdk::read_input()).expect_utf8(FAILED_PARSE),
-        );
+        let args: TransferEthCallArgs =
+            TransferEthCallArgs::from(parse_json(&sdk::read_input()).expect_utf8(FAILED_PARSE));
 
         let predecessor_account_id = sdk::predecessor_account_id();
         let sender_id = str_from_slice(&predecessor_account_id);
@@ -502,9 +495,8 @@ impl EthConnectorContract {
     }
 
     pub fn ft_transfer_call(&mut self) {
-        let args: TransferCallCallArgs = TransferCallCallArgs::from(
-            parse_json(&sdk::read_input()).expect_utf8(FAILED_PARSE),
-        );
+        let args: TransferCallCallArgs =
+            TransferCallCallArgs::from(parse_json(&sdk::read_input()).expect_utf8(FAILED_PARSE));
         #[cfg(feature = "log")]
         sdk::log(format!(
             "Transfer call to {} amount {}",
@@ -516,9 +508,8 @@ impl EthConnectorContract {
     }
 
     pub fn storage_deposit(&mut self) {
-        let args: StorageDepositCallArgs = StorageDepositCallArgs::from(
-            parse_json(&sdk::read_input()).expect_utf8(FAILED_PARSE),
-        );
+        let args: StorageDepositCallArgs =
+            StorageDepositCallArgs::from(parse_json(&sdk::read_input()).expect_utf8(FAILED_PARSE));
         let res = self
             .ft
             .storage_deposit(args.account_id.as_ref(), args.registration_only)
@@ -529,9 +520,8 @@ impl EthConnectorContract {
     }
 
     pub fn storage_withdraw(&mut self) {
-        let args: StorageWithdrawCallArgs = StorageWithdrawCallArgs::from(
-            parse_json(&sdk::read_input()).expect_utf8(FAILED_PARSE),
-        );
+        let args: StorageWithdrawCallArgs =
+            StorageWithdrawCallArgs::from(parse_json(&sdk::read_input()).expect_utf8(FAILED_PARSE));
         let res = self.ft.storage_withdraw(args.amount).try_to_vec().unwrap();
         self.save_contract();
         sdk::return_output(&res[..]);

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -8,7 +8,7 @@ use crate::prelude::{String, Vec};
 #[cfg(feature = "contract")]
 use crate::prover::Proof;
 #[cfg(feature = "contract")]
-use crate::types::str_from_slice;
+use crate::types::ExpectUtf8;
 use crate::types::{AccountId, RawAddress, RawH256, RawU256};
 #[cfg(feature = "contract")]
 use crate::types::{Balance, EthAddress};
@@ -167,9 +167,9 @@ pub struct FinishDepositEthCallArgs {
 impl From<json::JsonValue> for ResolveTransferCallArgs {
     fn from(v: json::JsonValue) -> Self {
         Self {
-            sender_id: v.string("sender_id").expect(str_from_slice(FAILED_PARSE)),
-            receiver_id: v.string("receiver_id").expect(str_from_slice(FAILED_PARSE)),
-            amount: v.u128("amount").expect(str_from_slice(FAILED_PARSE)),
+            sender_id: v.string("sender_id").expect_utf8(FAILED_PARSE),
+            receiver_id: v.string("receiver_id").expect_utf8(FAILED_PARSE),
+            amount: v.u128("amount").expect_utf8(FAILED_PARSE),
         }
     }
 }

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -4,7 +4,7 @@ use crate::engine::Engine;
 use crate::json::{self, FAILED_PARSE};
 use crate::log_entry::LogEntry;
 use crate::precompiles::ecrecover;
-use crate::types::{str_from_slice, AccountId, EthAddress};
+use crate::types::{AccountId, EthAddress, ExpectUtf8};
 use alloc::format;
 use borsh::{BorshDeserialize, BorshSerialize};
 use ethabi::{Bytes, Event, EventParam, Hash, Log, ParamType, RawLog, Token};
@@ -120,27 +120,27 @@ impl EthEvent {
 
 impl From<json::JsonValue> for Proof {
     fn from(v: json::JsonValue) -> Self {
-        let log_index = v.u64("log_index").expect(str_from_slice(FAILED_PARSE));
+        let log_index = v.u64("log_index").expect_utf8(FAILED_PARSE);
         let log_entry_data: Vec<u8> = v
             .array("log_entry_data", json::JsonValue::parse_u8)
-            .expect(str_from_slice(FAILED_PARSE));
-        let receipt_index = v.u64("receipt_index").expect(str_from_slice(FAILED_PARSE));
+            .expect_utf8(FAILED_PARSE);
+        let receipt_index = v.u64("receipt_index").expect_utf8(FAILED_PARSE);
         let receipt_data: Vec<u8> = v
             .array("receipt_data", json::JsonValue::parse_u8)
-            .expect(str_from_slice(FAILED_PARSE));
+            .expect_utf8(FAILED_PARSE);
         let header_data: Vec<u8> = v
             .array("header_data", json::JsonValue::parse_u8)
-            .expect(str_from_slice(FAILED_PARSE));
+            .expect_utf8(FAILED_PARSE);
         let proof = v
             .array("proof", |v1| match v1 {
                 json::JsonValue::Array(arr) => arr.iter().map(json::JsonValue::parse_u8).collect(),
                 _ => sdk::panic_utf8(FAILED_PARSE),
             })
-            .expect(str_from_slice(FAILED_PARSE));
+            .expect_utf8(FAILED_PARSE);
 
         let skip_bridge_call = v
             .bool("skip_bridge_call")
-            .expect(str_from_slice(FAILED_PARSE));
+            .expect_utf8(FAILED_PARSE);
         Self {
             log_index,
             log_entry_data,

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -138,9 +138,7 @@ impl From<json::JsonValue> for Proof {
             })
             .expect_utf8(FAILED_PARSE);
 
-        let skip_bridge_call = v
-            .bool("skip_bridge_call")
-            .expect_utf8(FAILED_PARSE);
+        let skip_bridge_call = v.bool("skip_bridge_call").expect_utf8(FAILED_PARSE);
         Self {
             log_index,
             log_entry_data,

--- a/src/types.rs
+++ b/src/types.rs
@@ -210,7 +210,7 @@ pub fn str_from_slice(inp: &[u8]) -> &str {
 impl From<json::JsonValue> for BalanceOfCallArgs {
     fn from(v: json::JsonValue) -> Self {
         Self {
-            account_id: v.string("account_id").expect(str_from_slice(FAILED_PARSE)),
+            account_id: v.string("account_id").expect_utf8(FAILED_PARSE),
         }
     }
 }
@@ -220,7 +220,7 @@ impl From<json::JsonValue> for BalanceOfEthCallArgs {
     fn from(v: json::JsonValue) -> Self {
         use crate::prover::validate_eth_address;
 
-        let address = v.string("address").expect(str_from_slice(FAILED_PARSE));
+        let address = v.string("address").expect_utf8(FAILED_PARSE);
         Self {
             address: validate_eth_address(address),
         }
@@ -233,10 +233,10 @@ impl From<json::JsonValue> for InitCallArgs {
         Self {
             eth_custodian_address: v
                 .string("eth_custodian_address")
-                .expect(str_from_slice(FAILED_PARSE)),
+                .expect_utf8(FAILED_PARSE),
             prover_account: v
                 .string("prover_account")
-                .expect(str_from_slice(FAILED_PARSE)),
+                .expect_utf8(FAILED_PARSE),
         }
     }
 }
@@ -247,8 +247,8 @@ impl From<json::JsonValue> for WithdrawCallArgs {
         Self {
             recipient_id: v
                 .string("recipient_id")
-                .expect(str_from_slice(FAILED_PARSE)),
-            amount: v.u128("amount").expect(str_from_slice(FAILED_PARSE)),
+                .expect_utf8(FAILED_PARSE),
+            amount: v.u128("amount").expect_utf8(FAILED_PARSE),
         }
     }
 }
@@ -266,7 +266,7 @@ impl From<json::JsonValue> for StorageWithdrawCallArgs {
 impl From<json::JsonValue> for StorageBalanceOfCallArgs {
     fn from(v: json::JsonValue) -> Self {
         Self {
-            account_id: v.string("account_id").expect(str_from_slice(FAILED_PARSE)),
+            account_id: v.string("account_id").expect_utf8(FAILED_PARSE),
         }
     }
 }
@@ -285,10 +285,10 @@ impl From<json::JsonValue> for StorageDepositCallArgs {
 impl From<json::JsonValue> for TransferCallCallArgs {
     fn from(v: json::JsonValue) -> Self {
         Self {
-            receiver_id: v.string("receiver_id").expect(str_from_slice(FAILED_PARSE)),
-            amount: v.u128("amount").expect(str_from_slice(FAILED_PARSE)),
+            receiver_id: v.string("receiver_id").expect_utf8(FAILED_PARSE),
+            amount: v.u128("amount").expect_utf8(FAILED_PARSE),
             memo: v.string("memo").ok(),
-            msg: v.string("msg").expect(str_from_slice(FAILED_PARSE)),
+            msg: v.string("msg").expect_utf8(FAILED_PARSE),
         }
     }
 }
@@ -297,8 +297,8 @@ impl From<json::JsonValue> for TransferCallCallArgs {
 impl From<json::JsonValue> for TransferCallArgs {
     fn from(v: json::JsonValue) -> Self {
         Self {
-            receiver_id: v.string("receiver_id").expect(str_from_slice(FAILED_PARSE)),
-            amount: v.u128("amount").expect(str_from_slice(FAILED_PARSE)),
+            receiver_id: v.string("receiver_id").expect_utf8(FAILED_PARSE),
+            amount: v.u128("amount").expect_utf8(FAILED_PARSE),
             memo: v.string("memo").ok(),
         }
     }
@@ -309,10 +309,10 @@ impl From<json::JsonValue> for TransferEthCallArgs {
     fn from(v: json::JsonValue) -> Self {
         use crate::prover::validate_eth_address;
 
-        let address = v.string("address").expect(str_from_slice(FAILED_PARSE));
+        let address = v.string("address").expect_utf8(FAILED_PARSE);
         Self {
             address: validate_eth_address(address),
-            amount: v.u128("amount").expect(str_from_slice(FAILED_PARSE)),
+            amount: v.u128("amount").expect_utf8(FAILED_PARSE),
             memo: v.string("memo").ok(),
         }
     }
@@ -324,17 +324,17 @@ impl From<json::JsonValue> for TransferNearCallArgs {
         use crate::prover::validate_eth_address;
         use alloc::str::FromStr;
 
-        let sender = v.string("sender").expect(str_from_slice(FAILED_PARSE));
-        let amount = v.string("amount").expect(str_from_slice(FAILED_PARSE));
+        let sender = v.string("sender").expect_utf8(FAILED_PARSE);
+        let amount = v.string("amount").expect_utf8(FAILED_PARSE);
         let eip712_signature: Vec<u8> = v
             .array("eip712_signature", json::JsonValue::parse_u8)
-            .expect(str_from_slice(FAILED_PARSE));
+            .expect_utf8(FAILED_PARSE);
         Self {
             sender: validate_eth_address(sender),
             near_recipient: v
                 .string("near_recipient")
-                .expect(str_from_slice(FAILED_PARSE)),
-            amount: U256::from_str(amount.as_str()).expect(str_from_slice(FAILED_PARSE)),
+                .expect_utf8(FAILED_PARSE),
+            amount: U256::from_str(amount.as_str()).expect_utf8(FAILED_PARSE),
             eip712_signature,
         }
     }
@@ -345,22 +345,44 @@ impl From<json::JsonValue> for WithdrawEthCallArgs {
     fn from(v: json::JsonValue) -> Self {
         use crate::prover::validate_eth_address;
 
-        let sender = v.string("sender").expect(str_from_slice(FAILED_PARSE));
+        let sender = v.string("sender").expect_utf8(FAILED_PARSE);
         let eth_recipient = v
             .string("eth_recipient")
-            .expect(str_from_slice(FAILED_PARSE));
-        let amount = v.string("amount").expect(str_from_slice(FAILED_PARSE));
+            .expect_utf8(FAILED_PARSE);
+        let amount = v.string("amount").expect_utf8(FAILED_PARSE);
 
         let eip712_signature: Vec<u8> = hex::decode(
             v.string("eip712_signature")
-                .expect(str_from_slice(FAILED_PARSE)),
+                .expect_utf8(FAILED_PARSE),
         )
         .expect("ETH_ADDRESS_FAILED");
         Self {
             sender: validate_eth_address(sender),
             eth_recipient: validate_eth_address(eth_recipient),
-            amount: U256::from_str_radix(amount.as_str(), 10).expect(str_from_slice(FAILED_PARSE)),
+            amount: U256::from_str_radix(amount.as_str(), 10).expect_utf8(FAILED_PARSE),
             eip712_signature,
+        }
+    }
+}
+
+pub trait ExpectUtf8<T> {
+    fn expect_utf8(self, message: &[u8]) -> T;
+}
+
+impl<T> ExpectUtf8<T> for Option<T> {
+    fn expect_utf8(self, message: &[u8]) -> T {
+        match self {
+            Some(t) => t,
+            None => sdk::panic_utf8(message),
+        }
+    }
+}
+
+impl<T, E> ExpectUtf8<T> for core::result::Result<T, E> {
+    fn expect_utf8(self, message: &[u8]) -> T {
+        match self {
+            Ok(t) => t,
+            Err(_) => sdk::panic_utf8(message),
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -353,10 +353,12 @@ impl From<json::JsonValue> for WithdrawEthCallArgs {
     }
 }
 
+#[cfg(feature = "contract")]
 pub trait ExpectUtf8<T> {
     fn expect_utf8(self, message: &[u8]) -> T;
 }
 
+#[cfg(feature = "contract")]
 impl<T> ExpectUtf8<T> for Option<T> {
     fn expect_utf8(self, message: &[u8]) -> T {
         match self {
@@ -366,6 +368,7 @@ impl<T> ExpectUtf8<T> for Option<T> {
     }
 }
 
+#[cfg(feature = "contract")]
 impl<T, E> ExpectUtf8<T> for core::result::Result<T, E> {
     fn expect_utf8(self, message: &[u8]) -> T {
         match self {

--- a/src/types.rs
+++ b/src/types.rs
@@ -231,12 +231,8 @@ impl From<json::JsonValue> for BalanceOfEthCallArgs {
 impl From<json::JsonValue> for InitCallArgs {
     fn from(v: json::JsonValue) -> Self {
         Self {
-            eth_custodian_address: v
-                .string("eth_custodian_address")
-                .expect_utf8(FAILED_PARSE),
-            prover_account: v
-                .string("prover_account")
-                .expect_utf8(FAILED_PARSE),
+            eth_custodian_address: v.string("eth_custodian_address").expect_utf8(FAILED_PARSE),
+            prover_account: v.string("prover_account").expect_utf8(FAILED_PARSE),
         }
     }
 }
@@ -245,9 +241,7 @@ impl From<json::JsonValue> for InitCallArgs {
 impl From<json::JsonValue> for WithdrawCallArgs {
     fn from(v: json::JsonValue) -> Self {
         Self {
-            recipient_id: v
-                .string("recipient_id")
-                .expect_utf8(FAILED_PARSE),
+            recipient_id: v.string("recipient_id").expect_utf8(FAILED_PARSE),
             amount: v.u128("amount").expect_utf8(FAILED_PARSE),
         }
     }
@@ -331,9 +325,7 @@ impl From<json::JsonValue> for TransferNearCallArgs {
             .expect_utf8(FAILED_PARSE);
         Self {
             sender: validate_eth_address(sender),
-            near_recipient: v
-                .string("near_recipient")
-                .expect_utf8(FAILED_PARSE),
+            near_recipient: v.string("near_recipient").expect_utf8(FAILED_PARSE),
             amount: U256::from_str(amount.as_str()).expect_utf8(FAILED_PARSE),
             eip712_signature,
         }
@@ -346,16 +338,12 @@ impl From<json::JsonValue> for WithdrawEthCallArgs {
         use crate::prover::validate_eth_address;
 
         let sender = v.string("sender").expect_utf8(FAILED_PARSE);
-        let eth_recipient = v
-            .string("eth_recipient")
-            .expect_utf8(FAILED_PARSE);
+        let eth_recipient = v.string("eth_recipient").expect_utf8(FAILED_PARSE);
         let amount = v.string("amount").expect_utf8(FAILED_PARSE);
 
-        let eip712_signature: Vec<u8> = hex::decode(
-            v.string("eip712_signature")
-                .expect_utf8(FAILED_PARSE),
-        )
-        .expect("ETH_ADDRESS_FAILED");
+        let eip712_signature: Vec<u8> =
+            hex::decode(v.string("eip712_signature").expect_utf8(FAILED_PARSE))
+                .expect("ETH_ADDRESS_FAILED");
         Self {
             sender: validate_eth_address(sender),
             eth_recipient: validate_eth_address(eth_recipient),


### PR DESCRIPTION
Clippy reports many errors like the following:

```
error: use of `expect` followed by a function call
   --> src/prover.rs:143:14
    |
143 |             .expect(str_from_slice(FAILED_PARSE));
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|_| { panic!("{}", str_from_slice(FAILED_PARSE).to_string()) })`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#expect_fun_call
```

This PR corrects all those errors by using a new trait on `Option` and `Result` that can take an expect message in bytes.