### PR TITLE
Update to `evm_core` 0.27.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1160,6 +1160,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "environmental"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
+
+[[package]]
 name = "errno"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,10 +1254,11 @@ checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 
 [[package]]
 name = "evm"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1202e8dfa45bea73ee003c4be2f3549d60cb2e2ac5b0c1db563bd4653213efde"
+checksum = "f833b0e642bec8286b80f00ad6cc6a95e50210c77949b9cb484637e6a05ed596"
 dependencies = [
+ "environmental",
  "ethereum",
  "evm-core",
  "evm-gasometer",
@@ -1266,9 +1273,9 @@ dependencies = [
 
 [[package]]
 name = "evm-core"
-version = "0.26.1"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f235e93b84fccc1ebdffad226dc56caf833de2fb2f3395f933d95fbf66b254e"
+checksum = "908739da31125d17a69533c290a6c818b494176e59a2ce8accbf122f7d76835c"
 dependencies = [
  "funty",
  "parity-scale-codec",
@@ -1278,10 +1285,11 @@ dependencies = [
 
 [[package]]
 name = "evm-gasometer"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463412356790c5e34e8a13cd23ba06284d9afa999e82e8c64497aed2ee625375"
+checksum = "4118f952ce320c11e1b7b8a575e477d70bc86a3b92ea23e427174d979cf1da26"
 dependencies = [
+ "environmental",
  "evm-core",
  "evm-runtime",
  "primitive-types",
@@ -1289,10 +1297,11 @@ dependencies = [
 
 [[package]]
 name = "evm-runtime"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c08f510e5535cee2352adb9b93ff24dc80f8ca1bad445a9aa1292ce144b45a1"
+checksum = "952296b416c3b334b26933ad1f9cfa9203e251691586fb317e411872886ca31b"
 dependencies = [
+ "environmental",
  "evm-core",
  "primitive-types",
  "sha3 0.8.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,8 +41,8 @@ rpath = false
 blake2 = { git = "https://github.com/near/near-blake2.git", version = "0.9.1", default-features = false }
 borsh = { version = "0.8.2", default-features = false }
 bn = { package = "aurora-bn", git = "https://github.com/aurora-is-near/aurora-bn.git", default-features = false }
-evm = { version = "0.26.0", default-features = false }
-evm-core = { version = "0.26.1", default-features = false }
+evm = { version = "0.27.0", default-features = false }
+evm-core = { version = "0.27.1", default-features = false }
 libsecp256k1 = { version = "0.3.5", default-features = false }
 num = { version = "0.4.0", default-features = false, features = ["alloc"] }
 primitive-types = { version = "0.9.0", default-features = false, features = ["rlp"] }

--- a/etc/state-migration-test/Cargo.lock
+++ b/etc/state-migration-test/Cargo.lock
@@ -299,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "evm"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1202e8dfa45bea73ee003c4be2f3549d60cb2e2ac5b0c1db563bd4653213efde"
+checksum = "f833b0e642bec8286b80f00ad6cc6a95e50210c77949b9cb484637e6a05ed596"
 dependencies = [
  "ethereum",
  "evm-core",
@@ -315,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "evm-core"
-version = "0.26.1"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f235e93b84fccc1ebdffad226dc56caf833de2fb2f3395f933d95fbf66b254e"
+checksum = "908739da31125d17a69533c290a6c818b494176e59a2ce8accbf122f7d76835c"
 dependencies = [
  "funty",
  "primitive-types",
@@ -325,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "evm-gasometer"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463412356790c5e34e8a13cd23ba06284d9afa999e82e8c64497aed2ee625375"
+checksum = "4118f952ce320c11e1b7b8a575e477d70bc86a3b92ea23e427174d979cf1da26"
 dependencies = [
  "evm-core",
  "evm-runtime",
@@ -336,9 +336,9 @@ dependencies = [
 
 [[package]]
 name = "evm-runtime"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c08f510e5535cee2352adb9b93ff24dc80f8ca1bad445a9aa1292ce144b45a1"
+checksum = "952296b416c3b334b26933ad1f9cfa9203e251691586fb317e411872886ca31b"
 dependencies = [
  "evm-core",
  "primitive-types",

--- a/src/precompiles/blake2.rs
+++ b/src/precompiles/blake2.rs
@@ -81,11 +81,7 @@ impl Precompile for Blake2F {
         let finished = input[212] != 0;
 
         let output = blake2::blake2b_f(rounds, h, m, t, finished).to_vec();
-        Ok(PrecompileOutput {
-            cost,
-            output,
-            ..Default::default()
-        })
+        Ok(PrecompileOutput::without_logs(cost, output))
     }
 }
 

--- a/src/precompiles/blake2.rs
+++ b/src/precompiles/blake2.rs
@@ -199,12 +199,12 @@ mod tests {
             01",
         )
         .unwrap();
-        Blake2F::run(&input, 12, &new_context()).unwrap().1
+        Blake2F::run(&input, 12, &new_context()).unwrap().output
     }
 
     fn test_blake2f_r_12() -> Vec<u8> {
         let input = hex::decode(INPUT).unwrap();
-        Blake2F::run(&input, 12, &new_context()).unwrap().1
+        Blake2F::run(&input, 12, &new_context()).unwrap().output
     }
 
     fn test_blake2f_final_block_false() -> Vec<u8> {
@@ -222,7 +222,7 @@ mod tests {
             00",
         )
         .unwrap();
-        Blake2F::run(&input, 12, &new_context()).unwrap().1
+        Blake2F::run(&input, 12, &new_context()).unwrap().output
     }
 
     #[test]

--- a/src/precompiles/blake2.rs
+++ b/src/precompiles/blake2.rs
@@ -1,6 +1,6 @@
-use crate::precompiles::{Precompile, PrecompileResult};
+use crate::precompiles::{Precompile, PrecompileOutput, PrecompileResult};
 use crate::prelude::{mem, Borrowed, TryInto};
-use evm::{Context, ExitError, ExitSucceed};
+use evm::{Context, ExitError};
 
 /// Blake2 costs.
 mod costs {
@@ -80,8 +80,12 @@ impl Precompile for Blake2F {
         }
         let finished = input[212] != 0;
 
-        let res = blake2::blake2b_f(rounds, h, m, t, finished).to_vec();
-        Ok((ExitSucceed::Returned, res, cost))
+        let output = blake2::blake2b_f(rounds, h, m, t, finished).to_vec();
+        Ok(PrecompileOutput {
+            cost,
+            output,
+            ..Default::default()
+        })
     }
 }
 

--- a/src/precompiles/bn128.rs
+++ b/src/precompiles/bn128.rs
@@ -1,6 +1,8 @@
-use crate::precompiles::{Byzantium, HardFork, Istanbul, Precompile, PrecompileResult};
+use crate::precompiles::{
+    Byzantium, HardFork, Istanbul, Precompile, PrecompileOutput, PrecompileResult,
+};
 use crate::prelude::*;
-use evm::{Context, ExitError, ExitSucceed};
+use evm::{Context, ExitError};
 
 /// bn128 costs.
 mod costs {
@@ -112,8 +114,12 @@ impl Precompile for BN128Add<Byzantium> {
         if cost > target_gas {
             Err(ExitError::OutOfGas)
         } else {
-            let res = Self::run_inner(input, context)?;
-            Ok((ExitSucceed::Returned, res, cost))
+            let output = Self::run_inner(input, context)?;
+            Ok(PrecompileOutput {
+                cost,
+                output,
+                ..Default::default()
+            })
         }
     }
 }
@@ -133,8 +139,12 @@ impl Precompile for BN128Add<Istanbul> {
         if cost > target_gas {
             Err(ExitError::OutOfGas)
         } else {
-            let res = Self::run_inner(input, context)?;
-            Ok((ExitSucceed::Returned, res, cost))
+            let output = Self::run_inner(input, context)?;
+            Ok(PrecompileOutput {
+                cost,
+                output,
+                ..Default::default()
+            })
         }
     }
 }
@@ -180,8 +190,12 @@ impl Precompile for BN128Mul<Byzantium> {
         if cost > target_gas {
             Err(ExitError::OutOfGas)
         } else {
-            let res = Self::run_inner(input, context)?;
-            Ok((ExitSucceed::Returned, res, cost))
+            let output = Self::run_inner(input, context)?;
+            Ok(PrecompileOutput {
+                cost,
+                output,
+                ..Default::default()
+            })
         }
     }
 }
@@ -200,8 +214,12 @@ impl Precompile for BN128Mul<Istanbul> {
         if cost > target_gas {
             Err(ExitError::OutOfGas)
         } else {
-            let res = Self::run_inner(input, context)?;
-            Ok((ExitSucceed::Returned, res, cost))
+            let output = Self::run_inner(input, context)?;
+            Ok(PrecompileOutput {
+                cost,
+                output,
+                ..Default::default()
+            })
         }
     }
 }
@@ -319,8 +337,12 @@ impl Precompile for BN128Pair<Byzantium> {
         if cost > target_gas {
             Err(ExitError::OutOfGas)
         } else {
-            let res = Self::run_inner(input, context)?;
-            Ok((ExitSucceed::Returned, res, cost))
+            let output = Self::run_inner(input, context)?;
+            Ok(PrecompileOutput {
+                cost,
+                output,
+                ..Default::default()
+            })
         }
     }
 }
@@ -342,8 +364,12 @@ impl Precompile for BN128Pair<Istanbul> {
         if cost > target_gas {
             Err(ExitError::OutOfGas)
         } else {
-            let res = Self::run_inner(input, context)?;
-            Ok((ExitSucceed::Returned, res, cost))
+            let output = Self::run_inner(input, context)?;
+            Ok(PrecompileOutput {
+                cost,
+                output,
+                ..Default::default()
+            })
         }
     }
 }

--- a/src/precompiles/bn128.rs
+++ b/src/precompiles/bn128.rs
@@ -405,7 +405,7 @@ mod tests {
 
         let res = BN128Add::<Byzantium>::run(&input, 500, &new_context())
             .unwrap()
-            .1;
+            .output;
         assert_eq!(res, expected);
 
         // zero sum test
@@ -426,7 +426,7 @@ mod tests {
 
         let res = BN128Add::<Byzantium>::run(&input, 500, &new_context())
             .unwrap()
-            .1;
+            .output;
         assert_eq!(res, expected);
 
         // out of gas test
@@ -452,7 +452,7 @@ mod tests {
 
         let res = BN128Add::<Byzantium>::run(&input, 500, &new_context())
             .unwrap()
-            .1;
+            .output;
         assert_eq!(res, expected);
 
         // point not on curve fail
@@ -490,7 +490,7 @@ mod tests {
 
         let res = BN128Mul::<Byzantium>::run(&input, 40_000, &new_context())
             .unwrap()
-            .1;
+            .output;
         assert_eq!(res, expected);
 
         // out of gas test
@@ -521,7 +521,7 @@ mod tests {
 
         let res = BN128Mul::<Byzantium>::run(&input, 40_000, &new_context())
             .unwrap()
-            .1;
+            .output;
         assert_eq!(res, expected);
 
         // no input test
@@ -535,7 +535,7 @@ mod tests {
 
         let res = BN128Mul::<Byzantium>::run(&input, 40_000, &new_context())
             .unwrap()
-            .1;
+            .output;
         assert_eq!(res, expected);
 
         // point not on curve fail
@@ -578,7 +578,7 @@ mod tests {
 
         let res = BN128Pair::<Byzantium>::run(&input, 260_000, &new_context())
             .unwrap()
-            .1;
+            .output;
         assert_eq!(res, expected);
 
         // out of gas test
@@ -609,7 +609,7 @@ mod tests {
 
         let res = BN128Pair::<Byzantium>::run(&input, 260_000, &new_context())
             .unwrap()
-            .1;
+            .output;
         assert_eq!(res, expected);
 
         // point not on curve fail

--- a/src/precompiles/bn128.rs
+++ b/src/precompiles/bn128.rs
@@ -115,11 +115,7 @@ impl Precompile for BN128Add<Byzantium> {
             Err(ExitError::OutOfGas)
         } else {
             let output = Self::run_inner(input, context)?;
-            Ok(PrecompileOutput {
-                cost,
-                output,
-                ..Default::default()
-            })
+            Ok(PrecompileOutput::without_logs(cost, output))
         }
     }
 }
@@ -140,11 +136,7 @@ impl Precompile for BN128Add<Istanbul> {
             Err(ExitError::OutOfGas)
         } else {
             let output = Self::run_inner(input, context)?;
-            Ok(PrecompileOutput {
-                cost,
-                output,
-                ..Default::default()
-            })
+            Ok(PrecompileOutput::without_logs(cost, output))
         }
     }
 }
@@ -191,11 +183,7 @@ impl Precompile for BN128Mul<Byzantium> {
             Err(ExitError::OutOfGas)
         } else {
             let output = Self::run_inner(input, context)?;
-            Ok(PrecompileOutput {
-                cost,
-                output,
-                ..Default::default()
-            })
+            Ok(PrecompileOutput::without_logs(cost, output))
         }
     }
 }
@@ -215,11 +203,7 @@ impl Precompile for BN128Mul<Istanbul> {
             Err(ExitError::OutOfGas)
         } else {
             let output = Self::run_inner(input, context)?;
-            Ok(PrecompileOutput {
-                cost,
-                output,
-                ..Default::default()
-            })
+            Ok(PrecompileOutput::without_logs(cost, output))
         }
     }
 }
@@ -338,11 +322,7 @@ impl Precompile for BN128Pair<Byzantium> {
             Err(ExitError::OutOfGas)
         } else {
             let output = Self::run_inner(input, context)?;
-            Ok(PrecompileOutput {
-                cost,
-                output,
-                ..Default::default()
-            })
+            Ok(PrecompileOutput::without_logs(cost, output))
         }
     }
 }
@@ -365,11 +345,7 @@ impl Precompile for BN128Pair<Istanbul> {
             Err(ExitError::OutOfGas)
         } else {
             let output = Self::run_inner(input, context)?;
-            Ok(PrecompileOutput {
-                cost,
-                output,
-                ..Default::default()
-            })
+            Ok(PrecompileOutput::without_logs(cost, output))
         }
     }
 }

