### PR TITLE
feat: Better errors

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -6,9 +6,6 @@ use evm::{Config, CreateScheme, ExitError, ExitReason};
 
 use crate::parameters::{FunctionCallArgs, NewCallArgs, ViewCallArgs};
 use crate::precompiles;
-use crate::prelude::fmt;
-#[cfg(feature = "std")]
-use crate::prelude::Error;
 use crate::prelude::{Address, Borrowed, Vec, H256, U256};
 use crate::sdk;
 use crate::storage::{address_to_key, storage_to_key, KeyPrefix};
@@ -23,12 +20,12 @@ pub enum NonceError {
     IncorrectNonce,
 }
 
-impl fmt::Display for NonceError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl NonceError {
+    pub fn to_str(&self) -> &str {
         use NonceError::*;
         match self {
-            NonceOverflow => write!(f, "ERR_NONCE_OVERFLOW"),
-            IncorrectNonce => write!(f, "ERR_INCORRECT_NONCE"),
+            NonceOverflow => "ERR_NONCE_OVERFLOW",
+            IncorrectNonce => "ERR_INCORRECT_NONCE",
         }
     }
 }
@@ -47,28 +44,28 @@ pub enum EngineError {
     EvmRevert(Vec<u8>),
 }
 
-impl fmt::Display for EngineError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl EngineError {
+    pub fn to_str(&self) -> &str {
         use EngineError::*;
         match self {
-            EvmError(ExitError::StackUnderflow) => write!(f, "ERR_STACK_UNDERFLOW"),
-            EvmError(ExitError::StackOverflow) => write!(f, "ERR_STACK_OVERFLOW"),
-            EvmError(ExitError::InvalidJump) => write!(f, "ERR_INVALID_JUMP"),
-            EvmError(ExitError::InvalidRange) => write!(f, "ERR_INVALID_RANGE"),
-            EvmError(ExitError::DesignatedInvalid) => write!(f, "ERR_DESIGNATED_INVALID"),
-            EvmError(ExitError::CallTooDeep) => write!(f, "ERR_CALL_TOO_DEEP"),
-            EvmError(ExitError::CreateCollision) => write!(f, "ERR_CREATE_COLLISION"),
-            EvmError(ExitError::CreateContractLimit) => write!(f, "ERR_CREATE_CONTRACT_LIMIT"),
-            EvmError(ExitError::OutOfOffset) => write!(f, "ERR_OUT_OF_OFFSET"),
-            EvmError(ExitError::OutOfGas) => write!(f, "ERR_OUT_OF_GAS"),
-            EvmError(ExitError::OutOfFund) => write!(f, "ERR_OUT_OF_FUND"),
-            EvmError(ExitError::Other(m)) => write!(f, "{}", m),
-            EvmError(_) => write!(f, ""), // unused misc
-            EvmFatal(ExitFatal::NotSupported) => write!(f, "ERR_NOT_SUPPORTED"),
-            EvmFatal(ExitFatal::UnhandledInterrupt) => write!(f, "ERR_UNHANDLED_INTERRUPT"),
-            EvmFatal(ExitFatal::Other(m)) => write!(f, "{}", m),
-            EvmFatal(_) => write!(f, ""), // unused misc
-            EvmRevert(_) => write!(f, "ERR_REVERT"),
+            EvmError(ExitError::StackUnderflow) => "ERR_STACK_UNDERFLOW",
+            EvmError(ExitError::StackOverflow) => "ERR_STACK_OVERFLOW",
+            EvmError(ExitError::InvalidJump) => "ERR_INVALID_JUMP",
+            EvmError(ExitError::InvalidRange) => "ERR_INVALID_RANGE",
+            EvmError(ExitError::DesignatedInvalid) => "ERR_DESIGNATED_INVALID",
+            EvmError(ExitError::CallTooDeep) => "ERR_CALL_TOO_DEEP",
+            EvmError(ExitError::CreateCollision) => "ERR_CREATE_COLLISION",
+            EvmError(ExitError::CreateContractLimit) => "ERR_CREATE_CONTRACT_LIMIT",
+            EvmError(ExitError::OutOfOffset) => "ERR_OUT_OF_OFFSET",
+            EvmError(ExitError::OutOfGas) => "ERR_OUT_OF_GAS",
+            EvmError(ExitError::OutOfFund) => "ERR_OUT_OF_FUND",
+            EvmError(ExitError::Other(m)) => m,
+            EvmError(_) => "", // unused misc
+            EvmFatal(ExitFatal::NotSupported) => "ERR_NOT_SUPPORTED",
+            EvmFatal(ExitFatal::UnhandledInterrupt) => "ERR_UNHANDLED_INTERRUPT",
+            EvmFatal(ExitFatal::Other(m)) => m,
+            EvmFatal(_) => "", // unused misc
+            EvmRevert(_) => "ERR_REVERT",
         }
     }
 }
