### PR TITLE
Eugene audit 2021 05 11

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,8 +174,8 @@ mod contract {
         use rlp::{Decodable, Rlp};
 
         let input = sdk::read_input();
-        let signed_transaction = EthSignedTransaction::decode(&Rlp::new(&input))
-            .sdk_expect("ERR_INVALID_TX");
+        let signed_transaction =
+            EthSignedTransaction::decode(&Rlp::new(&input)).sdk_expect("ERR_INVALID_TX");
 
         let state = Engine::get_state();
 
@@ -187,7 +187,9 @@ mod contract {
         }
 
         // Retrieve the signer of the transaction:
-        let sender = signed_transaction.sender().sdk_expect("ERR_INVALID_ECDSA_SIGNATURE");
+        let sender = signed_transaction
+            .sender()
+            .sdk_expect("ERR_INVALID_ECDSA_SIGNATURE");
 
         Engine::check_nonce(&sender, &signed_transaction.transaction.nonce).sdk_unwrap();
 
@@ -217,7 +219,8 @@ mod contract {
             &domain_separator,
             &sdk::current_account_id(),
             input,
-        ).sdk_expect("ERR_META_TX_PARSE");
+        )
+        .sdk_expect("ERR_META_TX_PARSE");
 
         Engine::check_nonce(&meta_call_args.sender, &meta_call_args.nonce).sdk_unwrap();
 

--- a/src/meta_parsing.rs
+++ b/src/meta_parsing.rs
@@ -507,6 +507,7 @@ pub fn prepare_meta_call_args(
     let args_decoded: Vec<RlpValue> = rlp_decode(&input.input)?;
     for (i, arg) in args_decoded.iter().enumerate() {
         arg_bytes.extend_from_slice(&eip_712_hash_argument(
+            // TODO: Check that method.args.len() == args_decoded.len(). Otherwise it may panic here.
             &methods.method.args[i].t,
             arg,
             &methods.types,
@@ -534,7 +535,7 @@ pub fn prepare_meta_call_args(
 }
 
 /// Parse encoded `MetaCallArgs`, validate with given domain and account and recover the sender's address from the signature.
-/// Returns error if method definition or arguments are wrong, invalid signature or EC recovery failed.  
+/// Returns error if method definition or arguments are wrong, invalid signature or EC recovery failed.
 pub fn parse_meta_call(
     domain_separator: &RawU256,
     account_id: &[u8],

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -171,6 +171,7 @@ pub fn read_input_arr20() -> [u8; 20] {
     unsafe {
         exports::input(0);
         let bytes = [0u8; 20];
+        // TODO: Is it fine to not check the length of the input register here?
         exports::read_register(0, bytes.as_ptr() as *const u64 as u64);
         bytes
     }
@@ -210,6 +211,7 @@ pub fn read_u64(key: &[u8]) -> Option<u64> {
     unsafe {
         if exports::storage_read(key.len() as u64, key.as_ptr() as u64, 0) == 1 {
             let result = [0u8; 8];
+            // TODO: Are you sure the register length is correct?
             exports::read_register(0, result.as_ptr() as _);
             Some(u64::from_le_bytes(result))
         } else {
@@ -328,6 +330,8 @@ pub fn self_deploy(code_key: &[u8]) {
         // Remove code from storage and store it in register 1.
         exports::storage_remove(code_key.len() as _, code_key.as_ptr() as _, 1);
         exports::promise_batch_action_deploy_contract(promise_id, u64::MAX as _, 1);
+        // TODO: Call upgrade on the same promise to make sure the state has migrated successfully.
+        //     Otherwise, you may have to handle non-latest state in every other method call, which might be inefficient.
     }
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -52,5 +52,15 @@ pub fn storage_to_key(address: &Address, key: &H256) -> [u8; 53] {
     result
 }
 
+#[allow(dead_code)]
+pub fn storage_to_key_nonced(address: &Address, storage_nonce: u32, key: &H256) -> [u8; 57] {
+    let mut result = [0u8; 57];
+    result[0] = KeyPrefix::Storage as u8;
+    result[1..21].copy_from_slice(&address.0);
+    result[21..25].copy_from_slice(&storage_nonce.to_le_bytes());
+    result[25..].copy_from_slice(&key.0);
+    result
+}
+
 #[cfg(test)]
 mod tests {}

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,7 +11,8 @@ pub type RawAddress = [u8; 20];
 pub type RawU256 = [u8; 32]; // Little-endian large integer type.
 pub type RawH256 = [u8; 32]; // Unformatted binary data of fixed length.
 
-pub const STORAGE_PRICE_PER_BYTE: u128 = 100_000_000_000_000_000_000; // 1e20yN, 0.0001N
+// NOTE: Upgraded to current correct storage price
+pub const STORAGE_PRICE_PER_BYTE: u128 = 10_000_000_000_000_000_000; // 1e19yN, 0.00001N
 
 /// Internal args format for meta call.
 #[derive(Debug)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,8 +11,7 @@ pub type RawAddress = [u8; 20];
 pub type RawU256 = [u8; 32]; // Little-endian large integer type.
 pub type RawH256 = [u8; 32]; // Unformatted binary data of fixed length.
 
-// NOTE: Upgraded to current correct storage price
-pub const STORAGE_PRICE_PER_BYTE: u128 = 10_000_000_000_000_000_000; // 1e19yN, 0.00001N
+pub const STORAGE_PRICE_PER_BYTE: u128 = 100_000_000_000_000_000_000; // 1e20yN, 0.0001N
 
 /// Internal args format for meta call.
 #[derive(Debug)]


### PR DESCRIPTION
I've decided to comment inline.

Overall I didn't find anything major. I think the biggest issue is `remove_all_storage`. This is a protocol level decision that led to the removal of prefix deletion or iterations. The recent protocol change also restricted account deletion if the storage usage exceeds 10Kb (beyond the contract). This is done to prevent key iteration.

```rust
    /// Removes all storage for the given address.
    pub fn remove_all_storage(_address: &Address) {
        // FIXME: there is presently no way to prefix delete trie state.
        // NOTE: There is not going to be a method on runtime for this.
        //     You may need to store all keys in a list if you want to do this in a contract.
        //     Maybe you can incentivize people to delete dead old keys. They can observe them from
        //     external indexer node and then issue special cleaning transaction.
        //     Either way you may have to store the nonce per storage address root. When the account
        //     has to be deleted the storage nonce needs to be increased, and the old nonce keys
        //     can be deleted over time. That's how TurboGeth does storage.
    }
```

Without an ability to remove old storage from the account may result in a storage draining in a longer run that is not covered by the protocol yet. I'd recommend addressing this issue asap, which may require a hardfork of existing addresses/contracts.

Potential implementation is:
```rust
#[allow(dead_code)]
pub fn storage_to_key_nonced(address: &Address, storage_nonce: u32, key: &H256) -> [u8; 57] {
    let mut result = [0u8; 57];
    result[0] = KeyPrefix::Storage as u8;
    result[1..21].copy_from_slice(&address.0);
    result[21..25].copy_from_slice(&storage_nonce.to_le_bytes());
    result[25..].copy_from_slice(&key.0);
    result
}
```

 