### PR TITLE
Ensure that Cargo.lock in the repo is valid

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --verbose
+          args: --locked --verbose
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0


### PR DESCRIPTION
At the moment, running `cargo check` locally for me:

* fails with some compilation error in the dependency
* updates Cargo.lock

That is, the Cargo.lock that is committed into the repo doesn't work. To
prevent this from happening in the future, let's forbid CI from
upgrading Cargo.lock.

Previously: https://github.com/aurora-is-near/aurora-engine/pull/93