### PR TITLE
fix: gas_limit

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -335,8 +335,16 @@ impl evm::backend::Backend for Engine {
         U256::from(sdk::block_index())
     }
 
+    /// Returns a mocked coinbase which is the first 160 bits of
+    /// `keccak256(b"aurora")`.
+    ///
+    /// It is not possible to return the address of the current block's miner in
+    /// NEAR as it isn't relevant.
     fn block_coinbase(&self) -> Address {
-        Address::zero()
+        Address([
+            0x2b, 0x0b, 0xf3, 0xb8, 0xff, 0xaa, 0x4f, 0x3d, 0x1f, 0x97, 0x76, 0x0d, 0x44, 0x44,
+            0x58, 0x84, 0x43, 0xc3, 0xa9, 0x12,
+        ])
     }
 
     fn block_timestamp(&self) -> U256 {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -267,7 +267,7 @@ impl Engine {
         let origin = self.origin();
         let contract = Address(args.contract);
         let value = U256::zero();
-        self.call(origin, contract, value, args.input, u64::MAX)
+        self.call(origin, contract, value, args.input)
     }
 
     pub fn call(
@@ -276,10 +276,9 @@ impl Engine {
         contract: Address,
         value: U256,
         input: Vec<u8>,
-        gas_limit: u64,
     ) -> (ExitReason, Vec<u8>) {
         let mut executor = self.make_executor();
-        let (status, result) = executor.transact_call(origin, contract, value, input, gas_limit);
+        let (status, result) = executor.transact_call(origin, contract, value, input, u64::MAX);
         let (values, logs) = executor.into_state().deconstruct();
         self.apply(values, logs, true);
         (status, result)

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -267,7 +267,7 @@ impl Engine {
         let origin = self.origin();
         let contract = Address(args.contract);
         let value = U256::zero();
-        self.call(origin, contract, value, args.input, args.gas_limit)
+        self.call(origin, contract, value, args.input, u64::MAX)
     }
 
     pub fn call(

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -357,7 +357,7 @@ impl evm::backend::Backend for Engine {
     }
 
     fn block_gas_limit(&self) -> U256 {
-        U256::zero() // TODO
+        U256::max_value()
     }
 
     fn chain_id(&self) -> U256 {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -267,7 +267,7 @@ impl Engine {
         let origin = self.origin();
         let contract = Address(args.contract);
         let value = U256::zero();
-        self.call(origin, contract, value, args.input)
+        self.call(origin, contract, value, args.input, args.gas_limit)
     }
 
     pub fn call(
@@ -276,9 +276,10 @@ impl Engine {
         contract: Address,
         value: U256,
         input: Vec<u8>,
+        gas_limit: u64,
     ) -> (ExitReason, Vec<u8>) {
         let mut executor = self.make_executor();
-        let (status, result) = executor.transact_call(origin, contract, value, input, u64::MAX);
+        let (status, result) = executor.transact_call(origin, contract, value, input, gas_limit);
         let (values, logs) = executor.into_state().deconstruct();
         self.apply(values, logs, true);
         (status, result)

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -335,6 +335,8 @@ impl evm::backend::Backend for Engine {
     /// Returns a block hash from a given index.
     ///
     /// Currently this returns zero, but may be changed in the future.
+    ///
+    /// See: https://doc.aurora.dev/develop/compat/evm#blockhash
     fn block_hash(&self, _number: U256) -> H256 {
         H256::zero() // TODO: https://github.com/near/nearcore/issues/3456
     }
@@ -346,6 +348,8 @@ impl evm::backend::Backend for Engine {
 
     /// Returns a mocked coinbase which is the EVM address for the Aurora
     /// account, being 0x4444588443C3a91288c5002483449Aba1054192b.
+    ///
+    /// See: https://doc.aurora.dev/develop/compat/evm#coinbase
     fn block_coinbase(&self) -> Address {
         Address([
             0x44, 0x44, 0x58, 0x84, 0x43, 0xC3, 0xa9, 0x12, 0x88, 0xc5, 0x00, 0x24, 0x83, 0x44,
@@ -359,6 +363,8 @@ impl evm::backend::Backend for Engine {
     }
 
     /// Returns the current block difficulty.
+    ///
+    /// See: https://doc.aurora.dev/develop/compat/evm#difficulty
     fn block_difficulty(&self) -> U256 {
         U256::zero()
     }
@@ -368,6 +374,8 @@ impl evm::backend::Backend for Engine {
     /// Currently, this returns 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
     /// as there isn't a gas limit alternative right now but this may change in
     /// the future.
+    ///
+    /// See: https://doc.aurora.dev/develop/compat/evm#gaslimit
     fn block_gas_limit(&self) -> U256 {
         U256::max_value()
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -344,15 +344,12 @@ impl evm::backend::Backend for Engine {
         U256::from(sdk::block_index())
     }
 
-    /// Returns a mocked coinbase which is the first 160 bits of
-    /// `keccak256(b"aurora")`.
-    ///
-    /// It is not possible to return the address of the current block's miner in
-    /// NEAR as it isn't relevant.
+    /// Returns a mocked coinbase which is the EVM address for the Aurora
+    /// account.
     fn block_coinbase(&self) -> Address {
         Address([
-            0x2b, 0x0b, 0xf3, 0xb8, 0xff, 0xaa, 0x4f, 0x3d, 0x1f, 0x97, 0x76, 0x0d, 0x44, 0x44,
-            0x58, 0x84, 0x43, 0xc3, 0xa9, 0x12,
+            0x44, 0x44, 0x58, 0x84, 0x43, 0xC3, 0xa9, 0x12, 0x88, 0xc5, 0x00, 0x24, 0x83, 0x44,
+            0x9A, 0xba, 0x10, 0x54, 0x19, 0x2b,
         ])
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -345,7 +345,7 @@ impl evm::backend::Backend for Engine {
     }
 
     /// Returns a mocked coinbase which is the EVM address for the Aurora
-    /// account.
+    /// account, being 0x4444588443C3a91288c5002483449Aba1054192b.
     fn block_coinbase(&self) -> Address {
         Address([
             0x44, 0x44, 0x58, 0x84, 0x43, 0xC3, 0xa9, 0x12, 0x88, 0xc5, 0x00, 0x24, 0x83, 0x44,
@@ -363,9 +363,11 @@ impl evm::backend::Backend for Engine {
         U256::zero()
     }
 
-    /// Returns the current block's gas limit.
+    /// Returns the current block gas limit.
     ///
-    /// Currently, this returns 0 as there is no concept of a gas limit.
+    /// Currently, this returns 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+    /// as there isn't a gas limit alternative right now but this may change in
+    /// the future.
     fn block_gas_limit(&self) -> U256 {
         U256::max_value()
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -320,18 +320,27 @@ impl Engine {
 }
 
 impl evm::backend::Backend for Engine {
+    /// Returns the gas price.
+    ///
+    /// This is currently zero, but may be changed in the future. This is mainly
+    /// because there already is another cost for transactions.
     fn gas_price(&self) -> U256 {
         U256::zero()
     }
 
+    /// Returns the origin address that created the contract.
     fn origin(&self) -> Address {
         self.origin
     }
 
+    /// Returns a block hash from a given index.
+    ///
+    /// Currently this returns zero, but may be changed in the future.
     fn block_hash(&self, _number: U256) -> H256 {
         H256::zero() // TODO: https://github.com/near/nearcore/issues/3456
     }
 
+    /// Returns the current block index number.
     fn block_number(&self) -> U256 {
         U256::from(sdk::block_index())
     }
@@ -348,26 +357,34 @@ impl evm::backend::Backend for Engine {
         ])
     }
 
+    /// Returns the current block timestamp.
     fn block_timestamp(&self) -> U256 {
         U256::from(sdk::block_timestamp())
     }
 
+    /// Returns the current block difficulty.
     fn block_difficulty(&self) -> U256 {
         U256::zero()
     }
 
+    /// Returns the current block's gas limit.
+    ///
+    /// Currently, this returns 0 as there is no concept of a gas limit.
     fn block_gas_limit(&self) -> U256 {
         U256::max_value()
     }
 
+    /// Returns the states chain ID.
     fn chain_id(&self) -> U256 {
         U256::from(self.state.chain_id)
     }
 
+    /// Checks if an address exists.
     fn exists(&self, address: Address) -> bool {
         !Engine::is_account_empty(&address)
     }
 
+    /// Returns basic account information.
     fn basic(&self, address: Address) -> Basic {
         Basic {
             nonce: Engine::get_nonce(&address),
@@ -375,14 +392,19 @@ impl evm::backend::Backend for Engine {
         }
     }
 
+    /// Returns the code of the contract from an address.
     fn code(&self, address: Address) -> Vec<u8> {
         Engine::get_code(&address)
     }
 
+    /// Get storage value of address at index.
     fn storage(&self, address: Address, index: H256) -> H256 {
         Engine::get_storage(&address, &index)
     }
 
+    /// Get original storage value of address at index, if available.
+    ///
+    /// Currently, this returns `None` for now.
     fn original_storage(&self, _address: Address, _index: H256) -> Option<H256> {
         None
     }

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -36,7 +36,6 @@ pub struct MetaCallArgs {
 #[derive(BorshSerialize, BorshDeserialize)]
 pub struct FunctionCallArgs {
     pub contract: RawAddress,
-    pub gas_limit: u64,
     pub input: Vec<u8>,
 }
 

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -36,6 +36,7 @@ pub struct MetaCallArgs {
 #[derive(BorshSerialize, BorshDeserialize)]
 pub struct FunctionCallArgs {
     pub contract: RawAddress,
+    pub gas_limit: u64,
     pub input: Vec<u8>,
 }
 


### PR DESCRIPTION
This is pretty short, I reviewed the code for the backend implementation and checked and diagnosed where we may have issues. The only real issue that I had found is that we likely have an issue if the `gas_limit` returns 0. This was changed to max value and docs were added in. The other change is the `block_coinbase` returning the first 2^160 of the keccak256 hash of `aurora`.