### PR TITLE
Use cache action to save cargo artifacts between runs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,14 @@ jobs:
     steps:
       - name: Clone the repository
         uses: actions/checkout@v2
+      - name: Cache Cargo artifacts
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install the toolchain
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
Closes #91 

Hopefully this works. It'll be a little difficult to test because it will only help future PRs (not this one since this one will create the cache I think). Currently the tests take ~20 minutes to run ([example](https://github.com/aurora-is-near/aurora-engine/runs/2578076872)), so we'll have to see if this time goes down.

Workflow based on the [official `cache` action documentation](https://github.com/actions/cache/blob/main/examples.md#rust---cargo).