### PR TITLE
Add JSON custom error types. Refactoring.

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -1,7 +1,5 @@
 use super::prelude::*;
-use crate::sdk;
 
-use crate::types::ERR_FAILED_PARSE;
 use alloc::collections::BTreeMap;
 use core::convert::From;
 use rjson::{Array, Null, Object, Value};
@@ -15,73 +13,99 @@ pub enum JsonValue {
     Object(BTreeMap<String, JsonValue>),
 }
 
+pub enum JsonError {
+    NotJsonType,
+    MissingValue,
+    InvalidU8,
+    InvalidU64,
+    InvalidU128,
+    InvalidBool,
+    InvalidString,
+    InvalidArray,
+}
+
 pub struct JsonArray(Vec<JsonValue>);
 pub struct JsonObject(BTreeMap<String, JsonValue>);
 
 impl JsonValue {
     #[allow(dead_code)]
-    pub fn string(&self, key: &str) -> Result<String, ()> {
+    pub fn string(&self, key: &str) -> Result<String, JsonError> {
         match self {
-            JsonValue::Object(o) => match o.get(key).ok_or(())? {
+            JsonValue::Object(o) => match o.get(key).ok_or(JsonError::MissingValue)? {
                 JsonValue::String(s) => Ok(s.into()),
-                _ => Err(()),
+                _ => Err(JsonError::InvalidString),
             },
-            _ => Err(()),
+            _ => Err(JsonError::NotJsonType),
         }
     }
 
     #[allow(dead_code)]
-    pub fn u64(&self, key: &str) -> Result<u64, ()> {
+    pub fn u64(&self, key: &str) -> Result<u64, JsonError> {
         match self {
-            JsonValue::Object(o) => match o.get(key).ok_or(())? {
+            JsonValue::Object(o) => match o.get(key).ok_or(JsonError::MissingValue)? {
                 JsonValue::Number(n) => Ok(*n as u64),
-                _ => Err(()),
+                _ => Err(JsonError::InvalidU64),
             },
-            _ => Err(()),
+            _ => Err(JsonError::NotJsonType),
         }
     }
 
     #[allow(dead_code)]
-    pub fn u128(&self, key: &str) -> Result<u128, ()> {
+    pub fn u128(&self, key: &str) -> Result<u128, JsonError> {
         match self {
-            JsonValue::Object(o) => match o.get(key).ok_or(())? {
+            JsonValue::Object(o) => match o.get(key).ok_or(JsonError::MissingValue)? {
                 JsonValue::Number(n) => Ok(*n as u128),
-                _ => Err(()),
+                _ => Err(JsonError::InvalidU128),
             },
-            _ => Err(()),
+            _ => Err(JsonError::NotJsonType),
         }
     }
 
     #[allow(dead_code)]
-    pub fn bool(&self, key: &str) -> Result<bool, ()> {
+    pub fn bool(&self, key: &str) -> Result<bool, JsonError> {
         match self {
-            JsonValue::Object(o) => match o.get(key).ok_or(())? {
+            JsonValue::Object(o) => match o.get(key).ok_or(JsonError::MissingValue)? {
                 JsonValue::Bool(n) => Ok(*n),
-                _ => Err(()),
+                _ => Err(JsonError::InvalidBool),
             },
-            _ => Err(()),
+            _ => Err(JsonError::NotJsonType),
         }
     }
 
     #[allow(dead_code)]
-    pub fn parse_u8(v: &JsonValue) -> u8 {
+    pub fn parse_u8(v: &JsonValue) -> Result<u8, JsonError> {
         match v {
-            JsonValue::Number(n) => *n as u8,
-            _ => sdk::panic_utf8(ERR_FAILED_PARSE.as_bytes()),
+            JsonValue::Number(n) => Ok(*n as u8),
+            _ => Err(JsonError::InvalidU8),
         }
     }
 
     #[allow(dead_code)]
-    pub fn array<T, F>(&self, key: &str, call: F) -> Result<Vec<T>, ()>
+    pub fn array<T, F>(&self, key: &str, call: F) -> Result<Vec<T>, JsonError>
     where
         F: FnMut(&JsonValue) -> T,
     {
         match self {
-            JsonValue::Object(o) => match o.get(key).ok_or(())? {
+            JsonValue::Object(o) => match o.get(key).ok_or(JsonError::MissingValue)? {
                 JsonValue::Array(arr) => Ok(arr.iter().map(call).collect()),
-                _ => Err(()),
+                _ => Err(JsonError::InvalidArray),
             },
-            _ => Err(()),
+            _ => Err(JsonError::NotJsonType),
+        }
+    }
+}
+
+impl AsRef<[u8]> for JsonError {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            Self::NotJsonType => b"ERR_NOT_A_JSON_TYPE",
+            Self::MissingValue => b"ERR_JSON_MISSING_VALUE",
+            Self::InvalidU8 => b"ERR_FAILED_PARSE_U8",
+            Self::InvalidU64 => b"ERR_FAILED_PARSE_U64",
+            Self::InvalidU128 => b"ERR_FAILED_PARSE_U128",
+            Self::InvalidBool => b"ERR_FAILED_PARSE_BOOL",
+            Self::InvalidString => b"ERR_FAILED_PARSE_STRING",
+            Self::InvalidArray => b"ERR_FAILED_PARSE_ARRAY",
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,9 @@ mod contract {
     use crate::prelude::{Address, H256, U256};
     use crate::sdk;
     use crate::storage::{bytes_to_key, KeyPrefix};
-    use crate::types::{near_account_to_evm_address, u256_to_arr, ERR_FAILED_PARSE};
+    use crate::types::{
+        near_account_to_evm_address, u256_to_arr, SdkExpect, SdkUnwrap, ERR_FAILED_PARSE,
+    };
 
     const CODE_KEY: &[u8; 4] = b"CODE";
     const CODE_STAGE_KEY: &[u8; 10] = b"CODE_STAGE";
@@ -512,50 +514,6 @@ mod contract {
 
     fn predecessor_address() -> Address {
         near_account_to_evm_address(&sdk::predecessor_account_id())
-    }
-
-    trait SdkExpect<T> {
-        fn sdk_expect(self, msg: &str) -> T;
-    }
-
-    impl<T> SdkExpect<T> for Option<T> {
-        fn sdk_expect(self, msg: &str) -> T {
-            match self {
-                Some(t) => t,
-                None => sdk::panic_utf8(msg.as_ref()),
-            }
-        }
-    }
-
-    impl<T, E> SdkExpect<T> for Result<T, E> {
-        fn sdk_expect(self, msg: &str) -> T {
-            match self {
-                Ok(t) => t,
-                Err(_) => sdk::panic_utf8(msg.as_ref()),
-            }
-        }
-    }
-
-    trait SdkUnwrap<T> {
-        fn sdk_unwrap(self) -> T;
-    }
-
-    impl<T> SdkUnwrap<T> for Option<T> {
-        fn sdk_unwrap(self) -> T {
-            match self {
-                Some(t) => t,
-                None => sdk::panic_utf8("ERR_UNWRAP".as_bytes()),
-            }
-        }
-    }
-
-    impl<T, E: AsRef<[u8]>> SdkUnwrap<T> for Result<T, E> {
-        fn sdk_unwrap(self) -> T {
-            match self {
-                Ok(t) => t,
-                Err(e) => sdk::panic_utf8(e.as_ref()),
-            }
-        }
     }
 
     trait SdkProcess<T> {

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -11,11 +11,9 @@ use crate::prelude::{String, Vec};
 use crate::prover::Proof;
 #[cfg(feature = "engine")]
 use crate::sdk;
-#[cfg(feature = "engine")]
-use crate::types::Balance;
 use crate::types::{AccountId, RawAddress, RawH256, RawU256};
 #[cfg(feature = "engine")]
-use crate::types::{EthAddress, ERR_FAILED_PARSE};
+use crate::types::{Balance, EthAddress, SdkUnwrap};
 use evm::backend::Log;
 
 /// Borsh-encoded parameters for the `new` function.
@@ -258,12 +256,10 @@ pub struct TransferCallCallArgs {
 impl From<json::JsonValue> for TransferCallCallArgs {
     fn from(v: json::JsonValue) -> Self {
         Self {
-            receiver_id: v
-                .string("receiver_id")
-                .expect_utf8(ERR_FAILED_PARSE.as_bytes()),
-            amount: v.u128("amount").expect_utf8(ERR_FAILED_PARSE.as_bytes()),
+            receiver_id: v.string("receiver_id").sdk_unwrap(),
+            amount: v.u128("amount").sdk_unwrap(),
             memo: v.string("memo").ok(),
-            msg: v.string("msg").expect_utf8(ERR_FAILED_PARSE.as_bytes()),
+            msg: v.string("msg").sdk_unwrap(),
         }
     }
 }
@@ -279,9 +275,7 @@ pub struct StorageBalanceOfCallArgs {
 impl From<json::JsonValue> for StorageBalanceOfCallArgs {
     fn from(v: json::JsonValue) -> Self {
         Self {
-            account_id: v
-                .string("account_id")
-                .expect_utf8(ERR_FAILED_PARSE.as_bytes()),
+            account_id: v.string("account_id").sdk_unwrap(),
         }
     }
 }
@@ -333,10 +327,8 @@ pub struct TransferCallArgs {
 impl From<json::JsonValue> for TransferCallArgs {
     fn from(v: json::JsonValue) -> Self {
         Self {
-            receiver_id: v
-                .string("receiver_id")
-                .expect_utf8(ERR_FAILED_PARSE.as_bytes()),
-            amount: v.u128("amount").expect_utf8(ERR_FAILED_PARSE.as_bytes()),
+            receiver_id: v.string("receiver_id").sdk_unwrap(),
+            amount: v.u128("amount").sdk_unwrap(),
             memo: v.string("memo").ok(),
         }
     }
@@ -367,9 +359,7 @@ pub struct BalanceOfEthCallArgs {
 impl From<json::JsonValue> for BalanceOfCallArgs {
     fn from(v: json::JsonValue) -> Self {
         Self {
-            account_id: v
-                .string("account_id")
-                .expect_utf8(ERR_FAILED_PARSE.as_bytes()),
+            account_id: v.string("account_id").sdk_unwrap(),
         }
     }
 }
@@ -415,13 +405,9 @@ impl<T, E> ExpectUtf8<T> for core::result::Result<T, E> {
 impl From<json::JsonValue> for ResolveTransferCallArgs {
     fn from(v: json::JsonValue) -> Self {
         Self {
-            sender_id: v
-                .string("sender_id")
-                .expect_utf8(ERR_FAILED_PARSE.as_bytes()),
-            receiver_id: v
-                .string("receiver_id")
-                .expect_utf8(ERR_FAILED_PARSE.as_bytes()),
-            amount: v.u128("amount").expect_utf8(ERR_FAILED_PARSE.as_bytes()),
+            sender_id: v.string("sender_id").sdk_unwrap(),
+            receiver_id: v.string("receiver_id").sdk_unwrap(),
+            amount: v.u128("amount").sdk_unwrap(),
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,7 +6,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 #[cfg(not(feature = "contract"))]
 use sha3::{Digest, Keccak256};
 
-#[cfg(feature = "contract")]
+#[cfg(feature = "engine")]
 use crate::sdk;
 
 pub type AccountId = String;
@@ -182,6 +182,56 @@ impl<T, E> ExpectUtf8<T> for core::result::Result<T, E> {
         match self {
             Ok(t) => t,
             Err(_) => sdk::panic_utf8(message),
+        }
+    }
+}
+
+#[cfg(feature = "engine")]
+pub trait SdkExpect<T> {
+    fn sdk_expect(self, msg: &str) -> T;
+}
+
+#[cfg(feature = "engine")]
+impl<T> SdkExpect<T> for Option<T> {
+    fn sdk_expect(self, msg: &str) -> T {
+        match self {
+            Some(t) => t,
+            None => sdk::panic_utf8(msg.as_ref()),
+        }
+    }
+}
+
+#[cfg(feature = "engine")]
+impl<T, E> SdkExpect<T> for core::result::Result<T, E> {
+    fn sdk_expect(self, msg: &str) -> T {
+        match self {
+            Ok(t) => t,
+            Err(_) => sdk::panic_utf8(msg.as_ref()),
+        }
+    }
+}
+
+#[cfg(feature = "engine")]
+pub trait SdkUnwrap<T> {
+    fn sdk_unwrap(self) -> T;
+}
+
+#[cfg(feature = "engine")]
+impl<T> SdkUnwrap<T> for Option<T> {
+    fn sdk_unwrap(self) -> T {
+        match self {
+            Some(t) => t,
+            None => sdk::panic_utf8("ERR_UNWRAP".as_bytes()),
+        }
+    }
+}
+
+#[cfg(feature = "engine")]
+impl<T, E: AsRef<[u8]>> SdkUnwrap<T> for core::result::Result<T, E> {
+    fn sdk_unwrap(self) -> T {
+        match self {
+            Ok(t) => t,
+            Err(e) => sdk::panic_utf8(e.as_ref()),
         }
     }
 }


### PR DESCRIPTION
* Add `JsonError` for `json` module.
* Use `JsonError` instead `()` for errors in `JsonValue`.
* Don't panic in `json` module on parsing.
* Move `SdkUnwrap`, `SdkExpect` traits from `lib.rs` to `types.rs`.
* Unwrap the error when parsing JSON for parameter args instead of failing with generic `ERR_FAILED_PARSE`.