### PR TITLE
Fix: nightly clippy checks

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -45,7 +45,7 @@ impl Wei {
         amount.checked_mul(Self::ETH_TO_WEI).map(Self)
     }
 
-    pub fn to_bytes(&self) -> [u8; 32] {
+    pub fn to_bytes(self) -> [u8; 32] {
         u256_to_arr(&self.0)
     }
 


### PR DESCRIPTION
Running `cargo +nightly clippy --no-default-features --features=contract,log -- -D warnings` gives

```
error: methods with the following characteristics: (`to_*` and `self` type is `Copy`) usually take `self` by value
  --> src/types.rs:48:21
   |
48 |     pub fn to_bytes(&self) -> [u8; 32] {
   |                     ^^^^^
   |
   = note: `-D clippy::wrong-self-convention` implied by `-D warnings`
   = help: consider choosing a less ambiguous name
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention

error: aborting due to previous error

error: could not compile `aurora-engine`
```

This PR fixes the issue. The project should now pass `clippy` on latest nightly! 🎉 