### PR TITLE
Properly document endianess.

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -22,7 +22,7 @@ use ethabi::param_type::Writer;
 pub type AccountId = String;
 pub type Balance = u128;
 pub type RawAddress = [u8; 20];
-pub type RawU256 = [u8; 32]; // Little-endian large integer type.
+pub type RawU256 = [u8; 32]; // Big-endian large integer type.
 pub type RawH256 = [u8; 32]; // Unformatted binary data of fixed length.
 pub type EthAddress = [u8; 20];
 pub type Gas = u64;


### PR DESCRIPTION
The EVM uses big-endian, WebAssembly uses little-endian encoding.

See discussions on #30 and #122.