### PR TITLE
fix: logs

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -404,10 +404,7 @@ impl Engine {
         // allows a return of UTF-8 strings.
         self.apply(values, Vec::<Log>::new(), true);
 
-        let mut res_logs = Vec::new();
-        for log in logs {
-            res_logs.push(log.into());
-        }
+        let res_logs = logs.into_iter().map(Into::into).collect();
 
         let res = match status {
             ExitReason::Succeed(_) | ExitReason::Revert(_) => Some( SubmitResult {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -371,7 +371,7 @@ impl Engine {
         let res_logs = logs.into_iter().map(Into::into).collect();
 
         let res = match status {
-            ExitReason::Succeed(_) | ExitReason::Revert(_) => Some( SubmitResult {
+            ExitReason::Succeed(_) | ExitReason::Revert(_) => Some(SubmitResult {
                 gas_used: used_gas,
                 logs: res_logs,
                 result: result.0.to_vec(),
@@ -407,10 +407,10 @@ impl Engine {
         let res_logs = logs.into_iter().map(Into::into).collect();
 
         let res = match status {
-            ExitReason::Succeed(_) | ExitReason::Revert(_) => Some( SubmitResult {
+            ExitReason::Succeed(_) | ExitReason::Revert(_) => Some(SubmitResult {
                 gas_used: used_gas,
                 logs: res_logs,
-                result
+                result,
             }),
             ExitReason::Error(_) | ExitReason::Fatal(_) => None,
         };

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -384,10 +384,10 @@ impl Engine {
         let origin = self.origin();
         let contract = Address(args.contract);
         let value = U256::zero();
-        self.submit(origin, contract, value, args.input)
+        self.call(origin, contract, value, args.input)
     }
 
-    pub fn submit(
+    pub fn call(
         &mut self,
         origin: Address,
         contract: Address,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -4,7 +4,7 @@ use evm::executor::{MemoryStackState, StackExecutor, StackSubstateMetadata};
 use evm::ExitFatal;
 use evm::{Config, CreateScheme, ExitError, ExitReason};
 
-use crate::parameters::{FunctionCallArgs, NewCallArgs, ViewCallArgs, SubmitResult};
+use crate::parameters::{FunctionCallArgs, NewCallArgs, SubmitResult, ViewCallArgs};
 use crate::precompiles;
 use crate::prelude::{Address, Vec, H256, U256};
 use crate::sdk;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -366,17 +366,17 @@ impl Engine {
             executor.transact_create(origin, value, Vec::from(input), u64::MAX),
             address,
         );
-        let is_revert = status.is_revert();
+        let is_succeed = status.is_succeed();
         status.into_result()?;
         let used_gas = executor.used_gas();
         let (values, logs) = executor.into_state().deconstruct();
         self.apply(values, Vec::<Log>::new(), true);
 
         Ok(SubmitResult {
-            reverted: is_revert,
+            status: is_succeed,
             gas_used: used_gas,
-            logs: logs.into_iter().map(Into::into).collect(),
             result: result.0.to_vec(),
+            logs: logs.into_iter().map(Into::into).collect(),
         })
     }
 
@@ -398,17 +398,17 @@ impl Engine {
         let (status, result) = executor.transact_call(origin, contract, value, input, u64::MAX);
         let used_gas = executor.used_gas();
         let (values, logs) = executor.into_state().deconstruct();
-        let is_revert = status.is_revert();
+        let is_succeed = status.is_succeed();
         status.into_result()?;
         // There is no way to return the logs to the NEAR log method as it only
         // allows a return of UTF-8 strings.
         self.apply(values, Vec::<Log>::new(), true);
 
         Ok(SubmitResult {
-            reverted: is_revert,
+            status: is_succeed,
             gas_used: used_gas,
-            logs: logs.into_iter().map(Into::into).collect(),
             result,
+            logs: logs.into_iter().map(Into::into).collect(),
         })
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -368,10 +368,7 @@ impl Engine {
         let (values, logs) = executor.into_state().deconstruct();
         self.apply(values, Vec::<Log>::new(), true);
 
-        let mut res_logs = Vec::new();
-        for log in logs {
-            res_logs.push(log.into());
-        }
+        let res_logs = logs.into_iter().map(Into::into).collect();
 
         let (res_status, used_gas) = match status {
             ExitReason::Succeed(_) => (true, used_gas),

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -370,18 +370,15 @@ impl Engine {
 
         let res_logs = logs.into_iter().map(Into::into).collect();
 
-        let (res_status, used_gas) = match status {
-            ExitReason::Succeed(_) => (true, used_gas),
-            ExitReason::Revert(_) => (false, used_gas),
-            ExitReason::Error(_) | ExitReason::Fatal(_) => (false, 0),
+        let res = match status {
+            ExitReason::Succeed(_) | ExitReason::Revert(_) => Some( SubmitResult {
+                gas_used: used_gas,
+                logs: res_logs,
+                result: result.0.to_vec(),
+            }),
+            ExitReason::Error(_) | ExitReason::Fatal(_) => None,
         };
 
-        let res = SubmitResult {
-            status: res_status,
-            gas_used: used_gas,
-            logs: res_logs,
-            result: result.0.to_vec(),
-        };
         (status, res)
     }
 
@@ -412,18 +409,15 @@ impl Engine {
             res_logs.push(log.into());
         }
 
-        let (res_status, used_gas) = match status {
-            ExitReason::Succeed(_) => (true, used_gas),
-            ExitReason::Revert(_) => (false, used_gas),
-            ExitReason::Error(_) | ExitReason::Fatal(_) => (false, 0),
+        let res = match status {
+            ExitReason::Succeed(_) | ExitReason::Revert(_) => Some( SubmitResult {
+                gas_used: used_gas,
+                logs: res_logs,
+                result
+            }),
+            ExitReason::Error(_) | ExitReason::Fatal(_) => None,
         };
 
-        let res = SubmitResult {
-            status: res_status,
-            gas_used: used_gas,
-            logs: res_logs,
-            result,
-        };
         (status, res)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,8 @@ mod sdk;
 
 #[cfg(feature = "contract")]
 mod contract {
-    use borsh::BorshDeserialize;
+    use borsh::{BorshDeserialize, BorshSerialize};
+    use evm::{ExitError, ExitFatal, ExitReason};
 
     use crate::engine::{Engine, EngineError, EngineResult, EngineState};
     #[cfg(feature = "evm_bully")]
@@ -155,7 +156,7 @@ mod contract {
     /// Process signed Ethereum transaction.
     /// Must match CHAIN_ID to make sure it's signed for given chain vs replayed from another chain.
     #[no_mangle]
-    pub extern "C" fn raw_call() {
+    pub extern "C" fn submit() {
         use crate::transaction::EthSignedTransaction;
         use rlp::{Decodable, Rlp};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,7 +199,7 @@ mod contract {
                 Engine::transfer(&mut engine, &sender, &receiver, &value).map(|_f| Vec::new())
             } else {
                 // Execute a contract call:
-                Engine::submit(&mut engine, sender, receiver, value, data)
+                Engine::call(&mut engine, sender, receiver, value, data)
                     .map(|res| res.try_to_vec().sdk_expect("ERR_SERIALIZE"))
                 // TODO: charge for storage
             };
@@ -232,7 +232,7 @@ mod contract {
         Engine::check_nonce(&meta_call_args.sender, &meta_call_args.nonce).sdk_unwrap();
 
         let mut engine = Engine::new_with_state(state, meta_call_args.sender);
-        let result = engine.submit(
+        let result = engine.call(
             meta_call_args.sender,
             meta_call_args.contract_address,
             meta_call_args.value,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,7 +196,7 @@ mod contract {
                 Engine::transfer(&mut engine, &sender, &receiver, &value).map(|_f| Vec::new())
             } else {
                 // Execute a contract call:
-                Engine::call(&mut engine, sender, receiver, value, data)
+                Engine::submit(&mut engine, sender, receiver, value, data)
                 // TODO: charge for storage
             };
             result.sdk_process();

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -33,7 +33,7 @@ pub struct MetaCallArgs {
     pub args: Vec<u8>,
 }
 
-/// Borsch-encoded log for use in a `SubmitResult`.
+/// Borsh-encoded log for use in a `SubmitResult`.
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 pub struct ResultLog {
     pub topics: Vec<RawU256>,
@@ -54,8 +54,8 @@ impl From<Log> for ResultLog {
     }
 }
 
-/// Borsch-encoded parameters for the `submit`, `call_with_args`, `deploy_code`,
-/// `deploy_with_input` methods.
+/// Borsh-encoded parameters for the `call`, `call_with_args`, `deploy_code`,
+/// and `deploy_with_input` methods.
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 pub struct SubmitResult {
     pub status: bool,

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -58,7 +58,6 @@ impl From<Log> for ResultLog {
 /// Borsch-encoded parameters for the `raw_call` function.
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 pub struct SubmitResult {
-    pub status: bool,
     pub gas_used: u64,
     pub logs: Vec<ResultLog>,
     pub result: Vec<u8>,

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -57,7 +57,7 @@ impl From<Log> for ResultLog {
 
 /// Borsch-encoded parameters for the `raw_call` function.
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
-pub struct RawCallResult {
+pub struct SubmitResult {
     pub status: bool,
     pub gas_used: u64,
     pub logs: Vec<ResultLog>,

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -2,6 +2,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 
 use crate::prelude::{String, Vec};
 use crate::types::{AccountId, RawAddress, RawH256, RawU256};
+use evm::backend::Log;
 
 /// Borsh-encoded parameters for the `new` function.
 #[derive(BorshSerialize, BorshDeserialize)]
@@ -30,6 +31,37 @@ pub struct MetaCallArgs {
     pub value: RawU256,
     pub method_def: String,
     pub args: Vec<u8>,
+}
+
+/// Borsch-encoded log for use in a `RawCallResult`.
+#[derive(Debug, BorshSerialize, BorshDeserialize)]
+pub struct ResultLog {
+    pub topics: Vec<RawU256>,
+    pub data: Vec<u8>,
+}
+
+impl From<Log> for ResultLog {
+    fn from(log: Log) -> Self {
+        let mut res_topics = Vec::with_capacity(log.topics.len());
+        for topic in log.topics.into_iter() {
+            let res_topic = topic.0;
+            res_topics.push(res_topic);
+        }
+
+        ResultLog {
+            topics: res_topics,
+            data: log.data,
+        }
+    }
+}
+
+/// Borsch-encoded parameters for the `raw_call` function.
+#[derive(Debug, BorshSerialize, BorshDeserialize)]
+pub struct RawCallResult {
+    pub status: bool,
+    pub gas_used: u64,
+    pub logs: Vec<ResultLog>,
+    pub result: Vec<u8>,
 }
 
 /// Borsh-encoded parameters for the `call` function.

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -57,6 +57,7 @@ impl From<Log> for ResultLog {
 /// Borsch-encoded parameters for the `raw_call` function.
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 pub struct SubmitResult {
+    pub reverted: bool,
     pub gas_used: u64,
     pub logs: Vec<ResultLog>,
     pub result: Vec<u8>,

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -42,14 +42,13 @@ pub struct ResultLog {
 
 impl From<Log> for ResultLog {
     fn from(log: Log) -> Self {
-        let mut res_topics = Vec::with_capacity(log.topics.len());
-        for topic in log.topics.into_iter() {
-            let res_topic = topic.0;
-            res_topics.push(res_topic);
-        }
-
+        let topics = log
+            .topics
+            .into_iter()
+            .map(|topic| topic.0)
+            .collect::<Vec<_>>();
         ResultLog {
-            topics: res_topics,
+            topics,
             data: log.data,
         }
     }

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -33,7 +33,7 @@ pub struct MetaCallArgs {
     pub args: Vec<u8>,
 }
 
-/// Borsch-encoded log for use in a `RawCallResult`.
+/// Borsch-encoded log for use in a `SubmitResult`.
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 pub struct ResultLog {
     pub topics: Vec<RawU256>,
@@ -54,13 +54,14 @@ impl From<Log> for ResultLog {
     }
 }
 
-/// Borsch-encoded parameters for the `raw_call` function.
+/// Borsch-encoded parameters for the `submit`, `call_with_args`, `deploy_code`,
+/// `deploy_with_input` methods.
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 pub struct SubmitResult {
-    pub reverted: bool,
+    pub status: bool,
     pub gas_used: u64,
-    pub logs: Vec<ResultLog>,
     pub result: Vec<u8>,
+    pub logs: Vec<ResultLog>,
 }
 
 /// Borsh-encoded parameters for the `call` function.

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,9 +1,7 @@
-use crate::prelude::{vec, Address, String, Vec, H256, U256};
+use crate::prelude::{Address, String, Vec, H256, U256};
 
 #[cfg(not(feature = "contract"))]
 use sha3::{Digest, Keccak256};
-
-use evm::backend::Log;
 
 #[cfg(feature = "contract")]
 use crate::sdk;

--- a/src/types.rs
+++ b/src/types.rs
@@ -34,19 +34,6 @@ pub fn u256_to_arr(value: &U256) -> [u8; 32] {
     result
 }
 
-#[allow(dead_code)]
-pub fn log_to_bytes(log: Log) -> Vec<u8> {
-    let mut result = vec![0u8; 1 + log.topics.len() * 32 + log.data.len()];
-    result[0] = log.topics.len() as u8;
-    let mut index = 1;
-    for topic in log.topics.iter() {
-        result[index..index + 32].copy_from_slice(&topic.0);
-        index += 32;
-    }
-    result[index..].copy_from_slice(&log.data);
-    result
-}
-
 const HEX_ALPHABET: &[u8; 16] = b"0123456789abcdef";
 
 #[allow(dead_code)]


### PR DESCRIPTION
There is an issue with returning logs from the EVM currently. It is currently sending the logs out on the SDK but after a discussion with @artob we should instead return them back upon execution. This does exactly that, and omits the logs from being applied to the NEAR SDK.

- [x] Implement new logs
- [x] Find and include execution result