--- a/src/precompiles/hash.rs
+++ b/src/precompiles/hash.rs
@@ -50,11 +50,7 @@ impl Precompile for SHA256 {
             Err(ExitError::OutOfGas)
         } else {
             let output = sha2::Sha256::digest(input).to_vec();
-            Ok(PrecompileOutput {
-                cost,
-                output,
-                ..Default::default()
-            })
+            Ok(PrecompileOutput::without_logs(cost, output))
         }
     }
 
@@ -70,11 +66,7 @@ impl Precompile for SHA256 {
             Err(ExitError::OutOfGas)
         } else {
             let output = sdk::sha256(input).as_bytes().to_vec();
-            Ok(PrecompileOutput {
-                cost,
-                output,
-                ..Default::default()
-            })
+            Ok(PrecompileOutput::without_logs(cost, output))
         }
     }
 }
@@ -110,11 +102,7 @@ impl Precompile for RIPEMD160 {
             // the evm works with 32-byte words.
             let mut output = vec![0u8; 32];
             output[12..].copy_from_slice(&hash);
-            Ok(PrecompileOutput {
-                cost,
-                output,
-                ..Default::default()
-            })
+            Ok(PrecompileOutput::without_logs(cost, output))
         }
     }
 }

--- a/src/precompiles/identity.rs
+++ b/src/precompiles/identity.rs
@@ -66,11 +66,13 @@ mod tests {
         let input = [0u8, 1, 2, 3];
 
         let expected = input[0..2].to_vec();
-        let res = Identity::run(&input[0..2], 18, &new_context()).unwrap().1;
+        let res = Identity::run(&input[0..2], 18, &new_context())
+            .unwrap()
+            .output;
         assert_eq!(res, expected);
 
         let expected = input.to_vec();
-        let res = Identity::run(&input, 18, &new_context()).unwrap().1;
+        let res = Identity::run(&input, 18, &new_context()).unwrap().output;
         assert_eq!(res, expected);
 
         // gas fail
@@ -83,7 +85,7 @@ mod tests {
             0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
             24, 25, 26, 27, 28, 29, 30, 31, 32,
         ];
-        let res = Identity::run(&input, 21, &new_context()).unwrap().1;
+        let res = Identity::run(&input, 21, &new_context()).unwrap().output;
         assert_eq!(res, input.to_vec());
     }
 }

