### PR TITLE
Fix needless borrows

### DIFF
--- a/src/connector.rs
+++ b/src/connector.rs
@@ -66,8 +66,7 @@ impl EthConnectorContract {
     }
 
     fn get_contract_data<T: BorshDeserialize>(suffix: &EthConnectorStorageId) -> T {
-        let data =
-            sdk::read_storage(&Self::get_contract_key(&suffix)).expect("Failed read storage");
+        let data = sdk::read_storage(&Self::get_contract_key(suffix)).expect("Failed read storage");
         T::try_from_slice(&data[..]).unwrap()
     }
 
@@ -431,7 +430,7 @@ impl EthConnectorContract {
     /// Return total supply of NEAR + ETH
     pub fn ft_total_supply(&self) {
         let total_supply = self.ft.ft_total_supply();
-        sdk::return_output(&total_supply.to_string().as_bytes());
+        sdk::return_output(total_supply.to_string().as_bytes());
         #[cfg(feature = "log")]
         sdk::log(&format!("Total supply: {}", total_supply));
     }
@@ -439,7 +438,7 @@ impl EthConnectorContract {
     /// Return total supply of NEAR
     pub fn ft_total_supply_near(&self) {
         let total_supply = self.ft.ft_total_supply_near();
-        sdk::return_output(&total_supply.to_string().as_bytes());
+        sdk::return_output(total_supply.to_string().as_bytes());
         #[cfg(feature = "log")]
         sdk::log(&format!("Total supply NEAR: {}", total_supply));
     }
@@ -447,7 +446,7 @@ impl EthConnectorContract {
     /// Return total supply of ETH
     pub fn ft_total_supply_eth(&self) {
         let total_supply = self.ft.ft_total_supply_eth();
-        sdk::return_output(&total_supply.to_string().as_bytes());
+        sdk::return_output(total_supply.to_string().as_bytes());
         #[cfg(feature = "log")]
         sdk::log(&format!("Total supply ETH: {}", total_supply));
     }
@@ -458,7 +457,7 @@ impl EthConnectorContract {
             parse_json(&sdk::read_input()).expect_utf8(ERR_FAILED_PARSE.as_bytes()),
         );
         let balance = self.ft.ft_balance_of(&args.account_id);
-        sdk::return_output(&balance.to_string().as_bytes());
+        sdk::return_output(balance.to_string().as_bytes());
         #[cfg(feature = "log")]
         sdk::log(&format!(
             "Balance of NEAR [{}]: {}",
@@ -477,7 +476,7 @@ impl EthConnectorContract {
             hex::encode(args.address),
             balance
         ));
-        sdk::return_output(&balance.to_string().as_bytes());
+        sdk::return_output(balance.to_string().as_bytes());
     }
 
     /// Transfer between NEAR accounts
@@ -513,7 +512,7 @@ impl EthConnectorContract {
         ));
         // `ft_resolve_transfer` can change `total_supply` so we should save the contract
         self.save_ft_contract();
-        sdk::return_output(&amount.to_string().as_bytes());
+        sdk::return_output(amount.to_string().as_bytes());
     }
 
     /// FT transfer call from sender account (invoker account) to receiver
@@ -595,7 +594,7 @@ impl EthConnectorContract {
             let fee = message_data.fee.as_u128();
             self.burn_near(current_account_id, args.amount);
             // Mint fee to relayer
-            let relayer = engine.get_relayer(&message_data.relayer.as_bytes());
+            let relayer = engine.get_relayer(message_data.relayer.as_bytes());
             if fee > 0 && relayer.is_some() {
                 self.mint_eth(message_data.recipient, args.amount - fee);
                 let evm_relayer_address: EthAddress = relayer.unwrap().0;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -408,9 +408,9 @@ impl Engine {
     }
 
     fn make_executor(&self, gas_limit: u64) -> StackExecutor<MemoryStackState<Engine>> {
-        let metadata = StackSubstateMetadata::new(gas_limit, &CONFIG);
+        let metadata = StackSubstateMetadata::new(gas_limit, CONFIG);
         let state = MemoryStackState::new(metadata, self);
-        StackExecutor::new_with_precompile(state, &CONFIG, precompiles::istanbul_precompiles)
+        StackExecutor::new_with_precompile(state, CONFIG, precompiles::istanbul_precompiles)
     }
 
     pub fn register_relayer(&mut self, account_id: &[u8], evm_address: Address) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,7 +241,7 @@ mod contract {
         // Check intrinsic gas is covered by transaction gas limit
         match signed_transaction
             .transaction
-            .intrinsic_gas(&crate::engine::CONFIG)
+            .intrinsic_gas(crate::engine::CONFIG)
         {
             None => sdk::panic_utf8(GAS_OVERFLOW.as_bytes()),
             Some(intrinsic_gas) => {

--- a/src/meta_parsing.rs
+++ b/src/meta_parsing.rs
@@ -140,7 +140,7 @@ pub fn parse_type(field_type: &str) -> ParsingResult<ArgType> {
 pub fn near_erc712_domain(chain_id: U256) -> RawU256 {
     let mut bytes = Vec::with_capacity(70);
     bytes.extend_from_slice(
-        &keccak("EIP712Domain(string name,string version,uint256 chainId)".as_bytes()).as_bytes(),
+        keccak("EIP712Domain(string name,string version,uint256 chainId)".as_bytes()).as_bytes(),
     );
     let near: RawU256 = keccak(b"NEAR").into();
     bytes.extend_from_slice(&near);
@@ -165,7 +165,7 @@ pub fn encode_address(addr: Address) -> Vec<u8> {
 
 pub fn encode_string(s: &str) -> Vec<u8> {
     let mut bytes = vec![];
-    bytes.extend_from_slice(&keccak(s.as_bytes()).as_bytes());
+    bytes.extend_from_slice(keccak(s.as_bytes()).as_bytes());
     bytes
 }
 
@@ -360,12 +360,12 @@ fn eip_712_hash_argument(
 ) -> ParsingResult<Vec<u8>> {
     match ty {
         ArgType::String | ArgType::Bytes => {
-            eip_712_rlp_value(value, |b| Ok(keccak(&b).as_bytes().to_vec()))
+            eip_712_rlp_value(value, |b| Ok(keccak(b).as_bytes().to_vec()))
         }
         ArgType::Byte(_) => eip_712_rlp_value(value, |b| Ok(b.clone())),
         // TODO: ensure rlp int is encoded as sign extended uint256, otherwise this is wrong
         ArgType::Uint | ArgType::Int | ArgType::Bool => eip_712_rlp_value(value, |b| {
-            Ok(u256_to_arr(&U256::from_big_endian(&b)).to_vec())
+            Ok(u256_to_arr(&U256::from_big_endian(b)).to_vec())
         }),
         ArgType::Address => {
             eip_712_rlp_value(value, |b| Ok(encode_address(Address::from_slice(b))))
@@ -442,7 +442,7 @@ fn arg_to_abi_token(
         }
         ArgType::Byte(_) => value_to_abi_token(arg, |b| Ok(ABIToken::FixedBytes(b.clone()))),
         ArgType::Uint | ArgType::Int | ArgType::Bool => {
-            value_to_abi_token(arg, |b| Ok(ABIToken::Uint(U256::from_big_endian(&b))))
+            value_to_abi_token(arg, |b| Ok(ABIToken::Uint(U256::from_big_endian(b))))
         }
         ArgType::Address => {
             value_to_abi_token(arg, |b| Ok(ABIToken::Address(Address::from_slice(b))))
@@ -519,8 +519,8 @@ pub fn prepare_meta_call_args(
     // See "Rationale for typeHash" in https://eips.ethereum.org/EIPS/eip-712#definition-of-hashstruct
     // method_def is used here for typeHash
     let types = "NearTx(string evmId,uint256 nonce,uint256 feeAmount,address feeAddress,address contractAddress,uint256 value,string contractMethod,Arguments arguments)".to_string() + &arguments;
-    bytes.extend_from_slice(&keccak(types.as_bytes()).as_bytes());
-    bytes.extend_from_slice(&keccak(account_id).as_bytes());
+    bytes.extend_from_slice(keccak(types.as_bytes()).as_bytes());
+    bytes.extend_from_slice(keccak(account_id).as_bytes());
     bytes.extend_from_slice(&u256_to_arr(&input.nonce));
     bytes.extend_from_slice(&input.fee_amount.to_bytes());
     bytes.extend_from_slice(&encode_address(input.fee_address));
@@ -529,10 +529,10 @@ pub fn prepare_meta_call_args(
 
     let methods = MethodAndTypes::parse(&method_def)?;
     let method_sig = method_signature(&methods);
-    bytes.extend_from_slice(&keccak(method_sig.as_bytes()).as_bytes());
+    bytes.extend_from_slice(keccak(method_sig.as_bytes()).as_bytes());
 
     let mut arg_bytes = Vec::new();
-    arg_bytes.extend_from_slice(&keccak(arguments.as_bytes()).as_bytes());
+    arg_bytes.extend_from_slice(keccak(arguments.as_bytes()).as_bytes());
     let args_decoded: Vec<RlpValue> = rlp_decode(&input.input)?;
     if methods.method.args.len() != args_decoded.len() {
         return Err(ParsingError::ArgsLengthMismatch);

--- a/src/precompiles/modexp.rs
+++ b/src/precompiles/modexp.rs
@@ -61,7 +61,7 @@ impl Precompile for ModExp<Byzantium> {
         let mod_len = U256::from(&input[64..96]);
 
         let mul = Self::mult_complexity(core::cmp::max(mod_len, base_len))?;
-        let adj = core::cmp::max(Self::adj_exp_len(exp_len, base_len, &input), U256::from(1))
+        let adj = core::cmp::max(Self::adj_exp_len(exp_len, base_len, input), U256::from(1))
             / U256::from(20);
         let (gas_val, overflow) = mul.overflowing_mul(adj);
         if overflow {


### PR DESCRIPTION
Clippy (on latest nightly) pointed out several places where we were borrowing for no reason. This PR could also be called "remove a bunch of useless ampersands from the code" since no functionality is changed.