### PR TITLE
A more acceptable return for `Engine::block_hash`

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -421,7 +421,7 @@ impl evm::backend::Backend for Engine {
     /// See: https://doc.aurora.dev/develop/compat/evm#blockhash
     fn block_hash(&self, number: U256) -> H256 {
         let idx = U256::from(sdk::block_index());
-        if idx.saturating_sub(256) <= number && number < idx {
+        if idx.saturating_sub(U256::from(256)) <= number && number < idx {
             H256::from([255u8; 32])
         } else {
             H256::zero()


### PR DESCRIPTION
As per Ethereum VM opcodes, the block hash returns the block hash of the last 256 blocks, excluding the current one. Otherwise, it will return `0x0`. 

Unfortunately, we do not have the capability to return what the Ethereum VM wants, but we can at least give the best that we can for now. Simply, the requirement of returning `0x0` if we are on the current block or beyond 256 blocks. Otherwise, we can return the max value of an unsigned 256-bit integer.