--- a/src/precompiles/identity.rs
+++ b/src/precompiles/identity.rs
@@ -39,11 +39,7 @@ impl Precompile for Identity {
         if cost > target_gas {
             Err(ExitError::OutOfGas)
         } else {
-            Ok(PrecompileOutput {
-                output: input.to_vec(),
-                cost,
-                ..Default::default()
-            })
+            Ok(PrecompileOutput::without_logs(cost, input.to_vec()))
         }
     }
 }

--- a/src/precompiles/identity.rs
+++ b/src/precompiles/identity.rs
@@ -1,5 +1,5 @@
-use crate::precompiles::{Precompile, PrecompileResult};
-use evm::{Context, ExitError, ExitSucceed};
+use crate::precompiles::{Precompile, PrecompileOutput, PrecompileResult};
+use evm::{Context, ExitError};
 
 /// Identity precompile costs.
 mod costs {
@@ -39,7 +39,11 @@ impl Precompile for Identity {
         if cost > target_gas {
             Err(ExitError::OutOfGas)
         } else {
-            Ok((ExitSucceed::Returned, input.to_vec(), cost))
+            Ok(PrecompileOutput {
+                output: input.to_vec(),
+                cost,
+                ..Default::default()
+            })
         }
     }
 }

--- a/src/precompiles/mod.rs
+++ b/src/precompiles/mod.rs
@@ -129,7 +129,7 @@ pub fn homestead_precompiles(
         ExitToEthereum::ADDRESS => Some(ExitToEthereum::run(input, target_gas, context)),
         _ => None,
     };
