### PR TITLE
Feat: Check and increment nonce

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -98,33 +98,19 @@ impl Engine {
     }
 
     /// Checks the nonce for the address matches the transaction nonce, and if so
-    /// increments the account nonce
+    /// returns the next nonce (if it exists). Note: this does not modify the actual
+    /// nonce of the account in storage. The nonce still needs to be set to the new value
+    /// if this is required.
     #[inline]
-    pub fn check_nonce(address: &Address, transaction_nonce: U256) -> Result<(), NonceError> {
-        Self::check_and_increment_nonce(address, Some(transaction_nonce))
-    }
-
-    /// Increment the account nonce (without any check it matches a certain value)
-    #[inline]
-    pub fn increment_nonce(address: &Address) -> Result<(), NonceError> {
-        Self::check_and_increment_nonce(address, None)
-    }
-
-    fn check_and_increment_nonce(
-        address: &Address,
-        transaction_nonce: Option<U256>,
-    ) -> Result<(), NonceError> {
+    pub fn check_nonce(address: &Address, transaction_nonce: &U256) -> Result<U256, NonceError> {
         let account_nonce = Self::get_nonce(address);
 
-        if let Some(nonce) = transaction_nonce {
-            if nonce != account_nonce {
-                return Err(NonceError::IncorrectNonce);
-            }
+        if transaction_nonce != &account_nonce {
+            return Err(NonceError::IncorrectNonce);
         }
 
         account_nonce
             .checked_add(U256::one())
-            .map(|new_nonce| Self::set_nonce(address, &new_nonce))
             .ok_or(NonceError::NonceOverflow)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,7 @@ mod contract {
     pub extern "C" fn deploy_code() {
         let input = sdk::read_input();
         let origin = predecessor_address();
-        Engine::increment_nonce(&origin).unwrap_or_sdk_panic();
+        Engine::increment_nonce(&origin).sdk_unwrap();
         let mut engine = Engine::new(origin);
         let (status, address) = Engine::deploy_code_with_input(&mut engine, &input);
         // TODO: charge for storage
@@ -152,7 +152,7 @@ mod contract {
         let input = sdk::read_input();
         let args = FunctionCallArgs::try_from_slice(&input).expect("ERR_ARG_PARSE");
         let origin = predecessor_address();
-        Engine::increment_nonce(&origin).unwrap_or_sdk_panic();
+        Engine::increment_nonce(&origin).sdk_unwrap();
         let mut engine = Engine::new(origin);
         let (status, result) = Engine::call_with_args(&mut engine, args);
         // TODO: charge for storage
@@ -186,7 +186,7 @@ mod contract {
             None => sdk::panic_utf8(b"ERR_INVALID_ECDSA_SIGNATURE"),
         };
 
-        Engine::check_nonce(&sender, signed_transaction.transaction.nonce).unwrap_or_sdk_panic();
+        Engine::check_nonce(&sender, signed_transaction.transaction.nonce).sdk_unwrap();
 
         // Figure out what kind of a transaction this is, and execute it:
         let mut engine = Engine::new_with_state(state, sender);
@@ -229,7 +229,7 @@ mod contract {
             }
         };
 
-        Engine::check_nonce(&meta_call_args.sender, meta_call_args.nonce).unwrap_or_sdk_panic();
+        Engine::check_nonce(&meta_call_args.sender, meta_call_args.nonce).sdk_unwrap();
 
         let mut engine = Engine::new_with_state(state, meta_call_args.sender);
         let (status, result) = engine.call(
@@ -385,12 +385,12 @@ mod contract {
         }
     }
 
-    trait OrSdkPanic<T, E> {
-        fn unwrap_or_sdk_panic(self) -> T;
+    trait SdkUnwrap<T, E> {
+        fn sdk_unwrap(self) -> T;
     }
 
-    impl<T, E: ToStr> OrSdkPanic<T, E> for Result<T, E> {
-        fn unwrap_or_sdk_panic(self) -> T {
+    impl<T, E: ToStr> SdkUnwrap<T, E> for Result<T, E> {
+        fn sdk_unwrap(self) -> T {
             match self {
                 Ok(t) => t,
                 Err(e) => sdk::panic_utf8(e.to_str().as_bytes()),

--- a/src/types.rs
+++ b/src/types.rs
@@ -35,6 +35,14 @@ pub enum ErrorKind {
     InvalidEcRecoverSignature,
 }
 
+/// Errors involving the nonce
+pub enum NonceError {
+    /// Attempted to increment the nonce, but overflow occurred
+    NonceOverflow,
+    /// Account nonce did not match the transaction nonce
+    IncorrectNonce,
+}
+
 pub type Result<T> = core::result::Result<T, ErrorKind>;
 
 #[allow(dead_code)]


### PR DESCRIPTION
To prevent replaying transactions, we need to check the nonce matches the nonce of the account, and increment it if it matches.

In the case of directly calling `call` or `deploy_code` replaying the transaction is not a concern because it originates from Near, and so is protected by the base system, but I still increment the nonce in those cases to be consistent.

One issue with this is the case where the transaction runs out of Near gas. In that case the state changes are rolled back, including the incremented nonce, which is different behaviour from if the transaction ran on Ethereum directly. I think the best way to handle this would be to make running out of Near gas impossible by setting appropriate limits on the Eth gas. But this probably is not feasible in the short term. We might need to leave this as a known bug for now. I'm interested in what others think about this issue @artob @djsatok @joshuajbouw @mrLSD 