### PR TITLE
feat: add `transfer` method to engine

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,7 +1,7 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use evm::backend::{Apply, ApplyBackend, Backend, Basic, Log};
 use evm::executor::{MemoryStackState, StackExecutor, StackSubstateMetadata};
-use evm::{Config, CreateScheme, ExitReason, ExitError, ExitSucceed};
+use evm::{Config, CreateScheme, ExitError, ExitReason, ExitSucceed};
 
 use crate::parameters::{FunctionCallArgs, NewCallArgs, ViewCallArgs};
 use crate::precompiles;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,7 +190,7 @@ mod contract {
             let (status, result) = if data.is_empty() {
                 // Execute a balance transfer:
                 (
-                    Engine::transfer(&mut engine, sender, receiver, value),
+                    Engine::transfer(&mut engine, &sender, &receiver, &value),
                     vec![],
                 )
             } else {


### PR DESCRIPTION
Quite simply, adds a method, `transfer`, to transfer a balance from one to another to the `Engine`.

Comes with additional added methods which will allow others to easily increase or decrease a balance, `increase_balance` and `decrease_balance`.

Closes #35.