-    output.map(|res| res.map(|o| o.into()))
+    output.map(|res| res.map(Into::into))
 }
 
 /// Matches the address given to Byzantium precompiles.
@@ -160,7 +160,7 @@ pub fn byzantium_precompiles(
         ExitToEthereum::ADDRESS => Some(ExitToEthereum::run(input, target_gas, context)),
         _ => None,
     };
-    output.map(|res| res.map(|o| o.into()))
+    output.map(|res| res.map(Into::into))
 }
 
 /// Matches the address given to Istanbul precompiles.
@@ -192,7 +192,7 @@ pub fn istanbul_precompiles(
         ExitToEthereum::ADDRESS => Some(ExitToEthereum::run(input, target_gas, context)),
         _ => None,
     };
-    output.map(|res| res.map(|o| o.into()))
+    output.map(|res| res.map(Into::into))
 }
 
 /// Matches the address given to Berlin precompiles.
@@ -224,7 +224,7 @@ pub fn berlin_precompiles(
         ExitToEthereum::ADDRESS => Some(ExitToEthereum::run(input, target_gas, context)),
         _ => None,
     };
-    output.map(|res| res.map(|o| o.into()))
+    output.map(|res| res.map(Into::into))
 }
 
 /// const fn for making an address by concatenating the bytes from two given numbers,

