### PR TITLE
Remove unneeded nightly feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(core_intrinsics))]
 #![cfg_attr(not(feature = "std"), feature(alloc_error_handler))]
 
 #[cfg(not(feature = "std"))]
@@ -56,14 +55,14 @@ mod contract {
     #[panic_handler]
     #[no_mangle]
     pub unsafe fn on_panic(_info: &::core::panic::PanicInfo) -> ! {
-        ::core::intrinsics::abort();
+        ::core::arch::wasm32::unreachable();
     }
 
     #[cfg(target_arch = "wasm32")]
     #[alloc_error_handler]
     #[no_mangle]
     pub unsafe fn on_alloc_error(_: core::alloc::Layout) -> ! {
-        ::core::intrinsics::abort();
+        ::core::arch::wasm32::unreachable();
     }
 
     ///

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -468,9 +468,8 @@ pub fn assert_private_call() {
 }
 
 pub fn attached_deposit() -> u128 {
-    use core::intrinsics::size_of;
     unsafe {
-        let data = [0u8; size_of::<u128>()];
+        let data = [0u8; core::mem::size_of::<u128>()];
         exports::attached_deposit(data.as_ptr() as u64);
         u128::from_le_bytes(data)
     }


### PR DESCRIPTION
On wasm, intrinsic for trap unreachable is stable and exposed via
`core::arch`, no need for a nightly feature.

Previously: https://github.com/aurora-is-near/aurora-engine/pull/94
