### PR TITLE
Fix warnings

### DIFF
--- a/src/deposit_event.rs
+++ b/src/deposit_event.rs
@@ -66,7 +66,7 @@ impl DepositedEvent {
     #[cfg(not(feature = "contract"))]
     #[allow(dead_code)]
     pub fn to_log_entry_data(&self) -> Vec<u8> {
-        EthEvent::to_log_entry_data(
+        EthEvent::params_to_log_entry_data(
             DEPOSITED_EVENT,
             DepositedEvent::event_params(),
             self.eth_custodian_address,

--- a/src/deposit_event.rs
+++ b/src/deposit_event.rs
@@ -73,8 +73,8 @@ impl DepositedEvent {
             vec![self.sender.to_vec()],
             vec![
                 ethabi::Token::String(self.recipient.clone()),
-                ethabi::Token::Uint(self.amount.into()),
-                ethabi::Token::Uint(self.fee.clone()),
+                ethabi::Token::Uint(self.amount),
+                ethabi::Token::Uint(self.fee),
             ],
         )
     }

--- a/src/deposit_event.rs
+++ b/src/deposit_event.rs
@@ -1,6 +1,6 @@
-use crate::prelude::{vec, String, ToString};
 #[cfg(not(feature = "contract"))]
-use crate::prelude::{TryInto, Vec};
+use crate::prelude::Vec;
+use crate::prelude::{vec, String, ToString};
 
 use crate::types::*;
 use ethabi::{EventParam, ParamType};
@@ -45,7 +45,8 @@ impl DepositedEvent {
         ]
     }
 
-    /// Parse raw log Etherium proof entry data.
+    /// Parses raw Ethereum logs proof's entry data
+    #[cfg(feature = "engine")]
     pub fn from_log_entry_data(data: &[u8]) -> Self {
         let event = EthEvent::fetch_log_entry_data(DEPOSITED_EVENT, Self::event_params(), data);
         let sender = event.log.params[0].value.clone().into_address().unwrap().0;

--- a/src/fungible_token.rs
+++ b/src/fungible_token.rs
@@ -1,14 +1,16 @@
-#[cfg(feature = "engine")]
-use crate::parameters::*;
 #[cfg(feature = "log")]
 use crate::prelude::format;
-use crate::prelude::TryInto;
-#[cfg(feature = "engine")]
-use crate::prelude::{self, Ordering, String, ToString, Vec, U256};
 use crate::types::*;
-#[cfg(feature = "engine")]
-use crate::{connector, engine, sdk, storage};
 use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "engine")]
+use {
+    crate::connector,
+    crate::engine,
+    crate::parameters::*,
+    crate::prelude::{self, Ordering, String, ToString, TryInto, Vec, U256},
+    crate::sdk,
+    crate::storage,
+};
 
 #[cfg(feature = "engine")]
 const GAS_FOR_RESOLVE_TRANSFER: Gas = 5_000_000_000_000;

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -1,15 +1,15 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 
+use crate::prelude::{String, Vec};
+use crate::types::{AccountId, Balance, RawAddress, RawH256, RawU256};
 #[cfg(feature = "engine")]
-use crate::admin_controlled::PausedMask;
-#[cfg(feature = "engine")]
-use crate::json;
-use crate::prelude::{is_valid_account_id, String, ToString, TryFrom, Vec};
-#[cfg(feature = "engine")]
-use crate::sdk;
-use crate::types::{AccountId, Balance, Proof, RawAddress, RawH256, RawU256};
-#[cfg(feature = "engine")]
-use crate::types::{EthAddress, SdkUnwrap};
+use crate::{
+    admin_controlled::PausedMask,
+    json,
+    prelude::{is_valid_account_id, ToString, TryFrom},
+    sdk,
+    types::{EthAddress, Proof, SdkUnwrap},
+};
 use evm::backend::Log;
 
 /// Borsh-encoded parameters for the `new` function.

--- a/src/precompiles/blake2.rs
+++ b/src/precompiles/blake2.rs
@@ -18,6 +18,7 @@ mod consts {
 pub(super) struct Blake2F<S>(PhantomData<S>);
 
 impl<S> Blake2F<S> {
+    #[cfg_attr(not(feature = "engine"), allow(dead_code))]
     pub(super) const ADDRESS: [u8; 20] = super::make_address(0, 9);
 }
 

--- a/src/precompiles/bn128.rs
+++ b/src/precompiles/bn128.rs
@@ -48,8 +48,11 @@ mod consts {
 pub(super) mod addresses {
     use crate::precompiles;
 
+    #[cfg_attr(not(feature = "engine"), allow(dead_code))]
     pub const ADD: [u8; 20] = precompiles::make_address(0, 6);
+    #[cfg_attr(not(feature = "engine"), allow(dead_code))]
     pub const MUL: [u8; 20] = precompiles::make_address(0, 7);
+    #[cfg_attr(not(feature = "engine"), allow(dead_code))]
     pub const PAIR: [u8; 20] = precompiles::make_address(0, 8);
 }
 

--- a/src/precompiles/hash.rs
+++ b/src/precompiles/hash.rs
@@ -24,6 +24,7 @@ mod consts {
 pub struct SHA256<S>(PhantomData<S>);
 
 impl<S> SHA256<S> {
+    #[cfg_attr(not(feature = "engine"), allow(dead_code))]
     pub(super) const ADDRESS: [u8; 20] = super::make_address(0, 2);
 }
 
@@ -89,6 +90,7 @@ impl<S: AuroraState> Precompile<S> for SHA256<S> {
 pub struct RIPEMD160<S>(PhantomData<S>);
 
 impl<S> RIPEMD160<S> {
+    #[cfg_attr(not(feature = "engine"), allow(dead_code))]
     pub(super) const ADDRESS: [u8; 20] = super::make_address(0, 3);
 }
 

--- a/src/precompiles/identity.rs
+++ b/src/precompiles/identity.rs
@@ -21,6 +21,7 @@ mod consts {
 pub struct Identity<S>(PhantomData<S>);
 
 impl<S> Identity<S> {
+    #[cfg_attr(not(feature = "engine"), allow(dead_code))]
     pub(super) const ADDRESS: [u8; 20] = super::make_address(0, 4);
 }
 

--- a/src/precompiles/mod.rs
+++ b/src/precompiles/mod.rs
@@ -323,6 +323,7 @@ pub fn berlin_precompiles(
 /// const fn for making an address by concatenating the bytes from two given numbers,
 /// Note that 32 + 128 = 160 = 20 bytes (the length of an address). This function is used
 /// as a convenience for specifying the addresses of the various precompiles.
+#[cfg_attr(not(feature = "engine"), allow(dead_code))]
 const fn make_address(x: u32, y: u128) -> [u8; 20] {
     let x_bytes = x.to_be_bytes();
     let y_bytes = y.to_be_bytes();

--- a/src/precompiles/mod.rs
+++ b/src/precompiles/mod.rs
@@ -7,18 +7,21 @@ mod native;
 mod secp256k1;
 use evm::{Context, ExitError};
 
-use crate::precompiles::blake2::Blake2F;
-use crate::precompiles::bn128::{BN128Add, BN128Mul, BN128Pair};
-use crate::precompiles::hash::{RIPEMD160, SHA256};
-use crate::precompiles::identity::Identity;
-use crate::precompiles::modexp::ModExp;
-use crate::precompiles::native::{ExitToEthereum, ExitToNear};
 pub(crate) use crate::precompiles::secp256k1::ecrecover;
-use crate::precompiles::secp256k1::ECRecover;
-use crate::prelude::{Address, Vec};
-#[cfg(feature = "engine")]
-use crate::state::AuroraStackState;
+use crate::prelude::Vec;
 use crate::AuroraState;
+#[cfg(feature = "engine")]
+use crate::{
+    precompiles::blake2::Blake2F,
+    precompiles::bn128::{BN128Add, BN128Mul, BN128Pair},
+    precompiles::hash::{RIPEMD160, SHA256},
+    precompiles::identity::Identity,
+    precompiles::modexp::ModExp,
+    precompiles::native::{ExitToEthereum, ExitToNear},
+    precompiles::secp256k1::ECRecover,
+    prelude::Address,
+    state::AuroraStackState,
+};
 use evm::backend::Log;
 use evm::ExitSucceed;
 
@@ -63,6 +66,7 @@ impl From<PrecompileOutput> for evm::executor::PrecompileOutput {
 /// A precompile operation result.
 type PrecompileResult = Result<PrecompileOutput, ExitError>;
 
+#[cfg(feature = "engine")]
 type EvmPrecompileResult = Result<evm::executor::PrecompileOutput, ExitError>;
 
 /// A precompiled function for use in the EVM.

--- a/src/precompiles/modexp.rs
+++ b/src/precompiles/modexp.rs
@@ -6,6 +6,7 @@ use crate::AuroraState;
 use evm::{Context, ExitError};
 use num::{BigUint, Integer};
 
+#[cfg_attr(not(feature = "engine"), allow(dead_code))]
 pub(super) const ADDRESS: [u8; 20] = super::make_address(0, 5);
 
 pub(super) struct ModExp<HF: HardFork, S>(PhantomData<HF>, PhantomData<S>);

--- a/src/precompiles/native.rs
+++ b/src/precompiles/native.rs
@@ -1,16 +1,22 @@
 use evm::{Context, ExitError};
 
-use crate::parameters::PromiseCreateArgs;
-#[cfg(feature = "engine")]
-use crate::parameters::WithdrawCallArgs;
-use crate::prelude::{is_valid_account_id, Cow, PhantomData, String, ToString, TryInto, U256};
-use crate::storage::{bytes_to_key, KeyPrefix};
-use crate::types::AccountId;
+use crate::prelude::PhantomData;
+#[cfg(not(feature = "contract"))]
+use crate::prelude::Vec;
 use crate::AuroraState;
-use borsh::BorshSerialize;
+#[cfg(feature = "engine")]
+use {
+    crate::parameters::PromiseCreateArgs,
+    crate::parameters::WithdrawCallArgs,
+    crate::prelude::{is_valid_account_id, Cow, String, ToString, TryInto, U256},
+    crate::storage::{bytes_to_key, KeyPrefix},
+    crate::types::AccountId,
+    borsh::BorshSerialize,
+};
 
 use super::{Precompile, PrecompileResult};
 
+#[cfg(feature = "engine")]
 const ERR_TARGET_TOKEN_NOT_FOUND: &str = "Target token not found";
 
 use crate::precompiles::PrecompileOutput;
@@ -25,9 +31,11 @@ mod costs {
     pub(super) const EXIT_TO_ETHEREUM_GAS: Gas = 0;
 
     // TODO(#51): Determine the correct amount of gas
+    #[cfg(feature = "engine")]
     pub(super) const FT_TRANSFER_GAS: Gas = 100_000_000_000_000;
 
     // TODO(#51): Determine the correct amount of gas
+    #[cfg(feature = "engine")]
     pub(super) const WITHDRAWAL_GAS: Gas = 100_000_000_000_000;
 }
 
@@ -60,12 +68,10 @@ impl<S: AuroraState> Precompile<S> for ExitToNear<S> {
     fn run(
         input: &[u8],
         target_gas: u64,
-        context: &Context,
+        _context: &Context,
         _state: &mut S,
         _is_static: bool,
     ) -> PrecompileResult {
-        use crate::prelude::Vec;
-
         if Self::required_gas(input)? > target_gas {
             return Err(ExitError::OutOfGas);
         }
@@ -204,12 +210,10 @@ impl<S: AuroraState> Precompile<S> for ExitToEthereum<S> {
     fn run(
         input: &[u8],
         target_gas: u64,
-        context: &Context,
+        _context: &Context,
         _state: &mut S,
         _is_static: bool,
     ) -> PrecompileResult {
-        use crate::prelude::Vec;
-
         if Self::required_gas(input)? > target_gas {
             return Err(ExitError::OutOfGas);
         }

--- a/src/precompiles/native.rs
+++ b/src/precompiles/native.rs
@@ -16,7 +16,7 @@ use {
 
 use super::{Precompile, PrecompileResult};
 
-#[cfg(feature = "engine")]
+#[cfg_attr(not(feature = "engine"), allow(dead_code))]
 const ERR_TARGET_TOKEN_NOT_FOUND: &str = "Target token not found";
 
 use crate::precompiles::PrecompileOutput;
@@ -31,11 +31,11 @@ mod costs {
     pub(super) const EXIT_TO_ETHEREUM_GAS: Gas = 0;
 
     // TODO(#51): Determine the correct amount of gas
-    #[cfg(feature = "engine")]
+    #[cfg_attr(not(feature = "engine"), allow(dead_code))]
     pub(super) const FT_TRANSFER_GAS: Gas = 100_000_000_000_000;
 
     // TODO(#51): Determine the correct amount of gas
-    #[cfg(feature = "engine")]
+    #[cfg_attr(not(feature = "engine"), allow(dead_code))]
     pub(super) const WITHDRAWAL_GAS: Gas = 100_000_000_000_000;
 }
 
@@ -46,6 +46,7 @@ impl<S> ExitToNear<S> {
     ///
     /// Address: `0xe9217bc70b7ed1f598ddd3199e80b093fa71124f`
     /// This address is computed as: `&keccak("exitToNear")[12..]`
+    #[cfg_attr(not(feature = "engine"), allow(dead_code))]
     pub(super) const ADDRESS: [u8; 20] =
         super::make_address(0xe9217bc7, 0x0b7ed1f598ddd3199e80b093fa71124f);
 }
@@ -197,6 +198,7 @@ impl<S> ExitToEthereum<S> {
     ///
     /// Address: `0xb0bd02f6a392af548bdf1cfaee5dfa0eefcc8eab`
     /// This address is computed as: `&keccak("exitToEthereum")[12..]`
+    #[cfg_attr(not(feature = "engine"), allow(dead_code))]
     pub(super) const ADDRESS: [u8; 20] =
         super::make_address(0xb0bd02f6, 0xa392af548bdf1cfaee5dfa0eefcc8eab);
 }

--- a/src/precompiles/secp256k1.rs
+++ b/src/precompiles/secp256k1.rs
@@ -44,6 +44,7 @@ pub fn ecrecover(hash: H256, signature: &[u8]) -> Result<Address, ExitError> {
 pub(super) struct ECRecover<S>(PhantomData<S>);
 
 impl<S> ECRecover<S> {
+    #[cfg_attr(not(feature = "engine"), allow(dead_code))]
     pub(super) const ADDRESS: [u8; 20] = super::make_address(0, 1);
 }
 

--- a/src/test_utils/exit_precompile.rs
+++ b/src/test_utils/exit_precompile.rs
@@ -1,9 +1,9 @@
-use crate::parameters::{FunctionCallArgs, SubmitResult};
+use crate::parameters::SubmitResult;
 use crate::prelude::{Address, U256};
 use crate::test_utils::{solidity, AuroraRunner, Signer};
 use crate::transaction::EthTransaction;
-use borsh::BorshSerialize;
-use std::convert::TryInto;
+#[cfg(feature = "engine")]
+use {crate::parameters::FunctionCallArgs, borsh::BorshSerialize, std::convert::TryInto};
 
 pub(crate) struct TesterConstructor(pub solidity::ContractConstructor);
 

--- a/src/tests/contract_call.rs
+++ b/src/tests/contract_call.rs
@@ -1,13 +1,16 @@
 use crate::test_utils::{origin, AuroraRunner, Signer};
 
-use crate::prelude::U256;
 use crate::test_utils;
 use crate::test_utils::exit_precompile::{Tester, TesterConstructor};
-use crate::test_utils::solidity;
-use crate::transaction::EthTransaction;
-use ethabi::Address;
-use near_crypto::SecretKey;
-use std::path::{Path, PathBuf};
+#[cfg(feature = "engine")]
+use {
+    crate::prelude::U256,
+    crate::test_utils::solidity,
+    crate::transaction::EthTransaction,
+    ethabi::Address,
+    near_crypto::SecretKey,
+    std::path::{Path, PathBuf},
+};
 
 fn setup_test() -> (AuroraRunner, Signer, [u8; 20], Tester) {
     let mut runner = AuroraRunner::new();
@@ -37,7 +40,7 @@ fn setup_test() -> (AuroraRunner, Signer, [u8; 20], Tester) {
 
 #[test]
 fn hello_world_solidity() {
-    let (mut runner, mut signer, token, tester) = setup_test();
+    let (mut runner, mut signer, _token, tester) = setup_test();
 
     let name = "AuroraG".to_string();
     let expected = format!("Hello {}!", name);
@@ -48,7 +51,7 @@ fn hello_world_solidity() {
 
 #[test]
 fn withdraw() {
-    let (mut runner, mut signer, token, tester) = setup_test();
+    let (mut runner, mut signer, _token, tester) = setup_test();
 
     let test_data = vec![
         (true, "Call contract: tt.testnet.ft_transfer"),
@@ -64,7 +67,7 @@ fn withdraw() {
 
 #[test]
 fn withdraw_and_fail() {
-    let (mut runner, mut signer, token, tester) = setup_test();
+    let (mut runner, mut signer, _token, tester) = setup_test();
 
     let test_data = vec![
         (true, "Call contract: tt.testnet.ft_transfer"),
@@ -83,7 +86,7 @@ fn withdraw_and_fail() {
 
 #[test]
 fn try_withdraw_and_avoid_fail() {
-    let (mut runner, mut signer, token, tester) = setup_test();
+    let (mut runner, mut signer, _token, tester) = setup_test();
 
     let test_data = vec![
         (true, "Call contract: tt.testnet.ft_transfer"),
@@ -102,7 +105,7 @@ fn try_withdraw_and_avoid_fail() {
 
 #[test]
 fn try_withdraw_and_avoid_fail_and_succeed() {
-    let (mut runner, mut signer, token, tester) = setup_test();
+    let (mut runner, mut signer, _token, tester) = setup_test();
 
     let test_data = vec![
         (true, "Call contract: tt.testnet.ft_transfer"),

--- a/src/tests/erc20_connector.rs
+++ b/src/tests/erc20_connector.rs
@@ -1,9 +1,9 @@
-use crate::parameters::{FunctionCallArgs, NEP141FtOnTransferArgs, SubmitResult};
+use crate::parameters::{FunctionCallArgs, SubmitResult};
 use crate::prelude::*;
 use crate::test_utils;
 use crate::test_utils::{create_eth_transaction, origin, AuroraRunner};
 use crate::transaction::EthSignedTransaction;
-use crate::types::{near_account_to_evm_address, AccountId, Balance, RawAddress, Wei};
+use crate::types::{AccountId, Balance, RawAddress, Wei};
 use borsh::{BorshDeserialize, BorshSerialize};
 use ethabi::Token;
 use near_vm_logic::VMOutcome;
@@ -157,6 +157,7 @@ impl test_utils::AuroraRunner {
         result
     }
 
+    #[allow(dead_code)]
     pub fn admin(&mut self, token: RawAddress, origin: AccountId) -> CallResult {
         let input = build_input("admin()", &[]);
         let result = self.evm_call(token, input, origin);
@@ -239,7 +240,7 @@ fn test_mint() {
     let balance = runner.balance_of(token, address, origin());
     assert_eq!(balance, U256::from(0));
     let amount = 10;
-    let result = runner.mint(token, address, amount, origin());
+    let _result = runner.mint(token, address, amount, origin());
     let balance = runner.balance_of(token, address, origin());
     assert_eq!(balance, U256::from(amount));
 }

--- a/src/tests/sanity.rs
+++ b/src/tests/sanity.rs
@@ -188,13 +188,13 @@ fn initialize_transfer() -> (test_utils::AuroraRunner, SecretKey, Address) {
     (runner, source_account, dest_address)
 }
 
-use sha3::{Digest, Keccak256};
+use sha3::Digest;
 
 #[test]
 fn check_selector() {
-    /// Selector to call mint function in ERC 20 contract
-    ///
-    /// keccak("mint(address,uint256)".as_bytes())[..4];
+    // Selector to call mint function in ERC 20 contract
+    //
+    // keccak("mint(address,uint256)".as_bytes())[..4];
     let mut hasher = sha3::Keccak256::default();
     hasher.update(b"mint(address,uint256)");
     assert_eq!(hasher.finalize()[..4].to_vec(), ERC20_MINT_SELECTOR);

--- a/src/types.rs
+++ b/src/types.rs
@@ -72,7 +72,7 @@ impl EthEvent {
     /// Build log_entry_data from ethereum event
     #[cfg(not(feature = "contract"))]
     #[allow(dead_code)]
-    pub fn to_log_entry_data(
+    pub fn params_to_log_entry_data(
         name: &str,
         params: EventParams,
         locker_address: EthAddress,

--- a/src/types.rs
+++ b/src/types.rs
@@ -33,6 +33,7 @@ pub type StorageUsage = u64;
 /// Selector to call mint function in ERC 20 contract
 ///
 /// keccak("mint(address,uint256)".as_bytes())[..4];
+#[allow(dead_code)]
 pub(crate) const ERC20_MINT_SELECTOR: &[u8] = &[64, 193, 15, 25];
 
 pub type EventParams = Vec<EventParam>;

--- a/tests/test_meta_parsing.rs
+++ b/tests/test_meta_parsing.rs
@@ -1,12 +1,17 @@
-use borsh::BorshSerialize;
-
-use near_crypto::{InMemorySigner, KeyType, PublicKey, Signature, Signer};
-
 #[cfg(feature = "meta-call")]
-use aurora_engine::meta_parsing::{near_erc712_domain, parse_meta_call, prepare_meta_call_args};
-use aurora_engine::parameters::MetaCallArgs;
-use aurora_engine::prelude::{Address, U256};
-use aurora_engine::types::{keccak, u256_to_arr, InternalMetaCallArgs, Wei};
+use {
+    aurora_engine::meta_parsing::{near_erc712_domain, parse_meta_call, prepare_meta_call_args},
+    aurora_engine::parameters::MetaCallArgs,
+    aurora_engine::prelude::U256,
+    aurora_engine::types::{u256_to_arr, InternalMetaCallArgs, Wei},
+    borsh::BorshSerialize,
+    near_crypto::{InMemorySigner, KeyType, Signature, Signer},
+};
+
+use near_crypto::PublicKey;
+
+use aurora_engine::prelude::Address;
+use aurora_engine::types::keccak;
 
 #[cfg(feature = "meta-call")]
 pub fn encode_meta_call_function_args(


### PR DESCRIPTION
The purpose of PR is to fix all warnings we currently have.
For some constants it was weird to add an unnecessary `engine` feature check, so I decided to manually turn off the warning by using the following approach:
```rust
#[cfg_attr(not(feature = "engine"), allow(dead_code))]
```