--- a/src/precompiles/mod.rs
+++ b/src/precompiles/mod.rs
@@ -27,6 +27,16 @@ pub struct PrecompileOutput {
     pub logs: Vec<Log>,
 }
 
+impl PrecompileOutput {
+    pub fn without_logs(cost: u64, output: Vec<u8>) -> Self {
+        Self {
+            cost,
+            output,
+            logs: Vec::new(),
+        }
+    }
+}
+
 impl Default for PrecompileOutput {
     fn default() -> Self {
         PrecompileOutput {

--- a/src/precompiles/modexp.rs
+++ b/src/precompiles/modexp.rs
@@ -176,7 +176,7 @@ mod tests {
         .unwrap();
         let modexp_res = ModExp::<Byzantium>::run(&test_input1, 12_288, &new_context())
             .unwrap()
-            .1;
+            .output;
         let res = U256::from_big_endian(&modexp_res);
 
         assert_eq!(res, U256::from(1));
@@ -191,7 +191,7 @@ mod tests {
         .unwrap();
         let modexp_res = ModExp::<Byzantium>::run(&test_input2, 12_288, &new_context())
             .unwrap()
-            .1;
+            .output;
         let res = U256::from_big_endian(&modexp_res);
 
         assert_eq!(res, U256::from(0));
@@ -222,7 +222,7 @@ mod tests {
         );
         let modexp_res = ModExp::<Byzantium>::run(&test_input4, 12_288, &new_context())
             .unwrap()
-            .1;
+            .output;
         let res = U256::from_big_endian(&modexp_res);
         assert_eq!(res, expected);
 
@@ -241,7 +241,7 @@ mod tests {
         );
         let modexp_res = ModExp::<Byzantium>::run(&test_input5, 12_288, &new_context())
             .unwrap()
-            .1;
+            .output;
         let res = U256::from_big_endian(&modexp_res);
         assert_eq!(res, expected);
     }

--- a/src/precompiles/modexp.rs
+++ b/src/precompiles/modexp.rs
@@ -1,6 +1,8 @@
-use crate::precompiles::{Berlin, Byzantium, HardFork, Precompile, PrecompileResult};
+use crate::precompiles::{
+    Berlin, Byzantium, HardFork, Precompile, PrecompileOutput, PrecompileResult,
+};
 use crate::prelude::{PhantomData, Vec, U256};
-use evm::{Context, ExitError, ExitSucceed};
+use evm::{Context, ExitError};
 use num::BigUint;
 
 pub(super) const ADDRESS: [u8; 20] = super::make_address(0, 5);
@@ -115,7 +117,7 @@ impl Precompile for ModExp<Byzantium> {
         let exponent = BigUint::from_bytes_be(&exp_bytes);
         let modulus = BigUint::from_bytes_be(&mod_bytes);
 
-        let result = {
+        let output = {
             let computed_result = base.modpow(&exponent, &modulus).to_bytes_be();
             // The result must be the same length as the input modulus.
             // To ensure this we pad on the left with zeros.
@@ -130,7 +132,11 @@ impl Precompile for ModExp<Byzantium> {
             }
         };
 
-        Ok((ExitSucceed::Returned, result, cost))
+        Ok(PrecompileOutput {
+            cost,
+            output,
+            ..Default::default()
+        })
     }
 }
 

--- a/src/precompiles/modexp.rs
+++ b/src/precompiles/modexp.rs
@@ -132,11 +132,7 @@ impl Precompile for ModExp<Byzantium> {
             }
         };
 
-        Ok(PrecompileOutput {
-            cost,
-            output,
-            ..Default::default()
-        })
+        Ok(PrecompileOutput::without_logs(cost, output))
     }
 }
 

--- a/src/precompiles/native.rs
+++ b/src/precompiles/native.rs
@@ -1,6 +1,7 @@
 use evm::{Context, ExitError, ExitSucceed};
 
 use super::{Precompile, PrecompileResult};
+use crate::precompiles::PrecompileOutput;
 use crate::prelude::Vec;
 #[cfg(feature = "exit-precompiles")]
 use crate::{
@@ -128,7 +129,7 @@ impl Precompile for ExitToNear {
 
         crate::sdk::promise_return(promise0);
 
-        Ok((ExitSucceed::Returned, Vec::new(), 0))
+        Ok(PrecompileOutput::default())
     }
 }
 
@@ -229,7 +230,7 @@ impl Precompile for ExitToEthereum {
 
         crate::sdk::promise_return(promise0);
 
-        Ok((ExitSucceed::Returned, Vec::new(), 0))
+        Ok(PrecompileOutput::default())
     }
 }
 

