### PR TITLE
Fix Precompiles: RIPEMD160, modexp

### DIFF
--- a/src/precompiles/hash.rs
+++ b/src/precompiles/hash.rs
@@ -85,7 +85,11 @@ impl Precompile for RIPEMD160 {
             Err(ExitError::OutOfGas)
         } else {
             let hash = ripemd160::Ripemd160::digest(input);
-            Ok((ExitSucceed::Returned, hash.to_vec(), 0))
+            // The result needs to be padded with leading zeros because it is only 20 bytes, but
+            // the evm works with 32-byte words.
+            let mut result = [0u8; 32];
+            result[12..].copy_from_slice(&hash);
+            Ok((ExitSucceed::Returned, result.to_vec(), 0))
         }
     }
 }

--- a/src/precompiles/hash.rs
+++ b/src/precompiles/hash.rs
@@ -120,7 +120,9 @@ mod tests {
     #[test]
     fn test_ripemd160() {
         let input = b"";
-        let expected = hex::decode("9c1185a5c5e9fc54612808977ee8f548b2258d31").unwrap();
+        let expected =
+            hex::decode("0000000000000000000000009c1185a5c5e9fc54612808977ee8f548b2258d31")
+                .unwrap();
 
         let res = RIPEMD160::run(input, 600, &new_context()).unwrap().1;
         assert_eq!(res, expected);


### PR DESCRIPTION
Fixes two small issues with the precompiles:

1. In RIPEMD160 the result needs to be padded out to 32 bytes
2. In modexp the result needs to be padded out to the same length as the modulus