### PR TITLE
EthConnector: use strings in JSON for amounts.

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -56,7 +56,7 @@ impl JsonValue {
     pub fn u128_string(&self, key: &str) -> Result<u128, ()> {
         match self {
             JsonValue::Object(o) => match o.get(key).ok_or(())? {
-                JsonValue::String(s) => u128::from_str_radix(s, 10).map_err(|_| ()),
+                JsonValue::String(s) => s.parse::<u128>().map_err(|_| ()),
                 _ => Err(()),
             },
             _ => Err(()),

--- a/src/json.rs
+++ b/src/json.rs
@@ -53,6 +53,17 @@ impl JsonValue {
     }
 
     #[allow(dead_code)]
+    pub fn u128_string(&self, key: &str) -> Result<u128, ()> {
+        match self {
+            JsonValue::Object(o) => match o.get(key).ok_or(())? {
+                JsonValue::String(s) => u128::from_str_radix(s, 10).map_err(|_| ()),
+                _ => Err(()),
+            },
+            _ => Err(()),
+        }
+    }
+
+    #[allow(dead_code)]
     pub fn bool(&self, key: &str) -> Result<bool, ()> {
         match self {
             JsonValue::Object(o) => match o.get(key).ok_or(())? {

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -261,7 +261,9 @@ impl From<json::JsonValue> for TransferCallCallArgs {
             receiver_id: v
                 .string("receiver_id")
                 .expect_utf8(ERR_FAILED_PARSE.as_bytes()),
-            amount: v.u128("amount").expect_utf8(ERR_FAILED_PARSE.as_bytes()),
+            amount: v
+                .u128_string("amount")
+                .expect_utf8(ERR_FAILED_PARSE.as_bytes()),
             memo: v.string("memo").ok(),
             msg: v.string("msg").expect_utf8(ERR_FAILED_PARSE.as_bytes()),
         }
@@ -315,7 +317,7 @@ pub struct StorageWithdrawCallArgs {
 impl From<json::JsonValue> for StorageWithdrawCallArgs {
     fn from(v: json::JsonValue) -> Self {
         Self {
-            amount: v.u128("amount").ok(),
+            amount: v.u128_string("amount").ok(),
         }
     }
 }
@@ -336,7 +338,9 @@ impl From<json::JsonValue> for TransferCallArgs {
             receiver_id: v
                 .string("receiver_id")
                 .expect_utf8(ERR_FAILED_PARSE.as_bytes()),
-            amount: v.u128("amount").expect_utf8(ERR_FAILED_PARSE.as_bytes()),
+            amount: v
+                .u128_string("amount")
+                .expect_utf8(ERR_FAILED_PARSE.as_bytes()),
             memo: v.string("memo").ok(),
         }
     }
@@ -421,7 +425,9 @@ impl From<json::JsonValue> for ResolveTransferCallArgs {
             receiver_id: v
                 .string("receiver_id")
                 .expect_utf8(ERR_FAILED_PARSE.as_bytes()),
-            amount: v.u128("amount").expect_utf8(ERR_FAILED_PARSE.as_bytes()),
+            amount: v
+                .u128_string("amount")
+                .expect_utf8(ERR_FAILED_PARSE.as_bytes()),
         }
     }
 }

--- a/tests/test_connector.rs
+++ b/tests/test_connector.rs
@@ -345,7 +345,7 @@ fn test_ft_transfer() {
         "ft_transfer",
         json!({
             "receiver_id": DEPOSITED_RECIPIENT,
-            "amount": transfer_amount,
+            "amount": transfer_amount.to_string(),
             "memo": "transfer memo"
         })
         .to_string()
@@ -408,7 +408,7 @@ fn test_ft_transfer_call_eth() {
         "ft_transfer_call",
         json!({
             "receiver_id": CONTRACT_ACC,
-            "amount": transfer_amount as u64,
+            "amount": transfer_amount.to_string(),
             "msg": message,
         })
         .to_string()
@@ -501,7 +501,7 @@ fn test_ft_transfer_call_without_relayer() {
         "ft_transfer_call",
         json!({
             "receiver_id": CONTRACT_ACC,
-            "amount": transfer_amount as u64,
+            "amount": transfer_amount.to_string(),
             "msg": message,
         })
         .to_string()
@@ -885,7 +885,7 @@ fn test_get_accounts_counter_and_transfer() {
         "ft_transfer",
         json!({
             "receiver_id": DEPOSITED_RECIPIENT,
-            "amount": transfer_amount,
+            "amount": transfer_amount.to_string(),
             "memo": "transfer memo"
         })
         .to_string()


### PR DESCRIPTION
The integer values in JSON are limited by `u64`. So we need to use strings instead and then convert them to the needed integer type.