### PR TITLE
Fix sanity tests in connector

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,6 @@ git2 = "0.13"
 [features]
 default = ["sha2", "std"]
 std = ["borsh/std", "evm/std", "primitive-types/std", "rlp/std", "sha3/std", "ethabi/std", "lunarity-lexer/std", "bn/std"]
-testnet = []
 contract = []
 evm_bully = []
 log = []

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -299,8 +299,9 @@ impl EthConnectorContract {
 
     /// Internal logic for explicitly setting an eth balance (needed by ApplyBackend for Engine)
     pub(crate) fn internal_set_eth_balance(&mut self, address: &Address, amount: &U256) {
-        // TODO: this `as_u128` looks pretty dangerous! We need to somehow handle the case where
-        // `amount` does not fit into a u128...
+        // Call to `as_u128` here should be fine because u128::MAX is a value greater than
+        // all the Wei in existence, so a u128 should always be able to represent
+        // the balance of a single account.
         self.ft
             .internal_set_eth_balance(address.0, amount.as_u128());
         self.save_contract();

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -75,7 +75,7 @@ impl EthConnectorContract {
         let args = InitCallArgs::try_from_slice(&sdk::read_input()).expect(ERR_FAILED_PARSE);
         let current_account_id = sdk::current_account_id();
         let owner_id = String::from_utf8(current_account_id).unwrap();
-        let mut ft = FungibleToken::default();
+        let mut ft = FungibleToken::new();
         // Register FT account for current contract
         ft.internal_register_account(&owner_id);
         let contract_data = EthConnector {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -499,7 +499,7 @@ impl ApplyBackend for Engine {
                     //Engine::set_balance(&address, &basic.balance);
                     // Apply changes for eth-conenctor
                     EthConnectorContract::get_instance()
-                        .internal_deposit_eth(&address, &basic.balance);
+                        .internal_set_eth_balance(&address, &basic.balance);
                     if let Some(code) = code {
                         Engine::set_code(&address, &code)
                     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -495,9 +495,7 @@ impl ApplyBackend for Engine {
                     reset_storage,
                 } => {
                     Engine::set_nonce(&address, &basic.nonce);
-                    // TODO: should be aligned to eth-connector balance management logic
-                    //Engine::set_balance(&address, &basic.balance);
-                    // Apply changes for eth-conenctor
+                    // Apply changes for eth-connector
                     EthConnectorContract::get_instance()
                         .internal_set_eth_balance(&address, &basic.balance);
                     if let Some(code) = code {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -339,17 +339,6 @@ impl Engine {
         Self::set_nonce(address, &new_nonce);
     }
 
-    #[cfg(feature = "testnet")]
-    /// Credits the address with 10 coins from the faucet.
-    pub fn credit(&self, address: &Address) -> EngineResult<()> {
-        let balance = Self::get_balance(address);
-        // Saturating adds are intentional
-        let new_balance = balance.saturating_add(U256::from(10_000_000_000_000_000_000));
-
-        Self::set_balance(address, &new_balance);
-        Ok(())
-    }
-
     pub fn view_with_args(&self, args: ViewCallArgs) -> EngineResult<Vec<u8>> {
         let origin = Address::from_slice(&args.sender);
         let contract = Address::from_slice(&args.address);

--- a/src/fungible_token.rs
+++ b/src/fungible_token.rs
@@ -89,7 +89,7 @@ impl FungibleToken {
         let current_balance = self.internal_unwrap_balance_of_eth(address);
         match current_balance.cmp(&new_balance) {
             Ordering::Less => {
-                // new current_balance is smaller, so we need to deposit
+                // current_balance is smaller, so we need to deposit
                 let diff = new_balance - current_balance;
                 self.internal_deposit_eth(address, diff);
             }

--- a/src/fungible_token.rs
+++ b/src/fungible_token.rs
@@ -31,6 +31,10 @@ pub struct FungibleToken {
 
 #[cfg(feature = "contract")]
 impl FungibleToken {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     /// Balance of NEAR tokens
     pub fn internal_unwrap_balance_of(&self, account_id: &str) -> Balance {
         match self.accounts_get(account_id) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,6 @@ mod connector;
 mod deposit_event;
 #[cfg(feature = "contract")]
 mod engine;
-#[cfg(feature = "contract")]
 mod fungible_token;
 #[cfg(feature = "contract")]
 mod log_entry;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,20 +265,6 @@ mod contract {
             .sdk_process();
     }
 
-    #[cfg(feature = "testnet")]
-    #[no_mangle]
-    pub extern "C" fn make_it_rain() {
-        let input = sdk::read_input();
-        let dest_address = Address::from_slice(&input);
-        let source_address = predecessor_address();
-        let engine = Engine::new(source_address);
-
-        engine.increment_nonce(&source_address);
-
-        let result = engine.credit(&dest_address);
-        result.map(|_f| Vec::new()).sdk_process();
-    }
-
     #[no_mangle]
     pub extern "C" fn register_relayer() {
         let relayer_address = sdk::read_input();

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -213,7 +213,6 @@ pub struct FinishDepositEthCallArgs {
 }
 
 /// eth-connector initial args
-#[cfg(feature = "contract")]
 #[derive(BorshSerialize, BorshDeserialize)]
 pub struct InitCallArgs {
     pub prover_account: AccountId,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -11,11 +11,12 @@ pub use alloc::{
     vec::Vec,
 };
 #[cfg(not(feature = "std"))]
-pub use core::{convert::TryInto, marker::PhantomData, mem};
+pub use core::{cmp::Ordering, convert::TryInto, marker::PhantomData, mem};
 #[cfg(feature = "std")]
 pub use std::{
-    borrow::Cow::Borrowed, borrow::ToOwned, boxed::Box, collections::HashMap, convert::TryInto,
-    error::Error, fmt, marker::PhantomData, mem, string::String, string::ToString, vec, vec::Vec,
+    borrow::Cow::Borrowed, borrow::ToOwned, boxed::Box, cmp::Ordering, collections::HashMap,
+    convert::TryInto, error::Error, fmt, marker::PhantomData, mem, string::String,
+    string::ToString, vec, vec::Vec,
 };
 
 pub use primitive_types::{H160, H256, U256};

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -13,6 +13,14 @@ pub enum KeyPrefix {
     EthConnector = 0x6,
 }
 
+/// Enum used to differentiate different storage keys used by eth-connector
+#[derive(Clone, Copy, BorshSerialize, BorshDeserialize)]
+pub enum EthConnectorStorageId {
+    Contract = 0x0,
+    FungibleToken = 0x1,
+    UsedEvent = 0x2,
+}
+
 /// We can't use const generic over Enum, but we can do it over integral type
 pub type KeyPrefixU8 = u8;
 

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -12,7 +12,7 @@ use primitive_types::U256;
 use rlp::RlpStream;
 use secp256k1::{self, Message, PublicKey, SecretKey};
 
-use crate::parameters::{NewCallArgs, SubmitResult};
+use crate::parameters::{InitCallArgs, NewCallArgs, SubmitResult};
 use crate::prelude::Address;
 use crate::storage;
 use crate::test_utils::solidity::{ContractConstructor, DeployedContract};
@@ -245,12 +245,24 @@ pub(crate) fn deploy_evm() -> AuroraRunner {
     let args = NewCallArgs {
         chain_id: types::u256_to_arr(&U256::from(runner.chain_id)),
         owner_id: runner.aurora_account_id.clone(),
-        bridge_prover_id: "prover.near".to_string(),
+        bridge_prover_id: "bridge_prover.near".to_string(),
         upgrade_delay_blocks: 1,
     };
 
     let (_, maybe_error) = runner.call(
         "new",
+        runner.aurora_account_id.clone(),
+        args.try_to_vec().unwrap(),
+    );
+
+    assert!(maybe_error.is_none());
+
+    let args = InitCallArgs {
+        prover_account: "prover.near".to_string(),
+        eth_custodian_address: "d045f7e19B2488924B97F9c145b5E51D0D895A65".to_string(),
+    };
+    let (_, maybe_error) = runner.call(
+        "new_eth_connector",
         runner.aurora_account_id.clone(),
         args.try_to_vec().unwrap(),
     );


### PR DESCRIPTION
There are a few things here:

1. A call to `new` is not enough to initialize the Aurora engine contract anymore, an eth-connector instance is also required (because it is used in the `ApplyBackend` implementation). This makes me wonder if they should be separate calls in the first place. In the tests I now create an eth-connector.
2. As mentioned above, the `ApplyBackend` implementation uses a eth-connector function to update balances (this is to make sure the connector does not fall out of sync with the base engine). However, the structure passed to `apply` contains the actual new balance, not the change in balance. Therefore, the deposit call was incorrect, and instead it needs to be a set balance call. I have implemented that to fix the bug.
3. We decided that having an Aurora native faucet (`make_it_rain`) does not make sense with the connector (it causes a problem if you mint new eth on the Aurora side then try to withdraw it to ropsten). So we remove `make_it_rain`.
4. I think this was pointed out elsewhere, but working with the code myself I see this u128 vs U256 incompatibility could be a really big problem. We probably can't do anything about it before launch, but I am concerned.
5. I had to add a new ` #[allow(dead_code)]` for some reason. I don't think any of my changes removed usages of the function in question, so I'm wondering what's going on there.

Note: This PR is release critical if we want to use the eth-connector branch on testnet for the launch tomorrow.