### PR TITLE
Return precompile cost instead of 0.

### DIFF
--- a/src/precompiles/blake2.rs
+++ b/src/precompiles/blake2.rs
@@ -38,13 +38,14 @@ impl Precompile for Blake2F {
             return Err(ExitError::Other(Borrowed("ERR_BLAKE2F_INVALID_LEN")));
         }
 
+        let cost = Self::required_gas(input)?;
+        if cost > target_gas {
+            return Err(ExitError::OutOfGas);
+        }
+
         let mut rounds_bytes = [0u8; 4];
         rounds_bytes.copy_from_slice(&input[0..4]);
         let rounds = u32::from_be_bytes(rounds_bytes);
-
-        if Self::required_gas(input)? > target_gas {
-            return Err(ExitError::OutOfGas);
-        }
 
         let mut h = [0u64; 8];
         for (mut x, value) in h.iter_mut().enumerate() {
@@ -76,7 +77,7 @@ impl Precompile for Blake2F {
         let finished = input[212] != 0;
 
         let res = blake2::blake2b_f(rounds, h, m, t, finished).to_vec();
-        Ok((ExitSucceed::Returned, res, 0))
+        Ok((ExitSucceed::Returned, res, cost))
     }
 }
 

--- a/src/precompiles/bn128.rs
+++ b/src/precompiles/bn128.rs
@@ -67,7 +67,7 @@ fn read_point(input: &[u8], pos: usize) -> Result<bn::G1, ExitError> {
 pub(super) struct BN128Add<HF: HardFork>(PhantomData<HF>);
 
 impl<HF: HardFork> BN128Add<HF> {
-    fn run_inner(input: &[u8], _context: &Context) -> PrecompileResult {
+    fn run_inner(input: &[u8], _context: &Context) -> Result<Vec<u8>, ExitError> {
         use bn::AffineG1;
 
         let mut input = input.to_vec();
@@ -84,7 +84,7 @@ impl<HF: HardFork> BN128Add<HF> {
             output[32..64].copy_from_slice(&y);
         }
 
-        Ok((ExitSucceed::Returned, output.to_vec(), 0))
+        Ok(output.to_vec())
     }
 }
 
@@ -99,10 +99,12 @@ impl Precompile for BN128Add<Byzantium> {
     /// See: https://eips.ethereum.org/EIPS/eip-196
     /// See: https://etherscan.io/address/0000000000000000000000000000000000000006
     fn run(input: &[u8], target_gas: u64, context: &Context) -> PrecompileResult {
-        if Self::required_gas(input)? > target_gas {
+        let cost = Self::required_gas(input)?;
+        if cost > target_gas {
             Err(ExitError::OutOfGas)
         } else {
-            Self::run_inner(input, context)
+            let res = Self::run_inner(input, context)?;
+            Ok((ExitSucceed::Returned, res, cost))
         }
     }
 }
@@ -118,10 +120,12 @@ impl Precompile for BN128Add<Istanbul> {
     /// See: https://eips.ethereum.org/EIPS/eip-196
     /// See: https://etherscan.io/address/0000000000000000000000000000000000000006
     fn run(input: &[u8], target_gas: u64, context: &Context) -> PrecompileResult {
-        if Self::required_gas(input)? > target_gas {
+        let cost = Self::required_gas(input)?;
+        if cost > target_gas {
             Err(ExitError::OutOfGas)
         } else {
-            Self::run_inner(input, context)
+            let res = Self::run_inner(input, context)?;
+            Ok((ExitSucceed::Returned, res, cost))
         }
     }
 }
@@ -129,7 +133,7 @@ impl Precompile for BN128Add<Istanbul> {
 pub(super) struct BN128Mul<HF: HardFork>(PhantomData<HF>);
 
 impl<HF: HardFork> BN128Mul<HF> {
-    fn run_inner(input: &[u8], _context: &Context) -> PrecompileResult {
+    fn run_inner(input: &[u8], _context: &Context) -> Result<Vec<u8>, ExitError> {
         use bn::AffineG1;
 
         let mut input = input.to_vec();
@@ -149,7 +153,7 @@ impl<HF: HardFork> BN128Mul<HF> {
             output[32..64].copy_from_slice(&y);
         }
 
-        Ok((ExitSucceed::Returned, output.to_vec(), 0))
+        Ok(output.to_vec())
     }
 }
 
@@ -163,10 +167,12 @@ impl Precompile for BN128Mul<Byzantium> {
     /// See: https://eips.ethereum.org/EIPS/eip-196
     /// See: https://etherscan.io/address/0000000000000000000000000000000000000007
     fn run(input: &[u8], target_gas: u64, context: &Context) -> PrecompileResult {
-        if Self::required_gas(input)? > target_gas {
+        let cost = Self::required_gas(input)?;
+        if cost > target_gas {
             Err(ExitError::OutOfGas)
         } else {
-            Self::run_inner(input, context)
+            let res = Self::run_inner(input, context)?;
+            Ok((ExitSucceed::Returned, res, cost))
         }
     }
 }
@@ -181,10 +187,12 @@ impl Precompile for BN128Mul<Istanbul> {
     /// See: https://eips.ethereum.org/EIPS/eip-196
     /// See: https://etherscan.io/address/0000000000000000000000000000000000000007
     fn run(input: &[u8], target_gas: u64, context: &Context) -> PrecompileResult {
-        if Self::required_gas(input)? > target_gas {
+        let cost = Self::required_gas(input)?;
+        if cost > target_gas {
             Err(ExitError::OutOfGas)
         } else {
-            Self::run_inner(input, context)
+            let res = Self::run_inner(input, context)?;
+            Ok((ExitSucceed::Returned, res, cost))
         }
     }
 }
@@ -192,7 +200,7 @@ impl Precompile for BN128Mul<Istanbul> {
 pub(super) struct BN128Pair<HF: HardFork>(PhantomData<HF>);
 
 impl<HF: HardFork> BN128Pair<HF> {
-    fn run_inner(input: &[u8], _context: &Context) -> PrecompileResult {
+    fn run_inner(input: &[u8], _context: &Context) -> Result<Vec<u8>, ExitError> {
         use bn::{arith::U256, AffineG1, AffineG2, Fq, Fq2, Group, Gt, G1, G2};
 
         if input.len() % consts::PAIR_ELEMENT_LEN != 0 {
@@ -281,7 +289,7 @@ impl<HF: HardFork> BN128Pair<HF> {
             }
         };
 
-        Ok((ExitSucceed::Returned, output.to_big_endian().to_vec(), 0))
+        Ok(output.to_big_endian().to_vec())
     }
 }
 
@@ -298,10 +306,12 @@ impl Precompile for BN128Pair<Byzantium> {
     /// See: https://eips.ethereum.org/EIPS/eip-197
     /// See: https://etherscan.io/address/0000000000000000000000000000000000000008
     fn run(input: &[u8], target_gas: u64, context: &Context) -> PrecompileResult {
-        if Self::required_gas(input)? > target_gas {
+        let cost = Self::required_gas(input)?;
+        if cost > target_gas {
             Err(ExitError::OutOfGas)
         } else {
-            Self::run_inner(input, context)
+            let res = Self::run_inner(input, context)?;
+            Ok((ExitSucceed::Returned, res, cost))
         }
     }
 }
@@ -319,10 +329,12 @@ impl Precompile for BN128Pair<Istanbul> {
     /// See: https://eips.ethereum.org/EIPS/eip-197
     /// See: https://etherscan.io/address/0000000000000000000000000000000000000008
     fn run(input: &[u8], target_gas: u64, context: &Context) -> PrecompileResult {
-        if Self::required_gas(input)? > target_gas {
+        let cost = Self::required_gas(input)?;
+        if cost > target_gas {
             Err(ExitError::OutOfGas)
         } else {
-            Self::run_inner(input, context)
+            let res = Self::run_inner(input, context)?;
+            Ok((ExitSucceed::Returned, res, cost))
         }
     }
 }

--- a/src/precompiles/hash.rs
+++ b/src/precompiles/hash.rs
@@ -51,13 +51,14 @@ impl Precompile for SHA256 {
     fn run(input: &[u8], target_gas: u64, _context: &Context) -> PrecompileResult {
         use crate::sdk;
 
-        if Self::required_gas(input)? > target_gas {
-            Err(ExitError::OutOfGas)
+        let cost = Self::required_gas(input)?;
+        if cost > target_gas {
+            return Err(ExitError::OutOfGas);
         } else {
             Ok((
                 ExitSucceed::Returned,
                 sdk::sha256(input).as_bytes().to_vec(),
-                0,
+                cost,
             ))
         }
     }
@@ -81,15 +82,16 @@ impl Precompile for RIPEMD160 {
     fn run(input: &[u8], target_gas: u64, _context: &Context) -> PrecompileResult {
         use ripemd160::Digest;
 
-        if Self::required_gas(input)? > target_gas {
-            Err(ExitError::OutOfGas)
+        let cost = Self::required_gas(input)?;
+        if cost > target_gas {
+            return Err(ExitError::OutOfGas);
         } else {
             let hash = ripemd160::Ripemd160::digest(input);
             // The result needs to be padded with leading zeros because it is only 20 bytes, but
             // the evm works with 32-byte words.
             let mut result = [0u8; 32];
             result[12..].copy_from_slice(&hash);
-            Ok((ExitSucceed::Returned, result.to_vec(), 0))
+            Ok((ExitSucceed::Returned, result.to_vec(), cost))
         }
     }
 }

--- a/src/precompiles/identity.rs
+++ b/src/precompiles/identity.rs
@@ -31,10 +31,11 @@ impl Precompile for Identity {
     /// See: https://ethereum.github.io/yellowpaper/paper.pdf
     /// See: https://etherscan.io/address/0000000000000000000000000000000000000004
     fn run(input: &[u8], target_gas: u64, _context: &Context) -> PrecompileResult {
-        if Self::required_gas(input)? > target_gas {
-            Err(ExitError::OutOfGas)
+        let cost = Self::required_gas(input)?;
+        if cost > target_gas {
+            return Err(ExitError::OutOfGas);
         } else {
-            Ok((ExitSucceed::Returned, input.to_vec(), 0))
+            Ok((ExitSucceed::Returned, input.to_vec(), cost))
         }
     }
 }

--- a/src/precompiles/modexp.rs
+++ b/src/precompiles/modexp.rs
@@ -70,7 +70,8 @@ impl Precompile for ModExp<Byzantium> {
     /// See: https://eips.ethereum.org/EIPS/eip-198
     /// See: https://etherscan.io/address/0000000000000000000000000000000000000005
     fn run(input: &[u8], target_gas: u64, _context: &Context) -> PrecompileResult {
-        if Self::required_gas(input)? > target_gas {
+        let cost = Self::required_gas(input)?;
+        if cost > target_gas {
             return Err(ExitError::OutOfGas);
         }
 
@@ -127,7 +128,7 @@ impl Precompile for ModExp<Byzantium> {
             }
         };
 
-        Ok((ExitSucceed::Returned, result, 0))
+        Ok((ExitSucceed::Returned, result, cost))
     }
 }
 

--- a/src/precompiles/secp256k1.rs
+++ b/src/precompiles/secp256k1.rs
@@ -47,7 +47,8 @@ impl Precompile for ECRecover {
     }
 
     fn run(input: &[u8], target_gas: u64, _context: &Context) -> PrecompileResult {
-        if Self::required_gas(input)? > target_gas {
+        let cost = Self::required_gas(input)?;
+        if cost > target_gas {
             return Err(ExitError::OutOfGas);
         }
 
@@ -84,7 +85,7 @@ impl Precompile for ECRecover {
             }
         };
 
-        Ok((ExitSucceed::Returned, output.to_vec(), 0))
+        Ok((ExitSucceed::Returned, output.to_vec(), cost))
     }
 }
 


### PR DESCRIPTION
@mfornet wanted to know [what the last value of a return was](https://github.com/aurora-is-near/aurora-engine/issues/64) pertaining to the pre-compiles. This led to the understanding that a bug needs to be fixed with the correct cost of the precompile and not just a return of 0.

This closes https://github.com/aurora-is-near/aurora-engine/issues/64.