### PR TITLE
EthConnector: don't burn NEP-141 on deposit.

### DIFF
--- a/src/connector.rs
+++ b/src/connector.rs
@@ -388,6 +388,7 @@ impl EthConnectorContract {
     }
 
     /// Burn NEAR tokens
+    #[allow(dead_code)]
     fn burn_near(&mut self, owner_id: AccountId, amount: Balance) {
         #[cfg(feature = "log")]
         sdk::log(&format!("Burn NEAR {} tokens for: {}", amount, owner_id));
@@ -593,7 +594,6 @@ impl EthConnectorContract {
         // Special case when predecessor_account_id is current_account_id
         if current_account_id == predecessor_account_id {
             let fee = message_data.fee.as_u128();
-            self.burn_near(current_account_id, args.amount);
             // Mint fee to relayer
             let relayer = engine.get_relayer(&message_data.relayer.as_bytes());
             if fee > 0 && relayer.is_some() {

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -387,14 +387,6 @@ impl EthConnectorContract {
         self.ft.internal_deposit_eth(owner_id, amount);
     }
 
-    /// Burn NEAR tokens
-    #[allow(dead_code)]
-    fn burn_near(&mut self, owner_id: AccountId, amount: Balance) {
-        #[cfg(feature = "log")]
-        sdk::log(&format!("Burn NEAR {} tokens for: {}", amount, owner_id));
-        self.ft.internal_withdraw(&owner_id, amount);
-    }
-
     /// Burn ETH tokens
     fn burn_eth(&mut self, address: EthAddress, amount: Balance) {
         #[cfg(feature = "log")]

--- a/tests/test_connector.rs
+++ b/tests/test_connector.rs
@@ -316,13 +316,13 @@ fn test_eth_deposit_balance_total_supply() {
     assert_eq!(balance, DEPOSITED_EVM_FEE);
 
     let balance = total_supply(&master_account, CONTRACT_ACC);
-    assert_eq!(balance, DEPOSITED_EVM_AMOUNT);
+    assert_eq!(balance, DEPOSITED_EVM_AMOUNT * 2);
 
     let balance = total_supply_eth(&master_account, CONTRACT_ACC);
     assert_eq!(balance, DEPOSITED_EVM_AMOUNT);
 
     let balance = total_supply_near(&master_account, CONTRACT_ACC);
-    assert_eq!(balance, 0);
+    assert_eq!(balance, DEPOSITED_EVM_AMOUNT);
 }
 
 #[test]
@@ -457,7 +457,7 @@ fn test_ft_transfer_call_eth() {
     assert_eq!(balance, DEPOSITED_AMOUNT - DEPOSITED_FEE);
 
     let balance = get_near_balance(&master_account, CONTRACT_ACC, CONTRACT_ACC);
-    assert_eq!(balance, DEPOSITED_FEE - transfer_amount);
+    assert_eq!(balance, DEPOSITED_FEE);
 
     let balance = get_eth_balance(
         &master_account,
@@ -474,10 +474,10 @@ fn test_ft_transfer_call_eth() {
     assert_eq!(balance, fee);
 
     let balance = total_supply(&master_account, CONTRACT_ACC);
-    assert_eq!(balance, DEPOSITED_AMOUNT);
+    assert_eq!(balance, DEPOSITED_AMOUNT + transfer_amount);
 
     let balance = total_supply_near(&master_account, CONTRACT_ACC);
-    assert_eq!(balance, DEPOSITED_AMOUNT - transfer_amount);
+    assert_eq!(balance, DEPOSITED_AMOUNT);
 
     let balance = total_supply_eth(&master_account, CONTRACT_ACC);
     assert_eq!(balance, transfer_amount);
@@ -558,7 +558,7 @@ fn test_ft_transfer_call_without_relayer() {
     assert_eq!(balance, DEPOSITED_AMOUNT - DEPOSITED_FEE);
 
     let balance = get_near_balance(&master_account, CONTRACT_ACC, CONTRACT_ACC);
-    assert_eq!(balance, DEPOSITED_FEE - transfer_amount);
+    assert_eq!(balance, DEPOSITED_FEE);
 
     let balance = get_eth_balance(
         &master_account,
@@ -575,10 +575,10 @@ fn test_ft_transfer_call_without_relayer() {
     assert_eq!(balance, 0);
 
     let balance = total_supply(&master_account, CONTRACT_ACC);
-    assert_eq!(balance, DEPOSITED_AMOUNT);
+    assert_eq!(balance, DEPOSITED_AMOUNT + transfer_amount);
 
     let balance = total_supply_near(&master_account, CONTRACT_ACC);
-    assert_eq!(balance, DEPOSITED_AMOUNT - transfer_amount);
+    assert_eq!(balance, DEPOSITED_AMOUNT);
 
     let balance = total_supply_eth(&master_account, CONTRACT_ACC);
     assert_eq!(balance, transfer_amount);
@@ -1042,13 +1042,13 @@ fn test_deposit_evm_with_zero_fee() {
     assert_eq!(balance, 0);
 
     let balance = total_supply(&master_account, CONTRACT_ACC);
-    assert_eq!(balance, deposited_amount);
+    assert_eq!(balance, deposited_amount * 2);
 
     let balance = total_supply_eth(&master_account, CONTRACT_ACC);
     assert_eq!(balance, deposited_amount);
 
     let balance = total_supply_near(&master_account, CONTRACT_ACC);
-    assert_eq!(balance, 0);
+    assert_eq!(balance, deposited_amount);
 }
 
 #[test]


### PR DESCRIPTION
We used to have the following workflow for depositing ETH to Aurora:
* Deposit nETH (NEP-141) tokens to Aurora account
* Burn Aurora's nETH tokens
* Mint ETH to Ethereum address on Aurora.

When we call `exitToNear` precompile for ETH, we expect to burn ETH on Aurora and make `ft_transfer` of nETH tokens from Aurora to the recipient on NEAR. The problem using the previously mentioned deposit workflow is that we don't have nETH tokens available on Aurora account when we try to perform this exit.

Possible solutions:
## 1) Don't burn nETH tokens on Aurora account during the deposit
This solution is currently implemented in the PR. 

Pros: 
* We have needed liquidity and keep calling just a regular  `ft_transfer` when calling `exitToNear` precompile for ETH.
* We have consistency with the approach that we use for ERC20 connector for Aurora (User transfers some NEP-141 tokens to Aurora account and we mint appropriate ERC20 tokens without burning NEP-141)
* We don't need to add any additional functionality to the contract interface and this is quite straightforward.

Cons:
* The balance of `total_balance_near` (which should be renamed to `total_balance_nep141` or something similar) will grow and will represent both nETH and ETH tokens, which might be not the thing we want.
* The balance of `total_balance` will be the sum of `total_balance_near` and `total_balance_eth`. And in this way is not really something meaningful.

## 2) Add needed private functions to Aurora contract
Add the private function `self_mint_and_ft_transfer` (and `self_mint_and_withdraw` for `exitToEthereum`) that will be called only from the appropriate precompile for ETH. The function will first mint the needed amount of nETH to Aurora account and then perform a regular `ft_transfer` to the recipient.

Pros:
* `total_supply_near`, `total_supply_eth`, `total_supply` values remain meaningful and we don't have any redundant balance for nETH that we keep in the contract.
* nETH tokens are minted only when the appropriate precompile is executed and immediately transferred to the recipient.

Cons:
* We have a different approach comparing to that we use when bridging NEP141->ERC20 on Aurora (this was described in the 1st approach).
* We introduce another one point where we mint some tokens -> This is another point for failure and needs a thorough review.

I expect that the 1st approach more likely will be accepted thus I implemented this here. 
However, I'm more into 2nd approach so I think it worth discussing. 

NB: this needs to be solved for both ETH exits: `exitToNear`, `exitToEthereum`.