### PR TITLE
Eugene's Eth connector review

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,7 @@ dependencies = [
  "primitive-types",
  "rand 0.7.3",
  "ripemd160",
+ "rjson",
  "rlp",
  "sha2 0.9.5",
  "sha3 0.9.1",
@@ -3309,6 +3310,12 @@ dependencies = [
  "digest 0.9.0",
  "opaque-debug 0.3.0",
 ]
+
+[[package]]
+name = "rjson"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5510dbde48c4c37bf69123b1f636b6dd5f8dffe1f4e358af03c46a4947dca219"
 
 [[package]]
 name = "rlp"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ lunarity-lexer = { git = "https://github.com/ilblackdragon/lunarity", rev = "520
 ethabi = { git = "https://github.com/darwinia-network/ethabi", branch = "xavier-no-std", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 byte-slice-cast = { version = "1.0", default-features = false }
+rjson = { version = "0.3.1", default-features = false }
 
 [dev-dependencies]
 bstr = "0.2"

--- a/src/fungible_token.rs
+++ b/src/fungible_token.rs
@@ -19,9 +19,6 @@ pub struct FungibleToken {
     /// Total supply of the all token.
     pub total_supply: Balance,
 
-    /// Total supply of the all NEAR token.
-    pub total_supply_near: Balance,
-
     /// Total supply of the all ETH token.
     pub total_supply_eth: Balance,
 
@@ -53,16 +50,6 @@ impl FungibleToken {
         let balance = self.internal_unwrap_balance_of(account_id);
         if let Some(new_balance) = balance.checked_add(amount) {
             self.accounts_insert(account_id, new_balance);
-            self.total_supply_near = self
-                .total_supply_near
-                .checked_add(amount)
-                .expect("ERR_TOTAL_SUPPLY_OVERFLOW");
-            // Note: Reusing total supply for a sum of ETH and NEAR is very weird. It doesn't give
-            // mean anything reasonable. I guess the goal is to just report changing numbers for the
-            // total supply when either ETH or NEAR balances are changing. In this case it's probably
-            // okay to report only one of them, e.g. ETH total_supply and not report NEAR total
-            // supply through `ft_total_supply`.
-            // TODO: Remove total_supply for NEAR
             self.total_supply = self
                 .total_supply
                 .checked_add(amount)
@@ -114,10 +101,6 @@ impl FungibleToken {
         let balance = self.internal_unwrap_balance_of(account_id);
         if let Some(new_balance) = balance.checked_sub(amount) {
             self.accounts_insert(account_id, new_balance);
-            self.total_supply_near = self
-                .total_supply_near
-                .checked_sub(amount)
-                .expect("ERR_TOTAL_SUPPLY_OVERFLOW");
             self.total_supply = self
                 .total_supply
                 .checked_sub(amount)
@@ -187,7 +170,7 @@ impl FungibleToken {
     }
 
     pub fn ft_total_supply_near(&self) -> u128 {
-        self.total_supply_near
+        self.total_supply - self.total_supply_eth
     }
 
     pub fn ft_total_supply_eth(&self) -> u128 {
@@ -262,8 +245,12 @@ impl FungibleToken {
         let unused_amount = match sdk::promise_result(0) {
             PromiseResult::NotReady => unreachable!(),
             PromiseResult::Successful(value) => {
-                // TODO: This has to use `JSON` instead of Borsh to match the FT standard.
-                if let Ok(unused_amount) = Balance::try_from_slice(&value[..]) {
+                if let Ok(unused_amount) = String::from_utf8(value) {
+                    let unused_amount = if let Ok(v) = unused_amount.parse::<u128>() {
+                        v
+                    } else {
+                        amount
+                    };
                     if amount > unused_amount {
                         unused_amount
                     } else {
@@ -375,8 +362,9 @@ impl FungibleToken {
         }
     }
 
-    pub fn storage_balance_of(&self, account_id: &str) -> Option<StorageBalance> {
+    pub fn storage_balance_of(&self, account_id: &str) -> StorageBalance {
         self.internal_storage_balance_of(account_id)
+            .unwrap_or_default()
     }
 
     // `registration_only` doesn't affect the implementation for vanilla fungible token.
@@ -433,8 +421,24 @@ impl FungibleToken {
         }
     }
 
+    /// Insert account.
+    /// Calculate total unique accounts
     pub fn accounts_insert(&self, account_id: &str, amount: Balance) {
-        sdk::save_contract(&Self::account_to_key(account_id), &amount)
+        if !self.accounts_contains_key(account_id) {
+            let key = Self::get_statistic_key();
+            let accounts_counter = sdk::read_u64(&key)
+                .unwrap_or(0)
+                .checked_add(1)
+                .expect("ERR_ACCOUNTS_COUNTER_OVERFLOW");
+            sdk::write_storage(&key, &accounts_counter.to_le_bytes());
+        }
+        sdk::save_contract(&Self::account_to_key(account_id), &amount);
+    }
+
+    /// Get accounts counter for statistics
+    /// It represents total unique accounts.
+    pub fn get_accounts_counter(&self) -> u64 {
+        sdk::read_u64(&Self::get_statistic_key()).unwrap_or(0)
     }
 
     fn accounts_contains_key(&self, account_id: &str) -> bool {
@@ -457,5 +461,13 @@ impl FungibleToken {
         );
         key.extend_from_slice(account_id.as_bytes());
         key
+    }
+
+    /// Key for store contract statistics data
+    fn get_statistic_key() -> Vec<u8> {
+        storage::bytes_to_key(
+            storage::KeyPrefix::EthConnector,
+            &[storage::EthConnectorStorageId::StatisticsAuroraAccountsCounter as u8],
+        )
     }
 }

--- a/src/json.rs
+++ b/src/json.rs
@@ -1,0 +1,169 @@
+use super::prelude::*;
+use crate::sdk;
+
+use crate::types::ERR_FAILED_PARSE;
+use alloc::collections::BTreeMap;
+use core::convert::From;
+use rjson::{Array, Null, Object, Value};
+
+pub enum JsonValue {
+    Null,
+    Number(f64),
+    Bool(bool),
+    String(String),
+    Array(Vec<JsonValue>),
+    Object(BTreeMap<String, JsonValue>),
+}
+
+pub struct JsonArray(Vec<JsonValue>);
+pub struct JsonObject(BTreeMap<String, JsonValue>);
+
+impl JsonValue {
+    #[allow(dead_code)]
+    pub fn string(&self, key: &str) -> Result<String, ()> {
+        match self {
+            JsonValue::Object(o) => match o.get(key).ok_or(())? {
+                JsonValue::String(s) => Ok(s.into()),
+                _ => Err(()),
+            },
+            _ => Err(()),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn u64(&self, key: &str) -> Result<u64, ()> {
+        match self {
+            JsonValue::Object(o) => match o.get(key).ok_or(())? {
+                JsonValue::Number(n) => Ok(*n as u64),
+                _ => Err(()),
+            },
+            _ => Err(()),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn u128(&self, key: &str) -> Result<u128, ()> {
+        match self {
+            JsonValue::Object(o) => match o.get(key).ok_or(())? {
+                JsonValue::Number(n) => Ok(*n as u128),
+                _ => Err(()),
+            },
+            _ => Err(()),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn bool(&self, key: &str) -> Result<bool, ()> {
+        match self {
+            JsonValue::Object(o) => match o.get(key).ok_or(())? {
+                JsonValue::Bool(n) => Ok(*n),
+                _ => Err(()),
+            },
+            _ => Err(()),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn parse_u8(v: &JsonValue) -> u8 {
+        match v {
+            JsonValue::Number(n) => *n as u8,
+            _ => sdk::panic_utf8(ERR_FAILED_PARSE.as_bytes()),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn array<T, F>(&self, key: &str, call: F) -> Result<Vec<T>, ()>
+    where
+        F: FnMut(&JsonValue) -> T,
+    {
+        match self {
+            JsonValue::Object(o) => match o.get(key).ok_or(())? {
+                JsonValue::Array(arr) => Ok(arr.iter().map(call).collect()),
+                _ => Err(()),
+            },
+            _ => Err(()),
+        }
+    }
+}
+
+impl Array<JsonValue, JsonObject, JsonValue> for JsonArray {
+    fn new() -> Self {
+        JsonArray(Vec::new())
+    }
+    fn push(&mut self, v: JsonValue) {
+        self.0.push(v)
+    }
+}
+
+impl Object<JsonValue, JsonArray, JsonValue> for JsonObject {
+    fn new<'b>() -> Self {
+        JsonObject(BTreeMap::new())
+    }
+    fn insert(&mut self, k: String, v: JsonValue) {
+        self.0.insert(k, v);
+    }
+}
+
+impl Null<JsonValue, JsonArray, JsonObject> for JsonValue {
+    fn new() -> Self {
+        JsonValue::Null
+    }
+}
+
+impl Value<JsonArray, JsonObject, JsonValue> for JsonValue {}
+
+impl From<f64> for JsonValue {
+    fn from(v: f64) -> Self {
+        JsonValue::Number(v)
+    }
+}
+
+impl From<bool> for JsonValue {
+    fn from(v: bool) -> Self {
+        JsonValue::Bool(v)
+    }
+}
+
+impl From<String> for JsonValue {
+    fn from(v: String) -> Self {
+        JsonValue::String(v)
+    }
+}
+
+impl From<JsonArray> for JsonValue {
+    fn from(v: JsonArray) -> Self {
+        JsonValue::Array(v.0)
+    }
+}
+
+impl From<JsonObject> for JsonValue {
+    fn from(v: JsonObject) -> Self {
+        JsonValue::Object(v.0)
+    }
+}
+
+impl core::fmt::Debug for JsonValue {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match *self {
+            JsonValue::Null => f.write_str("null"),
+            JsonValue::String(ref v) => f.write_fmt(format_args!("\"{}\"", v)),
+            JsonValue::Number(ref v) => f.write_fmt(format_args!("{}", v)),
+            JsonValue::Bool(ref v) => f.write_fmt(format_args!("{}", v)),
+            JsonValue::Array(ref v) => f.write_fmt(format_args!("{:?}", v)),
+            JsonValue::Object(ref v) => f.write_fmt(format_args!("{:#?}", v)),
+        }
+    }
+}
+
+impl core::fmt::Display for JsonValue {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.write_fmt(format_args!("{:?}", *self))
+    }
+}
+
+#[allow(dead_code)]
+pub fn parse_json(data: &[u8]) -> Option<JsonValue> {
+    let data_array: Vec<char> = data.iter().map(|b| *b as char).collect::<Vec<_>>();
+    let mut index = 0;
+    rjson::parse::<JsonValue, JsonArray, JsonObject, JsonValue>(&*data_array, &mut index)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,8 @@ mod deposit_event;
 mod engine;
 mod fungible_token;
 #[cfg(feature = "contract")]
+mod json;
+#[cfg(feature = "contract")]
 mod log_entry;
 mod precompiles;
 #[cfg(feature = "contract")]
@@ -47,11 +49,14 @@ mod contract {
     use crate::engine::{Engine, EngineResult, EngineState};
     #[cfg(feature = "evm_bully")]
     use crate::parameters::{BeginBlockArgs, BeginChainArgs};
-    use crate::parameters::{FunctionCallArgs, GetStorageAtArgs, NewCallArgs, ViewCallArgs};
+    use crate::parameters::{
+        ExpectUtf8, FunctionCallArgs, GetStorageAtArgs, NewCallArgs, TransferCallCallArgs,
+        ViewCallArgs,
+    };
     use crate::prelude::{Address, TryInto, H256, U256};
     use crate::sdk;
     use crate::storage::{bytes_to_key, KeyPrefix};
-    use crate::types::{near_account_to_evm_address, u256_to_arr};
+    use crate::types::{near_account_to_evm_address, u256_to_arr, ERR_FAILED_PARSE};
 
     #[global_allocator]
     static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
@@ -410,7 +415,15 @@ mod contract {
 
     #[no_mangle]
     pub extern "C" fn ft_transfer_call() {
-        EthConnectorContract::get_instance().ft_transfer_call();
+        use crate::json::parse_json;
+
+        // Check is payable
+        sdk::assert_one_yocto();
+
+        let args = TransferCallCallArgs::from(
+            parse_json(&sdk::read_input()).expect_utf8(ERR_FAILED_PARSE.as_bytes()),
+        );
+        EthConnectorContract::get_instance().ft_transfer_call(args);
     }
 
     #[no_mangle]
@@ -432,6 +445,11 @@ mod contract {
     pub extern "C" fn ft_on_transfer() {
         let engine = Engine::new(predecessor_address());
         EthConnectorContract::get_instance().ft_on_transfer(&engine)
+    }
+
+    #[no_mangle]
+    pub extern "C" fn get_accounts_counter() {
+        EthConnectorContract::get_instance().get_accounts_counter()
     }
 
     #[cfg(feature = "integration-test")]

--- a/src/precompiles/native.rs
+++ b/src/precompiles/native.rs
@@ -1,7 +1,7 @@
 use evm::{Context, ExitError, ExitSucceed};
 
 use super::{Precompile, PrecompileResult};
-use crate::prelude::{Cow, String, Vec, U256};
+use crate::prelude::{is_valid_account_id, Cow, String, Vec, U256};
 use crate::types::AccountId;
 
 mod costs {
@@ -25,44 +25,6 @@ mod costs {
 fn get_nep141_from_erc20(_erc20_token: &[u8]) -> Vec<u8> {
     // TODO(#51): Already implemented
     Vec::new()
-}
-
-/// The minimum length of a valid account ID.
-const MIN_ACCOUNT_ID_LEN: u64 = 2;
-/// The maximum length of a valid account ID.
-const MAX_ACCOUNT_ID_LEN: u64 = 64;
-
-/// Returns `true` if the given account ID is valid and `false` otherwise.
-///
-/// Taken from near-sdk-rs:
-/// (https://github.com/near/near-sdk-rs/blob/42f62384c3acd024829501ee86e480917da03896/near-sdk/src/environment/env.rs#L816-L843)
-pub fn is_valid_account_id(account_id: &[u8]) -> bool {
-    if (account_id.len() as u64) < MIN_ACCOUNT_ID_LEN
-        || (account_id.len() as u64) > MAX_ACCOUNT_ID_LEN
-    {
-        return false;
-    }
-
-    // NOTE: We don't want to use Regex here, because it requires extra time to compile it.
-    // The valid account ID regex is /^(([a-z\d]+[-_])*[a-z\d]+\.)*([a-z\d]+[-_])*[a-z\d]+$/
-    // Instead the implementation is based on the previous character checks.
-
-    // We can safely assume that last char was a separator.
-    let mut last_char_is_separator = true;
-
-    for c in account_id {
-        let current_char_is_separator = match *c {
-            b'a'..=b'z' | b'0'..=b'9' => false,
-            b'-' | b'_' | b'.' => true,
-            _ => return false,
-        };
-        if current_char_is_separator && last_char_is_separator {
-            return false;
-        }
-        last_char_is_separator = current_char_is_separator;
-    }
-    // The account can't end as separator.
-    !last_char_is_separator
 }
 
 pub struct ExitToNear; //TransferEthToNear

--- a/src/precompiles/native.rs
+++ b/src/precompiles/native.rs
@@ -97,7 +97,7 @@ impl Precompile for ExitToNear {
                 (
                     crate::sdk::current_account_id(),
                     crate::prelude::format!(
-                        r#"{{"receiver_id": "{}", "amount": "{}", "memo": null}}"#,
+                        r#"{{"receiver_id": "{}", "amount": "{}"}}"#,
                         String::from_utf8(input.to_vec()).unwrap(),
                         context.apparent_value.as_u128()
                     ),
@@ -122,12 +122,14 @@ impl Precompile for ExitToNear {
             let amount = U256::from_big_endian(&input_mut[..32]).as_u128();
             input_mut = &input_mut[32..];
 
+            // TODO: You have to charge caller's account balance for this transfer.
+
             if is_valid_account_id(input_mut) {
                 let receiver_account_id: AccountId = String::from_utf8(input_mut.to_vec()).unwrap();
                 (
                     nep141_address,
                     crate::prelude::format!(
-                        r#"{{"receiver_id": "{}", "amount": "{}", "memo": null}}"#,
+                        r#"{{"receiver_id": "{}", "amount": "{}"}}"#,
                         receiver_account_id,
                         amount
                     ),
@@ -211,6 +213,8 @@ impl Precompile for ExitToEthereum {
 
             let amount = U256::from_big_endian(&input_mut[..32]).as_u128();
             input_mut = &input_mut[32..];
+
+            // TODO: Charge the caller's account balance?
 
             if input_mut.len() == 20 {
                 // Parse ethereum address in hex

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -28,3 +28,41 @@ pub type Address = H160;
 pub fn Address(input: [u8; 20]) -> Address {
     H160(input)
 }
+
+/// The minimum length of a valid account ID.
+const MIN_ACCOUNT_ID_LEN: u64 = 2;
+/// The maximum length of a valid account ID.
+const MAX_ACCOUNT_ID_LEN: u64 = 64;
+
+/// Returns `true` if the given account ID is valid and `false` otherwise.
+///
+/// Taken from near-sdk-rs:
+/// (https://github.com/near/near-sdk-rs/blob/42f62384c3acd024829501ee86e480917da03896/near-sdk/src/environment/env.rs#L816-L843)
+pub fn is_valid_account_id(account_id: &[u8]) -> bool {
+    if (account_id.len() as u64) < MIN_ACCOUNT_ID_LEN
+        || (account_id.len() as u64) > MAX_ACCOUNT_ID_LEN
+    {
+        return false;
+    }
+
+    // NOTE: We don't want to use Regex here, because it requires extra time to compile it.
+    // The valid account ID regex is /^(([a-z\d]+[-_])*[a-z\d]+\.)*([a-z\d]+[-_])*[a-z\d]+$/
+    // Instead the implementation is based on the previous character checks.
+
+    // We can safely assume that last char was a separator.
+    let mut last_char_is_separator = true;
+
+    for c in account_id {
+        let current_char_is_separator = match *c {
+            b'a'..=b'z' | b'0'..=b'9' => false,
+            b'-' | b'_' | b'.' => true,
+            _ => return false,
+        };
+        if current_char_is_separator && last_char_is_separator {
+            return false;
+        }
+        last_char_is_separator = current_char_is_separator;
+    }
+    // The account can't end as separator.
+    !last_char_is_separator
+}

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -25,6 +25,7 @@ pub enum EthConnectorStorageId {
     Contract = 0x0,
     FungibleToken = 0x1,
     UsedEvent = 0x2,
+    StatisticsAuroraAccountsCounter = 0x3,
 }
 
 /// We can't use const generic over Enum, but we can do it over integral type


### PR DESCRIPTION
I didn't fully understand the flow. But here are a few findings:
- Use JSON instead of Borsh for FT standard methods. Since the goal is to be compatible with the rest of NEAR ecosystem with fungible tokens, this change has to use JSON as an input and output for methods like `ft_transfer` and `ft_transfer_call`, as well as view methods like `ft_balance_of`.
- I'm not sure if the internal `ft_transfer_call` is correctly addressing the balance and doesn't the rollback.
- It's very confusing to bundle NEAR and ETH into one FungibleToken struct. It probably worth to use 2 of them, but then have unified implementation. There is also a proposal for a multi-fungible token standard, but it's not on paper.
- I've commented in the code for the issues I found. 
- Also sorry for renaming `save_contract` to `save_ft_contract`, it's not necessary