### PR TITLE
Fix(ExitToNear): register the receiver account if it does not exist

### DIFF
--- a/src/fungible_token.rs
+++ b/src/fungible_token.rs
@@ -39,7 +39,7 @@ impl FungibleToken {
     pub fn internal_unwrap_balance_of_eth_on_near(&self, account_id: &str) -> Balance {
         match self.accounts_get(account_id) {
             Some(balance) => u128::try_from_slice(&balance[..]).unwrap(),
-            None => sdk::panic_utf8(b"ERR_ACCOUNT_NOT_EXIST"),
+            None => 0,
         }
     }
 

--- a/src/fungible_token.rs
+++ b/src/fungible_token.rs
@@ -39,7 +39,7 @@ impl FungibleToken {
     pub fn internal_unwrap_balance_of_eth_on_near(&self, account_id: &str) -> Balance {
         match self.accounts_get(account_id) {
             Some(balance) => u128::try_from_slice(&balance[..]).unwrap(),
-            None => 0,
+            None => sdk::panic_utf8(b"ERR_ACCOUNT_NOT_EXIST"),
         }
     }
 
@@ -144,6 +144,10 @@ impl FungibleToken {
             "Sender and receiver should be different"
         );
         assert!(amount > 0, "The amount should be a positive number");
+        if !self.accounts_contains_key(receiver_id) {
+            // TODO: how does this interact with the storage deposit concept?
+            self.internal_register_account(receiver_id)
+        }
         self.internal_withdraw_eth_from_near(sender_id, amount);
         self.internal_deposit_eth_to_near(receiver_id, amount);
         crate::log!(&format!(


### PR DESCRIPTION
I cannot take my ETH from my Aurora address and exit to my NEAR account. I get the error `Smart contract panicked: ERR_ACCOUNT_NOT_EXIST`. This is because my account has never held ETH before, but I think I should still be able to send it there.

See https://explorer.testnet.near.org/transactions/91qBTPUe7iA7qzDzbivJgmkv3DEYJKdVTqL9JsRRyeH6 for full transaction log.

This PR removes the panic, and thus should fix the issue. I wanted to write a test to prove that (a) this was the problem and (b) this fixes it, but writing such a test turned out to be much much harder than the solution (this is a problem itself; tests should be easy to write because then we will actually write them!). So I decided to submit this fix first and the test later because I think the fix is very high priority.