--- a/src/precompiles/secp256k1.rs
+++ b/src/precompiles/secp256k1.rs
@@ -138,7 +138,9 @@ mod tests {
             hex::decode("000000000000000000000000c08b5542d177ac6686946920409741463a15dddb")
                 .unwrap();
 
-        let res = ECRecover::run(&input, 3_000, &new_context()).unwrap().1;
+        let res = ECRecover::run(&input, 3_000, &new_context())
+            .unwrap()
+            .output;
         assert_eq!(res, expected);
 
         // out of gas
@@ -153,7 +155,9 @@ mod tests {
             hex::decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
                 .unwrap();
 
-        let res = ECRecover::run(&input, 3_000, &new_context()).unwrap().1;
+        let res = ECRecover::run(&input, 3_000, &new_context())
+            .unwrap()
+            .output;
         assert_eq!(res, expected);
 
         let input = hex::decode("47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad000000000000000000000000000000000000000000000000000000000000001b000000000000000000000000000000000000000000000000000000000000001b0000000000000000000000000000000000000000000000000000000000000000").unwrap();
@@ -161,7 +165,9 @@ mod tests {
             hex::decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
                 .unwrap();
 
-        let res = ECRecover::run(&input, 3_000, &new_context()).unwrap().1;
+        let res = ECRecover::run(&input, 3_000, &new_context())
+            .unwrap()
+            .output;
         assert_eq!(res, expected);
 
         let input = hex::decode("47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad000000000000000000000000000000000000000000000000000000000000001b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001b").unwrap();
@@ -169,7 +175,9 @@ mod tests {
             hex::decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
                 .unwrap();
 
-        let res = ECRecover::run(&input, 3_000, &new_context()).unwrap().1;
+        let res = ECRecover::run(&input, 3_000, &new_context())
+            .unwrap()
+            .output;
         assert_eq!(res, expected);
 
         let input = hex::decode("47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad000000000000000000000000000000000000000000000000000000000000001bffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff000000000000000000000000000000000000000000000000000000000000001b").unwrap();
@@ -177,14 +185,16 @@ mod tests {
             hex::decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
                 .unwrap();
 
-        let res = ECRecover::run(&input, 3_000, &new_context()).unwrap().1;
+        let res = ECRecover::run(&input, 3_000, &new_context())
+            .unwrap()
+            .output;
         assert_eq!(res, expected);
 
         // Why is this test returning an address???
         // let input = hex::decode("47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad000000000000000000000000000000000000000000000000000000000000001b000000000000000000000000000000000000000000000000000000000000001bffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").unwrap();
         // let expected = hex::decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").unwrap();
         //
-        // let res = ecrecover_raw(&input, Some(500)).unwrap().1;
+        // let res = ecrecover_raw(&input, Some(500)).unwrap().output;
         // assert_eq!(res, expected);
     }
 }

--- a/src/precompiles/secp256k1.rs
+++ b/src/precompiles/secp256k1.rs
@@ -72,11 +72,7 @@ impl Precompile for ECRecover {
         let v_bit = match v[31] {
             27 | 28 if v[..31] == [0; 31] => v[31] - 27,
             _ => {
-                return Ok(PrecompileOutput {
-                    cost: 0,
-                    output: vec![255u8; 32],
-                    ..Default::default()
-                });
+                return Ok(PrecompileOutput::without_logs(0, vec![255u8; 32]));
             }
         };
         signature[64] = v_bit; // v
@@ -93,11 +89,7 @@ impl Precompile for ECRecover {
             }
         };
 
-        Ok(PrecompileOutput {
-            cost,
-            output,
-            ..Default::default()
-        })
+        Ok(PrecompileOutput::without_logs(cost, output))
     }
 }
 

--- a/src/precompiles/secp256k1.rs
+++ b/src/precompiles/secp256k1.rs
@@ -1,7 +1,7 @@
-use crate::precompiles::{Precompile, PrecompileResult};
+use crate::precompiles::{Precompile, PrecompileOutput, PrecompileResult};
 use crate::prelude::*;
 use ethabi::Address;
-use evm::{Context, ExitError, ExitSucceed};
+use evm::{Context, ExitError};
 
 mod costs {
     pub(super) const ECRECOVER_BASE: u64 = 3_000;
@@ -72,7 +72,11 @@ impl Precompile for ECRecover {
         let v_bit = match v[31] {
             27 | 28 if v[..31] == [0; 31] => v[31] - 27,
             _ => {
-                return Ok((ExitSucceed::Returned, vec![255u8; 32], 0)); // Not confident on this return.
+                return Ok(PrecompileOutput {
+                    cost: 0,
+                    output: vec![255u8; 32],
+                    ..Default::default()
+                });
             }
         };
         signature[64] = v_bit; // v
@@ -89,7 +93,11 @@ impl Precompile for ECRecover {
             }
         };
 
-        Ok((ExitSucceed::Returned, output.to_vec(), cost))
+        Ok(PrecompileOutput {
+            cost,
+            output,
+            ..Default::default()
+        })
     }
 }
 


### PR DESCRIPTION
This updates the Aurora engine to the latest `evm-core`.

Do note that the merge to `master` is intentional given the nature of this update.

This also does include the logs which @mfornet had added to upstream so a further PR should be created to utilise logs.