### PR TITLE
Explicitly use `evm-core` 0.26.1.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,7 @@ dependencies = [
  "criterion",
  "ethabi",
  "evm",
+ "evm-core",
  "git2",
  "hex",
  "libsecp256k1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ blake2 = { git = "https://github.com/near/near-blake2.git", version = "0.9.1", d
 borsh = { version = "0.8.2", default-features = false }
 bn = { package = "aurora-bn", git = "https://github.com/aurora-is-near/aurora-bn.git", default-features = false }
 evm = { version = "0.26.0", default-features = false }
+evm-core = { version = "0.26.1", default-features = false }
 libsecp256k1 = { version = "0.3.5", default-features = false }
 num = { version = "0.4.0", default-features = false, features = ["alloc"] }
 primitive-types = { version = "0.9.0", default-features = false, features = ["rlp"] }


### PR DESCRIPTION
Just in case someone accidentally downgrades the `evm-core` as it is not explicitly directly used, we can specify the version in the cargo manifest to ensure we are using it. This wouldn't be needed if `evm` was updated to 0.26.1 as well.