### PR TITLE
Fix(engine): Fix scheduled nightly clippy

### DIFF
--- a/.github/workflows/scheduled_lints.yml
+++ b/.github/workflows/scheduled_lints.yml
@@ -17,8 +17,9 @@ jobs:
           toolchain: nightly
           override: true
           components: clippy
+      - run: make etc/eth-contracts/res/EvmErc20.bin
       - name: Run cargo clippy
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --no-default-features --features=contract -- -D warnings
+          args: --no-default-features --features=mainnet -- -D warnings

--- a/src/precompiles/modexp.rs
+++ b/src/precompiles/modexp.rs
@@ -94,7 +94,7 @@ impl<S: AuroraState> Precompile<S> for ModExp<Byzantium, S> {
         let (base_len, exp_len, mod_len) = parse_lengths(input);
 
         let mul = Self::mul_complexity(core::cmp::max(mod_len, base_len));
-        let iter_count = Self::calc_iter_count(exp_len, base_len, &input);
+        let iter_count = Self::calc_iter_count(exp_len, base_len, input);
         // mul * iter_count bounded by 2^195 < 2^256 (no overflow)
         let gas = mul * core::cmp::max(iter_count, U256::one()) / U256::from(20);
 
@@ -134,7 +134,7 @@ impl<S: AuroraState> Precompile<S> for ModExp<Berlin, S> {
         let (base_len, exp_len, mod_len) = parse_lengths(input);
 
         let mul = Self::mul_complexity(base_len, mod_len);
-        let iter_count = Self::calc_iter_count(exp_len, base_len, &input);
+        let iter_count = Self::calc_iter_count(exp_len, base_len, input);
         // mul * iter_count bounded by 2^189 (so no overflow)
         let gas = mul * iter_count / U256::from(3);
 


### PR DESCRIPTION
The [scheduled run of nightly clippy was broken](https://github.com/aurora-is-near/aurora-engine/runs/2902922641?check_suite_focus=true). If it would have run it would have also found two more needless borrows, so those are fixed here too.