### PR TITLE
Tests: always compile with `mainnet` feature enabled.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ target/wasm32-unknown-unknown/debug/aurora_engine.wasm: Cargo.toml Cargo.lock $(
 	$(CARGO) build --target wasm32-unknown-unknown --no-default-features --features=$(FEATURES) -Z avoid-dev-deps
 
 test-build: etc/eth-contracts/artifacts/contracts/test/StateTest.sol/StateTest.json etc/eth-contracts/res/EvmErc20.bin
-	RUSTFLAGS='-C link-arg=-s' $(CARGO) build --target wasm32-unknown-unknown --release --no-default-features --features=contract,integration-test,meta-call -Z avoid-dev-deps
+	RUSTFLAGS='-C link-arg=-s' $(CARGO) build --target wasm32-unknown-unknown --release --no-default-features --features=mainnet,integration-test,meta-call -Z avoid-dev-deps
 	ln -sf target/wasm32-unknown-unknown/release/aurora_engine.wasm release.wasm
 	ls -l target/wasm32-unknown-unknown/release/aurora_engine.wasm
 


### PR DESCRIPTION
I noticed that we still compile test-build without specifying `mainnet` feature that we recently added. Right now `mainnet` feature doesn't have any more features enabled, still I think we need this for consistency, so if new dependency features are added, we never miss them and always run tests on close to the production feature set.

Later we may even add 3 separate build configurations for tests running with `mainnet`, `testnet`, `betanet` features.