@@ -84,9 +81,6 @@ impl From<ExitFatal> for EngineError {
         EngineError::EvmFatal(e)
     }
 }
-
-#[cfg(feature = "std")]
-impl Error for EngineError {}
 
 /// An engine result.
 pub type EngineResult<T> = Result<T, EngineError>;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -82,11 +82,11 @@ impl EngineError {
             EvmError(ExitError::OutOfGas) => "ERR_OUT_OF_GAS",
             EvmError(ExitError::OutOfFund) => "ERR_OUT_OF_FUND",
             EvmError(ExitError::Other(m)) => m,
-            EvmError(_) => "", // unused misc
+            EvmError(_) => unreachable!(), // unused misc
             EvmFatal(ExitFatal::NotSupported) => "ERR_NOT_SUPPORTED",
             EvmFatal(ExitFatal::UnhandledInterrupt) => "ERR_UNHANDLED_INTERRUPT",
             EvmFatal(ExitFatal::Other(m)) => m,
-            EvmFatal(_) => "", // unused misc
+            EvmFatal(_) => unreachable!(), // unused misc
             EvmRevert(_) => "ERR_REVERT",
             BalanceTooHigh => "ERR_BALANCE_HIGH",
             BalanceTooLow => "ERR_BALANCE_LOW",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ mod contract {
     #[cfg(feature = "evm_bully")]
     use crate::parameters::{BeginBlockArgs, BeginChainArgs};
     use crate::parameters::{FunctionCallArgs, GetStorageAtArgs, NewCallArgs, ViewCallArgs};
-    use crate::prelude::{format, Address, Vec, H256, U256};
+    use crate::prelude::{Address, Vec, H256, U256};
     use crate::sdk;
     use crate::types::{near_account_to_evm_address, u256_to_arr};
 
@@ -341,7 +341,7 @@ mod contract {
         match result {
             Ok(r) => sdk::return_output(r.as_ref()),
             Err(EngineError::EvmRevert(r)) => sdk::panic_hex(r.as_ref()),
-            Err(e) => sdk::panic_utf8(format!("{}", e).as_bytes()),
+            Err(e) => sdk::panic_utf8(e.to_str().as_bytes()),
         }
     }
 
@@ -353,7 +353,7 @@ mod contract {
         fn sdk_unwrap(self) -> T {
             match self {
                 Ok(t) => t,
-                Err(e) => sdk::panic_utf8(format!("{}", e).as_ref()),
+                Err(e) => sdk::panic_utf8(e.to_str().as_ref()),
             }
         }
     }
@@ -362,7 +362,7 @@ mod contract {
         fn sdk_unwrap(self) -> T {
             match self {
                 Ok(t) => t,
-                Err(e) => sdk::panic_utf8(format!("{}", e).as_ref()),
+                Err(e) => sdk::panic_utf8(e.to_str().as_ref()),
             }
         }
     }

--- a/src/precompiles/blake2.rs
+++ b/src/precompiles/blake2.rs
@@ -225,30 +225,22 @@ mod tests {
 
         assert!(matches!(
             test_blake2f_empty(),
-            Err(ExitError::Other(Borrowed(
-                "input length invalid, must be 213 bytes"
-            )))
+            Err(ExitError::Other(Borrowed("ERR_BLAKE2F_INVALID_LEN")))
         ));
 
         assert!(matches!(
             test_blake2f_invalid_len_1(),
-            Err(ExitError::Other(Borrowed(
-                "input length invalid, must be 213 bytes"
-            )))
+            Err(ExitError::Other(Borrowed("ERR_BLAKE2F_INVALID_LEN")))
         ));
 
         assert!(matches!(
             test_blake2f_invalid_len_2(),
-            Err(ExitError::Other(Borrowed(
-                "input length invalid, must be 213 bytes"
-            )))
+            Err(ExitError::Other(Borrowed("ERR_BLAKE2F_INVALID_LEN")))
         ));
 
         assert!(matches!(
             test_blake2f_invalid_flag(),
-            Err(ExitError::Other(Borrowed(
-                "incorrect final block indicator flag",
-            )))
+            Err(ExitError::Other(Borrowed("ERR_BLAKE2F_FINAL_FLAG",)))
         ));
 
         let expected = hex::decode(

--- a/src/precompiles/blake2.rs
+++ b/src/precompiles/blake2.rs
@@ -35,9 +35,7 @@ impl Precompile for Blake2F {
     /// See: https://etherscan.io/address/0000000000000000000000000000000000000009
     fn run(input: &[u8], target_gas: u64, _context: &Context) -> PrecompileResult {
         if input.len() != consts::INPUT_LENGTH {
-            return Err(ExitError::Other(Borrowed(
-                "input length invalid, must be 213 bytes",
-            )));
+            return Err(ExitError::Other(Borrowed("ERR_BLAKE2F_INVALID_LEN")));
         }
 
         let mut rounds_bytes = [0u8; 4];
@@ -73,9 +71,7 @@ impl Precompile for Blake2F {
         }
 
         if input[212] != 0 && input[212] != 1 {
-            return Err(ExitError::Other(Borrowed(
-                "incorrect final block indicator flag",
-            )));
+            return Err(ExitError::Other(Borrowed("ERR_BLAKE2F_FINAL_FLAG")));
         }
         let finished = input[212] != 0;
 

--- a/src/precompiles/bn128.rs
+++ b/src/precompiles/bn128.rs
@@ -421,7 +421,7 @@ mod tests {
         let res = BN128Add::<Byzantium>::run(&input, 500, &new_context());
         assert!(matches!(
             res,
-            Err(ExitError::Other(Borrowed("invalid curve point")))
+            Err(ExitError::Other(Borrowed("ERR_BN128_INVALID_POINT")))
         ));
     }
 
@@ -503,7 +503,7 @@ mod tests {
         let res = BN128Mul::<Byzantium>::run(&input, 40_000, &new_context());
         assert!(matches!(
             res,
-            Err(ExitError::Other(Borrowed("invalid curve point")))
+            Err(ExitError::Other(Borrowed("ERR_BN128_INVALID_POINT")))
         ));
     }
 
@@ -580,9 +580,7 @@ mod tests {
         let res = BN128Pair::<Byzantium>::run(&input, 260_000, &new_context());
         assert!(matches!(
             res,
-            Err(ExitError::Other(Borrowed(
-                "invalid `a` argument, not on curve"
-            )))
+            Err(ExitError::Other(Borrowed("ERR_BN128_INVALID_A")))
         ));
 
         // invalid input length
@@ -598,9 +596,7 @@ mod tests {
         let res = BN128Pair::<Byzantium>::run(&input, 260_000, &new_context());
         assert!(matches!(
             res,
-            Err(ExitError::Other(Borrowed(
-                "input length invalid, must be multiple of 192",
-            )))
+            Err(ExitError::Other(Borrowed("ERR_BN128_INVALID_LEN",)))
         ));
     }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -15,8 +15,7 @@ pub use core::{convert::TryInto, marker::PhantomData, mem};
 #[cfg(feature = "std")]
 pub use std::{
     borrow::Cow::Borrowed, borrow::ToOwned, boxed::Box, collections::HashMap, convert::TryInto,
-    error::Error, fmt, marker::PhantomData, mem, string::String, string::ToString, vec,
-    vec::Vec,
+    error::Error, fmt, marker::PhantomData, mem, string::String, string::ToString, vec, vec::Vec,
 };
 
 pub use primitive_types::{H160, H256, U256};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -4,7 +4,7 @@ pub use alloc::{
     borrow::{Cow, Cow::*},
     boxed::Box,
     collections::BTreeMap as HashMap,
-    fmt, format,
+    fmt,
     string::String,
     string::ToString,
     vec,
@@ -15,7 +15,7 @@ pub use core::{convert::TryInto, marker::PhantomData, mem};
 #[cfg(feature = "std")]
 pub use std::{
     borrow::Cow::Borrowed, borrow::ToOwned, boxed::Box, collections::HashMap, convert::TryInto,
-    error::Error, fmt, format, marker::PhantomData, mem, string::String, string::ToString, vec,
+    error::Error, fmt, marker::PhantomData, mem, string::String, string::ToString, vec,
     vec::Vec,
 };
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -4,6 +4,7 @@ pub use alloc::{
     borrow::{Cow, Cow::*},
     boxed::Box,
     collections::BTreeMap as HashMap,
+    fmt, format,
     string::String,
     string::ToString,
     vec,
@@ -14,7 +15,8 @@ pub use core::{convert::TryInto, marker::PhantomData, mem};
 #[cfg(feature = "std")]
 pub use std::{
     borrow::Cow::Borrowed, borrow::ToOwned, boxed::Box, collections::HashMap, convert::TryInto,
-    marker::PhantomData, mem, string::String, string::ToString, vec, vec::Vec,
+    error::Error, fmt, format, marker::PhantomData, mem, string::String, string::ToString, vec,
+    vec::Vec,
 };
 
 pub use primitive_types::{H160, H256, U256};

--- a/src/types.rs
+++ b/src/types.rs
@@ -27,24 +27,6 @@ pub struct InternalMetaCallArgs {
     pub input: Vec<u8>,
 }
 
-/// Internal errors to propagate up and format in the single place.
-pub enum ErrorKind {
-    ArgumentParseError,
-    InvalidMetaTransactionMethodName,
-    InvalidMetaTransactionFunctionArg,
-    InvalidEcRecoverSignature,
-}
-
-/// Errors involving the nonce
-pub enum NonceError {
-    /// Attempted to increment the nonce, but overflow occurred
-    NonceOverflow,
-    /// Account nonce did not match the transaction nonce
-    IncorrectNonce,
-}
-
-pub type Result<T> = core::result::Result<T, ErrorKind>;
-
 #[allow(dead_code)]
 pub fn u256_to_arr(value: &U256) -> [u8; 32] {
     let mut result = [0u8; 32];


### PR DESCRIPTION
This PR came out out of this issue outlined here: https://github.com/aurora-is-near/aurora-engine/pull/48#discussion_r624676151.

Do note, that this PR may look intimidating with amount of files changed + lines, but most of it is refactoring.

This is in general just a much better error structure. I really hated how the underlying EVM for some bizarre reason mixed together BOTH result types. It just can be awkward to work with in general. That is fixed with this PR.

As a bonus, all error returns are now all consistent too as `ERR_`.

Point of discussion: As far as I'm aware, Reverts shouldn't be considered an "ERR" as they are part of everyday EVM life? As in, the contract executes correctly, but due to some circumstance, it'll back out without actually applying changes.

Closes: https://github.com/aurora-is-near/aurora-engine/issues/33