### PR TITLE
EIP-2930 refactor and extra changes

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -13,7 +13,7 @@ use crate::parameters::{
     ViewCallArgs,
 };
 
-use crate::precompiles::{self, PrecompileAddresses};
+use crate::precompiles::Precompiles;
 use crate::prelude::{Address, TryInto, Vec, H256, U256};
 use crate::sdk;
 use crate::state::AuroraStackState;
@@ -445,13 +445,10 @@ impl Engine {
         Ok(result)
     }
 
-    fn make_executor(
-        &self,
-        gas_limit: u64,
-    ) -> StackExecutor<AuroraStackState, PrecompileAddresses<precompiles::Homestead>> {
+    fn make_executor(&self, gas_limit: u64) -> StackExecutor<AuroraStackState, Precompiles> {
         let metadata = StackSubstateMetadata::new(gas_limit, CONFIG);
         let state = AuroraStackState::new(metadata, self);
-        StackExecutor::new_with_precompile(state, CONFIG, PrecompileAddresses::new_homestead())
+        StackExecutor::new_with_precompile(state, CONFIG, Precompiles::new_istanbul())
     }
 
     pub fn register_relayer(&mut self, account_id: &[u8], evm_address: Address) {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -448,10 +448,10 @@ impl Engine {
     fn make_executor(
         &self,
         gas_limit: u64,
-    ) -> StackExecutor<AuroraStackState, PrecompileAddresses<precompiles::Istanbul>> {
+    ) -> StackExecutor<AuroraStackState, PrecompileAddresses<precompiles::Homestead>> {
         let metadata = StackSubstateMetadata::new(gas_limit, CONFIG);
         let state = AuroraStackState::new(metadata, self);
-        StackExecutor::new_with_precompile(state, CONFIG, PrecompileAddresses::istanbul())
+        StackExecutor::new_with_precompile(state, CONFIG, PrecompileAddresses::new_homestead())
     }
 
     pub fn register_relayer(&mut self, account_id: &[u8], evm_address: Address) {

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -171,7 +171,7 @@ impl TryFrom<NEP141FtOnTransferArgs> for String {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize)]
+#[derive(Debug, BorshSerialize, BorshDeserialize)]
 pub struct PromiseCreateArgs {
     pub target_account_id: AccountId,
     pub method: String,

--- a/src/precompiles/blake2.rs
+++ b/src/precompiles/blake2.rs
@@ -1,7 +1,7 @@
 use evm::{Context, ExitError};
 
 use crate::precompiles::{Precompile, PrecompileOutput, PrecompileResult};
-use crate::prelude::{mem, Borrowed, PhantomData, TryInto};
+use crate::prelude::{mem, Address, Borrowed, PhantomData, TryInto};
 use crate::AuroraState;
 
 /// Blake2 costs.
@@ -15,13 +15,13 @@ mod consts {
     pub(super) const INPUT_LENGTH: usize = 213;
 }
 
-pub(super) struct Blake2F<S>(PhantomData<S>);
+pub(super) struct Blake2F;
 
-impl<S> Blake2F<S> {
-    pub(super) const ADDRESS: [u8; 20] = super::make_address(0, 9);
+impl Blake2F {
+    pub(super) const ADDRESS: Address = super::make_address(0, 9);
 }
 
-impl<S: AuroraState> Precompile<S> for Blake2F<S> {
+impl Precompile for Blake2F {
     fn required_gas(input: &[u8]) -> Result<u64, ExitError> {
         let (int_bytes, _) = input.split_at(mem::size_of::<u32>());
         Ok(u64::from(u32::from_be_bytes(
@@ -43,7 +43,6 @@ impl<S: AuroraState> Precompile<S> for Blake2F<S> {
         input: &[u8],
         target_gas: u64,
         _context: &Context,
-        _state: &mut S,
         _is_static: bool,
     ) -> PrecompileResult {
         if input.len() != consts::INPUT_LENGTH {
@@ -120,12 +119,12 @@ mod tests {
 
     fn test_blake2f_out_of_gas() -> PrecompileResult {
         let input = hex::decode(INPUT).unwrap();
-        Blake2F::run(&input, 11, &new_context(), &mut new_state(), false)
+        Blake2F::run(&input, 11, &new_context(), false)
     }
 
     fn test_blake2f_empty() -> PrecompileResult {
         let input = [0u8; 0];
-        Blake2F::run(&input, 0, &new_context(), &mut new_state(), false)
+        Blake2F::run(&input, 0, &new_context(), false)
     }
 
     fn test_blake2f_invalid_len_1() -> PrecompileResult {
@@ -143,7 +142,7 @@ mod tests {
             01",
         )
         .unwrap();
-        Blake2F::run(&input, 12, &new_context(), &mut new_state(), false)
+        Blake2F::run(&input, 12, &new_context(), false)
     }
 
     fn test_blake2f_invalid_len_2() -> PrecompileResult {
@@ -161,7 +160,7 @@ mod tests {
             01",
         )
         .unwrap();
-        Blake2F::run(&input, 12, &new_context(), &mut new_state(), false)
+        Blake2F::run(&input, 12, &new_context(), false)
     }
 
     fn test_blake2f_invalid_flag() -> PrecompileResult {
@@ -179,7 +178,7 @@ mod tests {
             02",
         )
         .unwrap();
-        Blake2F::run(&input, 12, &new_context(), &mut new_state(), false)
+        Blake2F::run(&input, 12, &new_context(), false)
     }
 
     fn test_blake2f_r_0() -> Vec<u8> {
@@ -197,14 +196,14 @@ mod tests {
             01",
         )
         .unwrap();
-        Blake2F::run(&input, 12, &new_context(), &mut new_state(), false)
+        Blake2F::run(&input, 12, &new_context(), false)
             .unwrap()
             .output
     }
 
     fn test_blake2f_r_12() -> Vec<u8> {
         let input = hex::decode(INPUT).unwrap();
-        Blake2F::run(&input, 12, &new_context(), &mut new_state(), false)
+        Blake2F::run(&input, 12, &new_context(), false)
             .unwrap()
             .output
     }
@@ -224,7 +223,7 @@ mod tests {
             00",
         )
         .unwrap();
-        Blake2F::run(&input, 12, &new_context(), &mut new_state(), false)
+        Blake2F::run(&input, 12, &new_context(), false)
             .unwrap()
             .output
     }

--- a/src/precompiles/blake2.rs
+++ b/src/precompiles/blake2.rs
@@ -1,8 +1,7 @@
 use evm::{Context, ExitError};
 
 use crate::precompiles::{Precompile, PrecompileOutput, PrecompileResult};
-use crate::prelude::{mem, Address, Borrowed, PhantomData, TryInto};
-use crate::AuroraState;
+use crate::prelude::{mem, Address, Borrowed, TryInto};
 
 /// Blake2 costs.
 mod costs {
@@ -95,7 +94,7 @@ impl Precompile for Blake2F {
 #[cfg(test)]
 mod tests {
     use crate::prelude::Vec;
-    use crate::test_utils::{new_context, new_state};
+    use crate::test_utils::new_context;
 
     use super::*;
 

--- a/src/precompiles/bn128.rs
+++ b/src/precompiles/bn128.rs
@@ -355,7 +355,7 @@ impl Precompile for Bn128Pair<Istanbul> {
 
 #[cfg(test)]
 mod tests {
-    use crate::test_utils::{new_context, new_state};
+    use crate::test_utils::new_context;
 
     use super::*;
 

--- a/src/precompiles/bn128.rs
+++ b/src/precompiles/bn128.rs
@@ -2,7 +2,6 @@ use crate::precompiles::{
     Byzantium, HardFork, Istanbul, Precompile, PrecompileOutput, PrecompileResult,
 };
 use crate::prelude::*;
-use crate::AuroraState;
 use evm::{Context, ExitError};
 
 /// bn128 costs.
@@ -44,15 +43,6 @@ mod consts {
     pub(super) const PAIR_ELEMENT_LEN: usize = 192;
 }
 
-/// bn128 precompile addresses
-pub(super) mod addresses {
-    use crate::precompiles;
-
-    pub const ADD: [u8; 20] = precompiles::make_address(0, 6);
-    pub const MUL: [u8; 20] = precompiles::make_address(0, 7);
-    pub const PAIR: [u8; 20] = precompiles::make_address(0, 8);
-}
-
 /// Reads the `x` and `y` points from an input at a given position.
 fn read_point(input: &[u8], pos: usize) -> Result<bn::G1, ExitError> {
     use bn::{AffineG1, Fq, Group, G1};
@@ -76,9 +66,13 @@ fn read_point(input: &[u8], pos: usize) -> Result<bn::G1, ExitError> {
     })
 }
 
-pub(super) struct BN128Add<HF: HardFork, S>(PhantomData<HF>, PhantomData<S>);
+pub(super) struct Bn128Add<HF: HardFork>(PhantomData<HF>);
 
-impl<HF: HardFork, S> BN128Add<HF, S> {
+impl<HF: HardFork> Bn128Add<HF> {
+    pub(super) const ADDRESS: Address = super::make_address(0, 6);
+}
+
+impl<HF: HardFork> Bn128Add<HF> {
     fn run_inner(input: &[u8], _context: &Context) -> Result<Vec<u8>, ExitError> {
         use bn::AffineG1;
 
@@ -100,7 +94,7 @@ impl<HF: HardFork, S> BN128Add<HF, S> {
     }
 }
 
-impl<S: AuroraState> Precompile<S> for BN128Add<Byzantium, S> {
+impl Precompile for Bn128Add<Byzantium> {
     fn required_gas(_input: &[u8]) -> Result<u64, ExitError> {
         Ok(costs::BYZANTIUM_ADD)
     }
@@ -110,13 +104,7 @@ impl<S: AuroraState> Precompile<S> for BN128Add<Byzantium, S> {
     ///
     /// See: https://eips.ethereum.org/EIPS/eip-196
     /// See: https://etherscan.io/address/0000000000000000000000000000000000000006
-    fn run(
-        input: &[u8],
-        target_gas: u64,
-        context: &Context,
-        _state: &mut S,
-        _is_static: bool,
-    ) -> PrecompileResult {
+    fn run(input: &[u8], target_gas: u64, context: &Context, _is_static: bool) -> PrecompileResult {
         let cost = Self::required_gas(input)?;
         if cost > target_gas {
             Err(ExitError::OutOfGas)
@@ -127,7 +115,7 @@ impl<S: AuroraState> Precompile<S> for BN128Add<Byzantium, S> {
     }
 }
 
-impl<S: AuroraState> Precompile<S> for BN128Add<Istanbul, S> {
+impl Precompile for Bn128Add<Istanbul> {
     fn required_gas(_input: &[u8]) -> Result<u64, ExitError> {
         Ok(costs::ISTANBUL_ADD)
     }
@@ -137,13 +125,7 @@ impl<S: AuroraState> Precompile<S> for BN128Add<Istanbul, S> {
     ///
     /// See: https://eips.ethereum.org/EIPS/eip-196
     /// See: https://etherscan.io/address/0000000000000000000000000000000000000006
-    fn run(
-        input: &[u8],
-        target_gas: u64,
-        context: &Context,
-        _state: &mut S,
-        _is_static: bool,
-    ) -> PrecompileResult {
+    fn run(input: &[u8], target_gas: u64, context: &Context, _is_static: bool) -> PrecompileResult {
         let cost = Self::required_gas(input)?;
         if cost > target_gas {
             Err(ExitError::OutOfGas)
@@ -154,9 +136,13 @@ impl<S: AuroraState> Precompile<S> for BN128Add<Istanbul, S> {
     }
 }
 
-pub(super) struct BN128Mul<HF: HardFork, S>(PhantomData<HF>, PhantomData<S>);
+pub(super) struct Bn128Mul<HF: HardFork>(PhantomData<HF>);
 
-impl<HF: HardFork, S> BN128Mul<HF, S> {
+impl<HF: HardFork> Bn128Mul<HF> {
+    pub(super) const ADDRESS: Address = super::make_address(0, 7);
+}
+
+impl<HF: HardFork> Bn128Mul<HF> {
     fn run_inner(input: &[u8], _context: &Context) -> Result<Vec<u8>, ExitError> {
         use bn::AffineG1;
 
@@ -181,7 +167,7 @@ impl<HF: HardFork, S> BN128Mul<HF, S> {
     }
 }
 
-impl<S: AuroraState> Precompile<S> for BN128Mul<Byzantium, S> {
+impl Precompile for Bn128Mul<Byzantium> {
     fn required_gas(_input: &[u8]) -> Result<u64, ExitError> {
         Ok(costs::BYZANTIUM_MUL)
     }
@@ -190,13 +176,7 @@ impl<S: AuroraState> Precompile<S> for BN128Mul<Byzantium, S> {
     ///
     /// See: https://eips.ethereum.org/EIPS/eip-196
     /// See: https://etherscan.io/address/0000000000000000000000000000000000000007
-    fn run(
-        input: &[u8],
-        target_gas: u64,
-        context: &Context,
-        _state: &mut S,
-        _is_static: bool,
-    ) -> PrecompileResult {
+    fn run(input: &[u8], target_gas: u64, context: &Context, _is_static: bool) -> PrecompileResult {
         let cost = Self::required_gas(input)?;
         if cost > target_gas {
             Err(ExitError::OutOfGas)
@@ -207,7 +187,7 @@ impl<S: AuroraState> Precompile<S> for BN128Mul<Byzantium, S> {
     }
 }
 
-impl<S: AuroraState> Precompile<S> for BN128Mul<Istanbul, S> {
+impl Precompile for Bn128Mul<Istanbul> {
     fn required_gas(_input: &[u8]) -> Result<u64, ExitError> {
         Ok(costs::ISTANBUL_MUL)
     }
@@ -216,13 +196,7 @@ impl<S: AuroraState> Precompile<S> for BN128Mul<Istanbul, S> {
     ///
     /// See: https://eips.ethereum.org/EIPS/eip-196
     /// See: https://etherscan.io/address/0000000000000000000000000000000000000007
-    fn run(
-        input: &[u8],
-        target_gas: u64,
-        context: &Context,
-        _state: &mut S,
-        _is_static: bool,
-    ) -> PrecompileResult {
+    fn run(input: &[u8], target_gas: u64, context: &Context, _is_static: bool) -> PrecompileResult {
         let cost = Self::required_gas(input)?;
         if cost > target_gas {
             Err(ExitError::OutOfGas)
@@ -233,9 +207,13 @@ impl<S: AuroraState> Precompile<S> for BN128Mul<Istanbul, S> {
     }
 }
 
-pub(super) struct BN128Pair<HF: HardFork, S>(PhantomData<HF>, PhantomData<S>);
+pub(super) struct Bn128Pair<HF: HardFork>(PhantomData<HF>);
 
-impl<HF: HardFork, S> BN128Pair<HF, S> {
+impl<HF: HardFork> Bn128Pair<HF> {
+    pub(super) const ADDRESS: Address = super::make_address(0, 8);
+}
+
+impl<HF: HardFork> Bn128Pair<HF> {
     fn run_inner(input: &[u8], _context: &Context) -> Result<Vec<u8>, ExitError> {
         use bn::{arith::U256, AffineG1, AffineG2, Fq, Fq2, Group, Gt, G1, G2};
 
@@ -329,7 +307,7 @@ impl<HF: HardFork, S> BN128Pair<HF, S> {
     }
 }
 
-impl<S: AuroraState> Precompile<S> for BN128Pair<Byzantium, S> {
+impl Precompile for Bn128Pair<Byzantium> {
     fn required_gas(input: &[u8]) -> Result<u64, ExitError> {
         Ok(
             costs::BYZANTIUM_PAIR_PER_POINT * input.len() as u64 / consts::PAIR_ELEMENT_LEN as u64
@@ -341,13 +319,7 @@ impl<S: AuroraState> Precompile<S> for BN128Pair<Byzantium, S> {
     ///
     /// See: https://eips.ethereum.org/EIPS/eip-197
     /// See: https://etherscan.io/address/0000000000000000000000000000000000000008
-    fn run(
-        input: &[u8],
-        target_gas: u64,
-        context: &Context,
-        _state: &mut S,
-        _is_static: bool,
-    ) -> PrecompileResult {
+    fn run(input: &[u8], target_gas: u64, context: &Context, _is_static: bool) -> PrecompileResult {
         let cost = Self::required_gas(input)?;
         if cost > target_gas {
             Err(ExitError::OutOfGas)
@@ -358,7 +330,7 @@ impl<S: AuroraState> Precompile<S> for BN128Pair<Byzantium, S> {
     }
 }
 
-impl<S: AuroraState> Precompile<S> for BN128Pair<Istanbul, S> {
+impl Precompile for Bn128Pair<Istanbul> {
     fn required_gas(input: &[u8]) -> Result<u64, ExitError> {
         Ok(
             costs::ISTANBUL_PAIR_PER_POINT * input.len() as u64 / consts::PAIR_ELEMENT_LEN as u64
@@ -370,13 +342,7 @@ impl<S: AuroraState> Precompile<S> for BN128Pair<Istanbul, S> {
     ///
     /// See: https://eips.ethereum.org/EIPS/eip-197
     /// See: https://etherscan.io/address/0000000000000000000000000000000000000008
-    fn run(
-        input: &[u8],
-        target_gas: u64,
-        context: &Context,
-        _state: &mut S,
-        _is_static: bool,
-    ) -> PrecompileResult {
+    fn run(input: &[u8], target_gas: u64, context: &Context, _is_static: bool) -> PrecompileResult {
         let cost = Self::required_gas(input)?;
         if cost > target_gas {
             Err(ExitError::OutOfGas)
@@ -410,10 +376,9 @@ mod tests {
         )
         .unwrap();
 
-        let res =
-            BN128Add::<Byzantium, _>::run(&input, 500, &new_context(), &mut new_state(), false)
-                .unwrap()
-                .output;
+        let res = Bn128Add::<Byzantium>::run(&input, 500, &new_context(), false)
+            .unwrap()
+            .output;
         assert_eq!(res, expected);
 
         // zero sum test
@@ -432,10 +397,9 @@ mod tests {
         )
         .unwrap();
 
-        let res =
-            BN128Add::<Byzantium, _>::run(&input, 500, &new_context(), &mut new_state(), false)
-                .unwrap()
-                .output;
+        let res = Bn128Add::<Byzantium>::run(&input, 500, &new_context(), false)
+            .unwrap()
+            .output;
         assert_eq!(res, expected);
 
         // out of gas test
@@ -447,8 +411,7 @@ mod tests {
             0000000000000000000000000000000000000000000000000000000000000000",
         )
         .unwrap();
-        let res =
-            BN128Add::<Byzantium, _>::run(&input, 499, &new_context(), &mut new_state(), false);
+        let res = Bn128Add::<Byzantium>::run(&input, 499, &new_context(), false);
         assert!(matches!(res, Err(ExitError::OutOfGas)));
 
         // no input test
@@ -460,10 +423,9 @@ mod tests {
         )
         .unwrap();
 
-        let res =
-            BN128Add::<Byzantium, _>::run(&input, 500, &new_context(), &mut new_state(), false)
-                .unwrap()
-                .output;
+        let res = Bn128Add::<Byzantium>::run(&input, 500, &new_context(), false)
+            .unwrap()
+            .output;
         assert_eq!(res, expected);
 
         // point not on curve fail
@@ -476,8 +438,7 @@ mod tests {
         )
         .unwrap();
 
-        let res =
-            BN128Add::<Byzantium, _>::run(&input, 500, &new_context(), &mut new_state(), false);
+        let res = Bn128Add::<Byzantium>::run(&input, 500, &new_context(), false);
         assert!(matches!(
             res,
             Err(ExitError::Other(Borrowed("ERR_BN128_INVALID_POINT")))
@@ -500,10 +461,9 @@ mod tests {
         )
         .unwrap();
 
-        let res =
-            BN128Mul::<Byzantium, _>::run(&input, 40_000, &new_context(), &mut new_state(), false)
-                .unwrap()
-                .output;
+        let res = Bn128Mul::<Byzantium>::run(&input, 40_000, &new_context(), false)
+            .unwrap()
+            .output;
         assert_eq!(res, expected);
 
         // out of gas test
@@ -514,8 +474,7 @@ mod tests {
             0200000000000000000000000000000000000000000000000000000000000000",
         )
         .unwrap();
-        let res =
-            BN128Mul::<Byzantium, _>::run(&input, 39_999, &new_context(), &mut new_state(), false);
+        let res = Bn128Mul::<Byzantium>::run(&input, 39_999, &new_context(), false);
         assert!(matches!(res, Err(ExitError::OutOfGas)));
 
         // zero multiplication test
@@ -533,10 +492,9 @@ mod tests {
         )
         .unwrap();
 
-        let res =
-            BN128Mul::<Byzantium, _>::run(&input, 40_000, &new_context(), &mut new_state(), false)
-                .unwrap()
-                .output;
+        let res = Bn128Mul::<Byzantium>::run(&input, 40_000, &new_context(), false)
+            .unwrap()
+            .output;
         assert_eq!(res, expected);
 
         // no input test
@@ -548,10 +506,9 @@ mod tests {
         )
         .unwrap();
 
-        let res =
-            BN128Mul::<Byzantium, _>::run(&input, 40_000, &new_context(), &mut new_state(), false)
-                .unwrap()
-                .output;
+        let res = Bn128Mul::<Byzantium>::run(&input, 40_000, &new_context(), false)
+            .unwrap()
+            .output;
         assert_eq!(res, expected);
 
         // point not on curve fail
@@ -563,8 +520,7 @@ mod tests {
         )
         .unwrap();
 
-        let res =
-            BN128Mul::<Byzantium, _>::run(&input, 40_000, &new_context(), &mut new_state(), false);
+        let res = Bn128Mul::<Byzantium>::run(&input, 40_000, &new_context(), false);
         assert!(matches!(
             res,
             Err(ExitError::Other(Borrowed("ERR_BN128_INVALID_POINT")))
@@ -593,15 +549,9 @@ mod tests {
             hex::decode("0000000000000000000000000000000000000000000000000000000000000001")
                 .unwrap();
 
-        let res = BN128Pair::<Byzantium, _>::run(
-            &input,
-            260_000,
-            &new_context(),
-            &mut new_state(),
-            false,
-        )
-        .unwrap()
-        .output;
+        let res = Bn128Pair::<Byzantium>::run(&input, 260_000, &new_context(), false)
+            .unwrap()
+            .output;
         assert_eq!(res, expected);
 
         // out of gas test
@@ -621,13 +571,7 @@ mod tests {
             12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa",
         )
         .unwrap();
-        let res = BN128Pair::<Byzantium, _>::run(
-            &input,
-            259_999,
-            &new_context(),
-            &mut new_state(),
-            false,
-        );
+        let res = Bn128Pair::<Byzantium>::run(&input, 259_999, &new_context(), false);
         assert!(matches!(res, Err(ExitError::OutOfGas)));
 
         // no input test
@@ -636,15 +580,9 @@ mod tests {
             hex::decode("0000000000000000000000000000000000000000000000000000000000000001")
                 .unwrap();
 
-        let res = BN128Pair::<Byzantium, _>::run(
-            &input,
-            260_000,
-            &new_context(),
-            &mut new_state(),
-            false,
-        )
-        .unwrap()
-        .output;
+        let res = Bn128Pair::<Byzantium>::run(&input, 260_000, &new_context(), false)
+            .unwrap()
+            .output;
         assert_eq!(res, expected);
 
         // point not on curve fail
@@ -659,13 +597,7 @@ mod tests {
         )
         .unwrap();
 
-        let res = BN128Pair::<Byzantium, _>::run(
-            &input,
-            260_000,
-            &new_context(),
-            &mut new_state(),
-            false,
-        );
+        let res = Bn128Pair::<Byzantium>::run(&input, 260_000, &new_context(), false);
         assert!(matches!(
             res,
             Err(ExitError::Other(Borrowed("ERR_BN128_INVALID_A")))
@@ -681,13 +613,7 @@ mod tests {
         )
         .unwrap();
 
-        let res = BN128Pair::<Byzantium, _>::run(
-            &input,
-            260_000,
-            &new_context(),
-            &mut new_state(),
-            false,
-        );
+        let res = Bn128Pair::<Byzantium>::run(&input, 260_000, &new_context(), false);
         assert!(matches!(
             res,
             Err(ExitError::Other(Borrowed("ERR_BN128_INVALID_LEN",)))

--- a/src/precompiles/hash.rs
+++ b/src/precompiles/hash.rs
@@ -1,8 +1,8 @@
 use crate::precompiles::{Precompile, PrecompileOutput, PrecompileResult};
-use crate::prelude::{vec, PhantomData};
+use crate::prelude::{vec, Address};
 use evm::{Context, ExitError};
 
-use crate::AuroraState;
+use crate::state::AuroraStackState;
 
 mod costs {
     pub(super) const SHA256_BASE: u64 = 60;
@@ -21,13 +21,13 @@ mod consts {
 }
 
 /// SHA256 precompile.
-pub struct SHA256<S>(PhantomData<S>);
+pub struct SHA256;
 
-impl<S> SHA256<S> {
-    pub(super) const ADDRESS: [u8; 20] = super::make_address(0, 2);
+impl SHA256 {
+    pub(super) const ADDRESS: Address = super::make_address(0, 2);
 }
 
-impl<S: AuroraState> Precompile<S> for SHA256<S> {
+impl Precompile for SHA256 {
     fn required_gas(input: &[u8]) -> Result<u64, ExitError> {
         Ok(
             (input.len() as u64 + consts::SHA256_WORD_LEN - 1) / consts::SHA256_WORD_LEN
@@ -44,7 +44,7 @@ impl<S: AuroraState> Precompile<S> for SHA256<S> {
         input: &[u8],
         target_gas: u64,
         _context: &Context,
-        _state: &mut S,
+        _state: &mut AuroraStackState,
         _is_static: bool,
     ) -> PrecompileResult {
         use sha2::Digest;
@@ -70,7 +70,6 @@ impl<S: AuroraState> Precompile<S> for SHA256<S> {
         input: &[u8],
         target_gas: u64,
         _context: &Context,
-        _state: &mut S,
         _is_static: bool,
     ) -> PrecompileResult {
         use crate::sdk;
@@ -86,13 +85,13 @@ impl<S: AuroraState> Precompile<S> for SHA256<S> {
 }
 
 /// RIPEMD160 precompile.
-pub struct RIPEMD160<S>(PhantomData<S>);
+pub struct RIPEMD160;
 
-impl<S> RIPEMD160<S> {
-    pub(super) const ADDRESS: [u8; 20] = super::make_address(0, 3);
+impl RIPEMD160 {
+    pub(super) const ADDRESS: Address = super::make_address(0, 3);
 }
 
-impl<S: AuroraState> Precompile<S> for RIPEMD160<S> {
+impl Precompile for RIPEMD160 {
     fn required_gas(input: &[u8]) -> Result<u64, ExitError> {
         Ok(
             (input.len() as u64 + consts::RIPEMD_WORD_LEN - 1) / consts::RIPEMD_WORD_LEN
@@ -108,7 +107,6 @@ impl<S: AuroraState> Precompile<S> for RIPEMD160<S> {
         input: &[u8],
         target_gas: u64,
         _context: &Context,
-        _state: &mut S,
         _is_static: bool,
     ) -> PrecompileResult {
         use ripemd160::Digest;
@@ -140,7 +138,7 @@ mod tests {
             hex::decode("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
                 .unwrap();
 
-        let res = SHA256::run(input, 60, &new_context(), &mut new_state(), false)
+        let res = SHA256::run(input, 60, &new_context(), false)
             .unwrap()
             .output;
         assert_eq!(res, expected);
@@ -153,7 +151,7 @@ mod tests {
             hex::decode("0000000000000000000000009c1185a5c5e9fc54612808977ee8f548b2258d31")
                 .unwrap();
 
-        let res = RIPEMD160::run(input, 600, &new_context(), &mut new_state(), false)
+        let res = RIPEMD160::run(input, 600, &new_context(), false)
             .unwrap()
             .output;
         assert_eq!(res, expected);

--- a/src/precompiles/hash.rs
+++ b/src/precompiles/hash.rs
@@ -2,8 +2,6 @@ use crate::precompiles::{Precompile, PrecompileOutput, PrecompileResult};
 use crate::prelude::{vec, Address};
 use evm::{Context, ExitError};
 
-use crate::state::AuroraStackState;
-
 mod costs {
     pub(super) const SHA256_BASE: u64 = 60;
 
@@ -44,7 +42,6 @@ impl Precompile for SHA256 {
         input: &[u8],
         target_gas: u64,
         _context: &Context,
-        _state: &mut AuroraStackState,
         _is_static: bool,
     ) -> PrecompileResult {
         use sha2::Digest;
@@ -127,7 +124,7 @@ impl Precompile for RIPEMD160 {
 
 #[cfg(test)]
 mod tests {
-    use crate::test_utils::{new_context, new_state};
+    use crate::test_utils::new_context;
 
     use super::*;
 

--- a/src/precompiles/identity.rs
+++ b/src/precompiles/identity.rs
@@ -1,7 +1,7 @@
 use crate::precompiles::{Precompile, PrecompileOutput, PrecompileResult};
 use evm::{Context, ExitError};
 
-use crate::prelude::PhantomData;
+use crate::prelude::{Address, PhantomData};
 use crate::AuroraState;
 
 /// Identity precompile costs.
@@ -18,13 +18,13 @@ mod consts {
     pub(super) const IDENTITY_WORD_LEN: u64 = 32;
 }
 
-pub struct Identity<S>(PhantomData<S>);
+pub struct Identity;
 
-impl<S> Identity<S> {
-    pub(super) const ADDRESS: [u8; 20] = super::make_address(0, 4);
+impl Identity {
+    pub(super) const ADDRESS: Address = super::make_address(0, 4);
 }
 
-impl<S: AuroraState> Precompile<S> for Identity<S> {
+impl Precompile for Identity {
     fn required_gas(input: &[u8]) -> Result<u64, ExitError> {
         Ok(
             (input.len() as u64 + consts::IDENTITY_WORD_LEN - 1) / consts::IDENTITY_WORD_LEN
@@ -41,7 +41,6 @@ impl<S: AuroraState> Precompile<S> for Identity<S> {
         input: &[u8],
         target_gas: u64,
         _context: &Context,
-        _state: &mut S,
         _is_static: bool,
     ) -> PrecompileResult {
         let cost = Self::required_gas(input)?;
@@ -66,19 +65,19 @@ mod tests {
         let input = [0u8, 1, 2, 3];
 
         let expected = input[0..2].to_vec();
-        let res = Identity::run(&input[0..2], 18, &new_context(), &mut new_state(), false)
+        let res = Identity::run(&input[0..2], 18, &new_context(), false)
             .unwrap()
             .output;
         assert_eq!(res, expected);
 
         let expected = input.to_vec();
-        let res = Identity::run(&input, 18, &new_context(), &mut new_state(), false)
+        let res = Identity::run(&input, 18, &new_context(), false)
             .unwrap()
             .output;
         assert_eq!(res, expected);
 
         // gas fail
-        let res = Identity::run(&input[0..2], 17, &new_context(), &mut new_state(), false);
+        let res = Identity::run(&input[0..2], 17, &new_context(), false);
 
         assert!(matches!(res, Err(ExitError::OutOfGas)));
 
@@ -87,7 +86,7 @@ mod tests {
             0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
             24, 25, 26, 27, 28, 29, 30, 31, 32,
         ];
-        let res = Identity::run(&input, 21, &new_context(), &mut new_state(), false)
+        let res = Identity::run(&input, 21, &new_context(), false)
             .unwrap()
             .output;
         assert_eq!(res, input.to_vec());

--- a/src/precompiles/identity.rs
+++ b/src/precompiles/identity.rs
@@ -1,8 +1,7 @@
 use crate::precompiles::{Precompile, PrecompileOutput, PrecompileResult};
 use evm::{Context, ExitError};
 
-use crate::prelude::{Address, PhantomData};
-use crate::AuroraState;
+use crate::prelude::Address;
 
 /// Identity precompile costs.
 mod costs {
@@ -56,7 +55,7 @@ impl Precompile for Identity {
 mod tests {
     use evm::ExitError;
 
-    use crate::test_utils::{new_context, new_state};
+    use crate::test_utils::new_context;
 
     use super::*;
 

--- a/src/precompiles/mod.rs
+++ b/src/precompiles/mod.rs
@@ -223,11 +223,11 @@ impl<'backend, 'config> executor::Precompiles<AuroraStackState<'backend, 'config
             None => return Some(EvmPrecompileResult::Err(ExitError::OutOfGas)),
         };
 
-        let output = self.get_fun(&address).map(|p| {
-            let mut res = (p)(input, target_gas, context, is_static);
-            if let Ok(o) = &mut res {
-                if let Some(p) = o.promise.take() {
-                    state.add_promise(p)
+        let output = self.get_fun(&address).map(|fun| {
+            let mut res = (fun)(input, target_gas, context, is_static);
+            if let Ok(output) = &mut res {
+                if let Some(promise) = output.promise.take() {
+                    state.add_promise(promise)
                 }
             }
             res

--- a/src/precompiles/mod.rs
+++ b/src/precompiles/mod.rs
@@ -1,16 +1,6 @@
-mod blake2;
-mod bn128;
-mod hash;
-mod identity;
-mod modexp;
-#[cfg_attr(not(feature = "contract"), allow(dead_code))]
-mod native;
-mod secp256k1;
-use evm::{executor, Context, ExitError};
-
 use crate::parameters::PromiseCreateArgs;
 pub(crate) use crate::precompiles::secp256k1::ecrecover;
-use crate::prelude::{vec, BTreeMap, PhantomData, Vec};
+use crate::prelude::{vec, Vec};
 use crate::AuroraState;
 use crate::{
     precompiles::blake2::Blake2F,
@@ -25,7 +15,16 @@ use crate::{
 };
 use evm::backend::Log;
 use evm::ExitSucceed;
-use std::ops::Index;
+use evm::{executor, Context, ExitError};
+
+mod blake2;
+mod bn128;
+mod hash;
+mod identity;
+mod modexp;
+#[cfg_attr(not(feature = "contract"), allow(dead_code))]
+mod native;
+mod secp256k1;
 
 #[derive(Debug)]
 pub struct PrecompileOutput {
@@ -107,14 +106,14 @@ impl HardFork for Berlin {}
 
 type PrecompileFn = fn(&[u8], u64, &Context, bool) -> PrecompileResult;
 
-struct Precompiles {
+pub(crate) struct Precompiles {
     addresses: Vec<Address>,
     fun: Vec<PrecompileFn>,
 }
 
 impl Precompiles {
     #[allow(dead_code)]
-    fn new_homestead() -> Self {
+    pub fn new_homestead() -> Self {
         let addresses = vec![
             ECRecover::ADDRESS,
             SHA256::ADDRESS,
@@ -133,7 +132,8 @@ impl Precompiles {
         Precompiles { addresses, fun }
     }
 
-    fn new_byzantium() -> Self {
+    #[allow(dead_code)]
+    pub fn new_byzantium() -> Self {
         let addresses = vec![
             ECRecover::ADDRESS,
             SHA256::ADDRESS,
@@ -155,9 +155,47 @@ impl Precompiles {
             Bn128Add::<Byzantium>::run,
             Bn128Mul::<Byzantium>::run,
             Bn128Pair::<Byzantium>::run,
+            ExitToNear::run,
+            ExitToEthereum::run,
         ];
 
         Precompiles { addresses, fun }
+    }
+
+    pub fn new_istanbul() -> Self {
+        let addresses = vec![
+            ECRecover::ADDRESS,
+            SHA256::ADDRESS,
+            RIPEMD160::ADDRESS,
+            Identity::ADDRESS,
+            ModExp::<Byzantium>::ADDRESS,
+            Bn128Add::<Istanbul>::ADDRESS,
+            Bn128Mul::<Istanbul>::ADDRESS,
+            Bn128Pair::<Istanbul>::ADDRESS,
+            Blake2F::ADDRESS,
+            ExitToNear::ADDRESS,
+            ExitToEthereum::ADDRESS,
+        ];
+        let fun: Vec<PrecompileFn> = vec![
+            ECRecover::run,
+            SHA256::run,
+            RIPEMD160::run,
+            Identity::run,
+            ModExp::<Byzantium>::run,
+            Bn128Add::<Istanbul>::run,
+            Bn128Mul::<Istanbul>::run,
+            Bn128Pair::<Istanbul>::run,
+            Blake2F::run,
+            ExitToNear::run,
+            ExitToEthereum::run,
+        ];
+
+        Precompiles { addresses, fun }
+    }
+
+    #[allow(dead_code)]
+    fn new_berlin() -> Self {
+        Self::new_istanbul()
     }
 
     fn get_fun(&self, address: &Address) -> Option<PrecompileFn> {
@@ -165,23 +203,12 @@ impl Precompiles {
             .iter()
             .position(|e| e == address)
             .and_then(|i| self.fun.get(i))
-            .map(|f| *f)
+            .copied()
     }
-
-    fn addresses(&self) -> &[Address] {
-        &self.addresses
-    }
-}
-
-pub(crate) struct PrecompileAddresses<HF> {
-    precompiles: Precompiles,
-    hark_fork: PhantomData<HF>,
 }
 
 /// Matches the address given to Homestead precompiles.
-impl<'backend, 'config> executor::Precompiles<AuroraStackState<'backend, 'config>>
-    for PrecompileAddresses<Homestead>
-{
+impl<'backend, 'config> executor::Precompiles<AuroraStackState<'backend, 'config>> for Precompiles {
     fn run(
         &self,
         address: Address,
@@ -196,282 +223,23 @@ impl<'backend, 'config> executor::Precompiles<AuroraStackState<'backend, 'config
             None => return Some(EvmPrecompileResult::Err(ExitError::OutOfGas)),
         };
 
-        let output = self.precompiles.get_fun(&address).and_then(|p| {
+        let output = self.get_fun(&address).map(|p| {
             let mut res = (p)(input, target_gas, context, is_static);
-            if let Ok(mut o) = &mut res {
+            if let Ok(o) = &mut res {
                 if let Some(p) = o.promise.take() {
                     state.add_promise(p)
                 }
             }
-            Some(res)
+            res
         });
 
         output.map(|res| res.map(Into::into))
     }
 
     fn addresses(&self) -> &[Address] {
-        &self.precompiles.addresses()
+        &self.addresses
     }
 }
-
-impl PrecompileAddresses<Homestead> {
-    #[allow(dead_code)]
-    pub fn new_homestead() -> Self {
-        Self {
-            precompiles: Precompiles::new_homestead(),
-            hark_fork: Default::default(),
-        }
-    }
-}
-
-//
-// /// Matches the address given to Byzantium precompiles.
-// impl<'backend, 'config> executor::Precompiles<AuroraStackState<'backend, 'config>>
-//     for PrecompileAddresses<Byzantium>
-// {
-//     fn run(
-//         &self,
-//         address: Address,
-//         input: &[u8],
-//         target_gas: Option<u64>,
-//         context: &Context,
-//         state: &mut AuroraStackState,
-//         is_static: bool,
-//     ) -> Option<EvmPrecompileResult> {
-//         let target_gas = match target_gas {
-//             Some(t) => t,
-//             None => return Some(EvmPrecompileResult::Err(ExitError::OutOfGas)),
-//         };
-//
-//         let output = match Address(address.0) {
-//             ECRecover::<AuroraStackState>::ADDRESS => Some(ECRecover::<AuroraStackState>::run(
-//                 input, target_gas, context, state, is_static,
-//             )),
-//             SHA256::<AuroraStackState>::ADDRESS => Some(SHA256::<AuroraStackState>::run(
-//                 input, target_gas, context, state, is_static,
-//             )),
-//             RIPEMD160::<AuroraStackState>::ADDRESS => Some(RIPEMD160::<AuroraStackState>::run(
-//                 input, target_gas, context, state, is_static,
-//             )),
-//             Identity::<AuroraStackState>::ADDRESS => Some(Identity::<AuroraStackState>::run(
-//                 input, target_gas, context, state, is_static,
-//             )),
-//             modexp::ADDRESS => Some(ModExp::<Byzantium, _>::run(
-//                 input, target_gas, context, state, is_static,
-//             )),
-//             bn128::addresses::ADD => Some(Bn128Add::<Byzantium, _>::run(
-//                 input, target_gas, context, state, is_static,
-//             )),
-//             bn128::addresses::MUL => Some(Bn128Mul::<Byzantium, _>::run(
-//                 input, target_gas, context, state, is_static,
-//             )),
-//             bn128::addresses::PAIR => Some(Bn128Pair::<Byzantium, _>::run(
-//                 input, target_gas, context, state, is_static,
-//             )),
-//             ExitToNear::<AuroraStackState>::ADDRESS => Some(ExitToNear::<AuroraStackState>::run(
-//                 input, target_gas, context, state, is_static,
-//             )),
-//             ExitToEthereum::<AuroraStackState>::ADDRESS => {
-//                 Some(ExitToEthereum::<AuroraStackState>::run(
-//                     input, target_gas, context, state, is_static,
-//                 ))
-//             }
-//             _ => None,
-//         };
-//         output.map(|res| res.map(Into::into))
-//     }
-//
-//     fn addresses(&self) -> &[Address] {
-//         &self.addresses
-//     }
-// }
-//
-// impl PrecompileAddresses<Byzantium> {
-//     #[allow(dead_code)]
-//     pub fn byzantium() -> Self {
-//         Self {
-//             precompiles: Precompiles {},
-//             hark_fork: Default::default(),
-//         }
-//     }
-// }
-//
-// /// Matches the address given to Istanbul precompiles.
-// impl<'backend, 'config> executor::Precompiles<AuroraStackState<'backend, 'config>>
-//     for PrecompileAddresses<Istanbul>
-// {
-//     fn run(
-//         &self,
-//         address: Address,
-//         input: &[u8],
-//         target_gas: Option<u64>,
-//         context: &Context,
-//         state: &mut AuroraStackState,
-//         is_static: bool,
-//     ) -> Option<EvmPrecompileResult> {
-//         let target_gas = match target_gas {
-//             Some(t) => t,
-//             None => return Some(EvmPrecompileResult::Err(ExitError::OutOfGas)),
-//         };
-//
-//         let output = match Address(address.0) {
-//             ECRecover::<AuroraStackState>::ADDRESS => Some(ECRecover::<AuroraStackState>::run(
-//                 input, target_gas, context, state, is_static,
-//             )),
-//             SHA256::<AuroraStackState>::ADDRESS => Some(SHA256::<AuroraStackState>::run(
-//                 input, target_gas, context, state, is_static,
-//             )),
-//             RIPEMD160::<AuroraStackState>::ADDRESS => Some(RIPEMD160::<AuroraStackState>::run(
-//                 input, target_gas, context, state, is_static,
-//             )),
-//             Identity::<AuroraStackState>::ADDRESS => Some(Identity::<AuroraStackState>::run(
-//                 input, target_gas, context, state, is_static,
-//             )),
-//             modexp::ADDRESS => Some(ModExp::<Byzantium, _>::run(
-//                 input, target_gas, context, state, is_static,
-//             )),
-//             bn128::addresses::ADD => Some(Bn128Add::<Istanbul, _>::run(
-//                 input, target_gas, context, state, is_static,
-//             )),
-//             bn128::addresses::MUL => Some(Bn128Mul::<Istanbul, _>::run(
-//                 input, target_gas, context, state, is_static,
-//             )),
-//             bn128::addresses::PAIR => Some(Bn128Pair::<Istanbul, _>::run(
-//                 input, target_gas, context, state, is_static,
-//             )),
-//             Blake2F::<AuroraStackState>::ADDRESS => Some(Blake2F::<AuroraStackState>::run(
-//                 input, target_gas, context, state, is_static,
-//             )),
-//             ExitToNear::<AuroraStackState>::ADDRESS => Some(ExitToNear::<AuroraStackState>::run(
-//                 input, target_gas, context, state, is_static,
-//             )),
-//             ExitToEthereum::<AuroraStackState>::ADDRESS => {
-//                 Some(ExitToEthereum::<AuroraStackState>::run(
-//                     input, target_gas, context, state, is_static,
-//                 ))
-//             }
-//             _ => None,
-//         };
-//         output.map(|res| res.map(Into::into))
-//     }
-//
-//     fn addresses(&self) -> &[Address] {
-//         // &self.addresses.0.keys()
-//     }
-// }
-//
-// impl PrecompileAddresses<Istanbul> {
-//     pub fn istanbul() -> Self {
-//         Self {
-//             addresses: vec![
-//                 ECRecover::<AuroraStackState>::ADDRESS,
-//                 SHA256::<AuroraStackState>::ADDRESS,
-//                 RIPEMD160::<AuroraStackState>::ADDRESS,
-//                 Identity::<AuroraStackState>::ADDRESS,
-//                 modexp::ADDRESS,
-//                 bn128::addresses::ADD,
-//                 bn128::addresses::MUL,
-//                 bn128::addresses::PAIR,
-//                 Blake2F::<AuroraStackState>::ADDRESS,
-//                 ExitToNear::<AuroraStackState>::ADDRESS,
-//                 ExitToEthereum::<AuroraStackState>::ADDRESS,
-//             ]
-//             .into_iter()
-//             .map(Address)
-//             .collect(),
-//             hark_fork: Default::default(),
-//         }
-//     }
-// }
-//
-// /// Matches the address given to Berlin precompiles.
-// impl<'backend, 'config> executor::Precompiles<AuroraStackState<'backend, 'config>>
-//     for PrecompileAddresses<Berlin>
-// {
-//     fn run(
-//         &self,
-//         address: Address,
-//         input: &[u8],
-//         target_gas: Option<u64>,
-//         context: &Context,
-//         state: &mut AuroraStackState,
-//         is_static: bool,
-//     ) -> Option<EvmPrecompileResult> {
-//         let target_gas = match target_gas {
-//             Some(t) => t,
-//             None => return Some(EvmPrecompileResult::Err(ExitError::OutOfGas)),
-//         };
-//
-//         let output = match Address(address.0) {
-//             ECRecover::<AuroraStackState>::ADDRESS => Some(ECRecover::<AuroraStackState>::run(
-//                 input, target_gas, context, state, is_static,
-//             )),
-//             SHA256::<AuroraStackState>::ADDRESS => Some(SHA256::<AuroraStackState>::run(
-//                 input, target_gas, context, state, is_static,
-//             )),
-//             RIPEMD160::<AuroraStackState>::ADDRESS => Some(RIPEMD160::<AuroraStackState>::run(
-//                 input, target_gas, context, state, is_static,
-//             )),
-//             Identity::<AuroraStackState>::ADDRESS => Some(Identity::<AuroraStackState>::run(
-//                 input, target_gas, context, state, is_static,
-//             )),
-//             modexp::ADDRESS => Some(ModExp::<Berlin, _>::run(
-//                 input, target_gas, context, state, is_static,
-//             )), // TODO gas changes
-//             bn128::addresses::ADD => Some(Bn128Add::<Istanbul, _>::run(
-//                 input, target_gas, context, state, is_static,
-//             )),
-//             bn128::addresses::MUL => Some(Bn128Mul::<Istanbul, _>::run(
-//                 input, target_gas, context, state, is_static,
-//             )),
-//             bn128::addresses::PAIR => Some(Bn128Pair::<Istanbul, _>::run(
-//                 input, target_gas, context, state, is_static,
-//             )),
-//             Blake2F::<AuroraStackState>::ADDRESS => Some(Blake2F::<AuroraStackState>::run(
-//                 input, target_gas, context, state, is_static,
-//             )),
-//             ExitToNear::<AuroraStackState>::ADDRESS => Some(ExitToNear::<AuroraStackState>::run(
-//                 input, target_gas, context, state, is_static,
-//             )),
-//             ExitToEthereum::<AuroraStackState>::ADDRESS => {
-//                 Some(ExitToEthereum::<AuroraStackState>::run(
-//                     input, target_gas, context, state, is_static,
-//                 ))
-//             }
-//             _ => None,
-//         };
-//         output.map(|res| res.map(Into::into))
-//     }
-//
-//     fn addresses(&self) -> &[Address] {
-//         // &self.addresses.0.keys()
-//     }
-// }
-//
-// impl PrecompileAddresses<Berlin> {
-//     #[allow(dead_code)]
-//     pub fn berlin() -> Self {
-//         Self {
-//             addresses: vec![
-//                 ECRecover::<AuroraStackState>::ADDRESS,
-//                 SHA256::<AuroraStackState>::ADDRESS,
-//                 RIPEMD160::<AuroraStackState>::ADDRESS,
-//                 Identity::<AuroraStackState>::ADDRESS,
-//                 modexp::ADDRESS,
-//                 bn128::addresses::ADD,
-//                 bn128::addresses::MUL,
-//                 bn128::addresses::PAIR,
-//                 Blake2F::<AuroraStackState>::ADDRESS,
-//                 ExitToNear::<AuroraStackState>::ADDRESS,
-//                 ExitToEthereum::<AuroraStackState>::ADDRESS,
-//             ]
-//             .into_iter()
-//             .map(Address)
-//             .collect(),
-//             hark_fork: Default::default(),
-//         }
-//     }
-// }
 
 /// const fn for making an address by concatenating the bytes from two given numbers,
 /// Note that 32 + 128 = 160 = 20 bytes (the length of an address). This function is used
@@ -505,32 +273,21 @@ const fn make_address(x: u32, y: u128) -> Address {
 
 #[cfg(test)]
 mod tests {
-    use crate::test_utils::MockState;
+    use crate::precompiles::{Byzantium, Istanbul};
+    use crate::prelude::Address;
     use rand::Rng;
 
     #[test]
     fn test_precompile_addresses() {
-        assert_eq!(
-            super::secp256k1::ECRecover::<MockState>::ADDRESS,
-            u8_to_address(1)
-        );
-        assert_eq!(super::hash::SHA256::<MockState>::ADDRESS, u8_to_address(2));
-        assert_eq!(
-            super::hash::RIPEMD160::<MockState>::ADDRESS,
-            u8_to_address(3)
-        );
-        assert_eq!(
-            super::identity::Identity::<MockState>::ADDRESS,
-            u8_to_address(4)
-        );
-        assert_eq!(super::ModExp::ADDRESS, u8_to_address(5));
-        assert_eq!(super::Bn128Add::ADDRESS, u8_to_address(6));
-        assert_eq!(super::Bn128Mul::ADDRESS, u8_to_address(7));
-        assert_eq!(super::Bn128Pair::ADDRESS, u8_to_address(8));
-        assert_eq!(
-            super::blake2::Blake2F::<MockState>::ADDRESS,
-            u8_to_address(9)
-        );
+        assert_eq!(super::secp256k1::ECRecover::ADDRESS, u8_to_address(1));
+        assert_eq!(super::hash::SHA256::ADDRESS, u8_to_address(2));
+        assert_eq!(super::hash::RIPEMD160::ADDRESS, u8_to_address(3));
+        assert_eq!(super::identity::Identity::ADDRESS, u8_to_address(4));
+        assert_eq!(super::ModExp::<Byzantium>::ADDRESS, u8_to_address(5));
+        assert_eq!(super::Bn128Add::<Istanbul>::ADDRESS, u8_to_address(6));
+        assert_eq!(super::Bn128Mul::<Istanbul>::ADDRESS, u8_to_address(7));
+        assert_eq!(super::Bn128Pair::<Istanbul>::ADDRESS, u8_to_address(8));
+        assert_eq!(super::blake2::Blake2F::ADDRESS, u8_to_address(9));
     }
 
     #[test]
@@ -541,20 +298,20 @@ mod tests {
 
         let mut rng = rand::thread_rng();
         for _ in 0..u8::MAX {
-            let address: [u8; 20] = rng.gen();
+            let address: Address = Address(rng.gen());
             let (x, y) = split_address(address);
             assert_eq!(address, super::make_address(x, y))
         }
     }
 
-    fn u8_to_address(x: u8) -> [u8; 20] {
+    fn u8_to_address(x: u8) -> Address {
         let mut bytes = [0u8; 20];
         bytes[19] = x;
-        bytes
+        Address(bytes)
     }
 
     // Inverse function of `super::make_address`.
-    fn split_address(a: [u8; 20]) -> (u32, u128) {
+    fn split_address(a: Address) -> (u32, u128) {
         let mut x_bytes = [0u8; 4];
         let mut y_bytes = [0u8; 16];
 

--- a/src/precompiles/modexp.rs
+++ b/src/precompiles/modexp.rs
@@ -2,8 +2,6 @@ use crate::precompiles::{
     Berlin, Byzantium, HardFork, Precompile, PrecompileOutput, PrecompileResult,
 };
 use crate::prelude::{Address, PhantomData, Vec, U256};
-use crate::state::AuroraStackState;
-use crate::AuroraState;
 use evm::{Context, ExitError};
 use num::{BigUint, Integer};
 
@@ -195,7 +193,7 @@ fn parse_lengths(input: &[u8]) -> (u64, u64, u64) {
 
 #[cfg(test)]
 mod tests {
-    use crate::test_utils::{new_context, new_state, MockState};
+    use crate::test_utils::new_context;
 
     use super::*;
 
@@ -357,7 +355,6 @@ mod tests {
     fn test_modexp() {
         for (test, test_gas) in TESTS.iter().zip(BYZANTIUM_GAS.iter()) {
             let input = hex::decode(&test.input).unwrap();
-            let mut state = new_state();
 
             let res = ModExp::<Byzantium>::run(&input, *test_gas, &new_context(), false)
                 .unwrap()
@@ -427,7 +424,6 @@ mod tests {
 
     #[test]
     fn test_berlin_modexp_empty_input() {
-        let mut state = new_state();
         let res = ModExp::<Berlin>::run(&[], 100_000, &new_context(), false).unwrap();
         let expected: Vec<u8> = Vec::new();
         assert_eq!(res.output, expected)

--- a/src/precompiles/modexp.rs
+++ b/src/precompiles/modexp.rs
@@ -1,16 +1,19 @@
 use crate::precompiles::{
     Berlin, Byzantium, HardFork, Precompile, PrecompileOutput, PrecompileResult,
 };
-use crate::prelude::{PhantomData, Vec, U256};
+use crate::prelude::{Address, PhantomData, Vec, U256};
+use crate::state::AuroraStackState;
 use crate::AuroraState;
 use evm::{Context, ExitError};
 use num::{BigUint, Integer};
 
-pub(super) const ADDRESS: [u8; 20] = super::make_address(0, 5);
+pub(super) struct ModExp<HF: HardFork>(PhantomData<HF>);
 
-pub(super) struct ModExp<HF: HardFork, S>(PhantomData<HF>, PhantomData<S>);
+impl<HF: HardFork> ModExp<HF> {
+    pub(super) const ADDRESS: Address = super::make_address(0, 5);
+}
 
-impl<HF: HardFork, S: AuroraState> ModExp<HF, S> {
+impl<HF: HardFork> ModExp<HF> {
     // Note: the output of this function is bounded by 2^67
     fn calc_iter_count(exp_len: u64, base_len: u64, bytes: &[u8]) -> U256 {
         #[allow(clippy::redundant_closure)]
@@ -73,7 +76,7 @@ impl<HF: HardFork, S: AuroraState> ModExp<HF, S> {
     }
 }
 
-impl<S: AuroraState> ModExp<Byzantium, S> {
+impl ModExp<Byzantium> {
     // ouput of this function is bounded by 2^128
     fn mul_complexity(x: u64) -> U256 {
         if x <= 64 {
@@ -89,7 +92,7 @@ impl<S: AuroraState> ModExp<Byzantium, S> {
     }
 }
 
-impl<S: AuroraState> Precompile<S> for ModExp<Byzantium, S> {
+impl Precompile for ModExp<Byzantium> {
     fn required_gas(input: &[u8]) -> Result<u64, ExitError> {
         let (base_len, exp_len, mod_len) = parse_lengths(input);
 
@@ -107,7 +110,6 @@ impl<S: AuroraState> Precompile<S> for ModExp<Byzantium, S> {
         input: &[u8],
         target_gas: u64,
         _context: &Context,
-        _state: &mut S,
         _is_static: bool,
     ) -> PrecompileResult {
         let cost = Self::required_gas(input)?;
@@ -120,7 +122,7 @@ impl<S: AuroraState> Precompile<S> for ModExp<Byzantium, S> {
     }
 }
 
-impl<S: AuroraState> ModExp<Berlin, S> {
+impl ModExp<Berlin> {
     // output bounded by 2^122
     fn mul_complexity(base_len: u64, mod_len: u64) -> U256 {
         let max_len = core::cmp::max(mod_len, base_len);
@@ -129,7 +131,7 @@ impl<S: AuroraState> ModExp<Berlin, S> {
     }
 }
 
-impl<S: AuroraState> Precompile<S> for ModExp<Berlin, S> {
+impl Precompile for ModExp<Berlin> {
     fn required_gas(input: &[u8]) -> Result<u64, ExitError> {
         let (base_len, exp_len, mod_len) = parse_lengths(input);
 
@@ -145,7 +147,6 @@ impl<S: AuroraState> Precompile<S> for ModExp<Berlin, S> {
         input: &[u8],
         target_gas: u64,
         _context: &Context,
-        _state: &mut S,
         _is_static: bool,
     ) -> PrecompileResult {
         let cost = Self::required_gas(input)?;
@@ -358,15 +359,9 @@ mod tests {
             let input = hex::decode(&test.input).unwrap();
             let mut state = new_state();
 
-            let res = ModExp::<Byzantium, MockState>::run(
-                &input,
-                *test_gas,
-                &new_context(),
-                &mut state,
-                false,
-            )
-            .unwrap()
-            .output;
+            let res = ModExp::<Byzantium>::run(&input, *test_gas, &new_context(), false)
+                .unwrap()
+                .output;
             let expected = hex::decode(&test.expected).unwrap();
             assert_eq!(res, expected, "{}", test.name);
         }
@@ -377,7 +372,7 @@ mod tests {
         for (test, test_gas) in TESTS.iter().zip(BYZANTIUM_GAS.iter()) {
             let input = hex::decode(&test.input).unwrap();
 
-            let gas = ModExp::<Byzantium, MockState>::required_gas(&input).unwrap();
+            let gas = ModExp::<Byzantium>::required_gas(&input).unwrap();
             assert_eq!(gas, *test_gas, "{} gas", test.name);
         }
     }
@@ -387,7 +382,7 @@ mod tests {
         for (test, test_gas) in TESTS.iter().zip(BERLIN_GAS.iter()) {
             let input = hex::decode(&test.input).unwrap();
 
-            let gas = ModExp::<Berlin, MockState>::required_gas(&input).unwrap();
+            let gas = ModExp::<Berlin>::required_gas(&input).unwrap();
             assert_eq!(gas, *test_gas, "{} gas", test.name);
         }
     }
@@ -408,7 +403,7 @@ mod tests {
         input.extend_from_slice(&crate::types::u256_to_arr(&exp));
 
         // completes without any overflow
-        ModExp::<Berlin, MockState>::required_gas(&input).unwrap();
+        ModExp::<Berlin>::required_gas(&input).unwrap();
     }
 
     #[test]
@@ -427,14 +422,13 @@ mod tests {
         input.extend_from_slice(&crate::types::u256_to_arr(&exp));
 
         // completes without any overflow
-        ModExp::<Berlin, MockState>::required_gas(&input).unwrap();
+        ModExp::<Berlin>::required_gas(&input).unwrap();
     }
 
     #[test]
     fn test_berlin_modexp_empty_input() {
         let mut state = new_state();
-        let res = ModExp::<Berlin, MockState>::run(&[], 100_000, &new_context(), &mut state, false)
-            .unwrap();
+        let res = ModExp::<Berlin>::run(&[], 100_000, &new_context(), false).unwrap();
         let expected: Vec<u8> = Vec::new();
         assert_eq!(res.output, expected)
     }

--- a/src/precompiles/native.rs
+++ b/src/precompiles/native.rs
@@ -1,11 +1,10 @@
-use evm::{Context, ExitError};
-
+use crate::parameters::PromiseCreateArgs;
 use crate::prelude::Address;
 #[cfg(not(feature = "contract"))]
 use crate::prelude::Vec;
+use evm::{Context, ExitError};
 #[cfg(feature = "contract")]
 use {
-    crate::parameters::PromiseCreateArgs,
     crate::parameters::WithdrawCallArgs,
     crate::prelude::{is_valid_account_id, Cow, String, ToString, TryInto, U256},
     crate::storage::{bytes_to_key, KeyPrefix},
@@ -20,7 +19,7 @@ const ERR_TARGET_TOKEN_NOT_FOUND: &str = "Target token not found";
 use crate::precompiles::PrecompileOutput;
 use crate::state::AuroraStackState;
 
-pub trait ReturnPromise {
+trait ReturnPromise {
     fn promise(&self, state: &mut AuroraStackState) -> PromiseCreateArgs;
 }
 
@@ -70,7 +69,6 @@ impl Precompile for ExitToNear {
         input: &[u8],
         target_gas: u64,
         _context: &Context,
-        _state: &mut S,
         _is_static: bool,
     ) -> PrecompileResult {
         if Self::required_gas(input)? > target_gas {
@@ -81,6 +79,7 @@ impl Precompile for ExitToNear {
             output: Vec::new(),
             cost: 0,
             logs: Vec::new(),
+            promise: None,
         })
     }
 
@@ -182,9 +181,7 @@ impl Precompile for ExitToNear {
     }
 }
 
-pub struct ExitToEthereum {
-    promise: PromiseCreateArgs,
-}
+pub struct ExitToEthereum;
 
 impl ExitToEthereum {
     /// Exit to Ethereum precompile address
@@ -205,7 +202,6 @@ impl Precompile for ExitToEthereum {
         input: &[u8],
         target_gas: u64,
         _context: &Context,
-        _state: &mut S,
         _is_static: bool,
     ) -> PrecompileResult {
         if Self::required_gas(input)? > target_gas {
@@ -216,6 +212,7 @@ impl Precompile for ExitToEthereum {
             output: Vec::new(),
             cost: 0,
             logs: Vec::new(),
+            promise: None,
         })
     }
 
@@ -328,12 +325,12 @@ mod tests {
     #[test]
     fn test_precompile_id() {
         assert_eq!(
-            ExitToEthereum::<()>::ADDRESS,
-            near_account_to_evm_address("exitToEthereum".as_bytes()).0
+            ExitToEthereum::ADDRESS,
+            near_account_to_evm_address("exitToEthereum".as_bytes())
         );
         assert_eq!(
-            ExitToNear::<()>::ADDRESS,
-            near_account_to_evm_address("exitToNear".as_bytes()).0
+            ExitToNear::ADDRESS,
+            near_account_to_evm_address("exitToNear".as_bytes())
         );
     }
 }

--- a/src/precompiles/secp256k1.rs
+++ b/src/precompiles/secp256k1.rs
@@ -100,9 +100,8 @@ impl Precompile for ECRecover {
 
 #[cfg(test)]
 mod tests {
-    use crate::test_utils::{new_context, new_state};
-
     use super::*;
+    use crate::test_utils::new_context;
 
     fn ecverify(hash: H256, signature: &[u8], signer: Address) -> bool {
         matches!(ecrecover(hash, signature), Ok(s) if s == signer)

--- a/src/precompiles/secp256k1.rs
+++ b/src/precompiles/secp256k1.rs
@@ -3,8 +3,6 @@ use crate::prelude::*;
 use ethabi::Address;
 use evm::{Context, ExitError};
 
-use crate::AuroraState;
-
 mod costs {
     pub(super) const ECRECOVER_BASE: u64 = 3_000;
 }
@@ -41,13 +39,13 @@ pub fn ecrecover(hash: H256, signature: &[u8]) -> Result<Address, ExitError> {
     Err(ExitError::Other(Borrowed("invalid ECDSA signature")))
 }
 
-pub(super) struct ECRecover<S>(PhantomData<S>);
+pub(super) struct ECRecover;
 
-impl<S> ECRecover<S> {
-    pub(super) const ADDRESS: [u8; 20] = super::make_address(0, 1);
+impl ECRecover {
+    pub(super) const ADDRESS: Address = super::make_address(0, 1);
 }
 
-impl<S: AuroraState> Precompile<S> for ECRecover<S> {
+impl Precompile for ECRecover {
     fn required_gas(_input: &[u8]) -> Result<u64, ExitError> {
         Ok(costs::ECRECOVER_BASE)
     }
@@ -56,7 +54,6 @@ impl<S: AuroraState> Precompile<S> for ECRecover<S> {
         input: &[u8],
         target_gas: u64,
         _context: &Context,
-        _state: &mut S,
         _is_static: bool,
     ) -> PrecompileResult {
         let cost = Self::required_gas(input)?;
@@ -132,7 +129,7 @@ mod tests {
             hex::decode("000000000000000000000000c08b5542d177ac6686946920409741463a15dddb")
                 .unwrap();
 
-        let res = ECRecover::run(&input, 3_000, &new_context(), &mut new_state(), false)
+        let res = ECRecover::run(&input, 3_000, &new_context(), false)
             .unwrap()
             .output;
         assert_eq!(res, expected);
@@ -140,7 +137,7 @@ mod tests {
         // out of gas
         let input = hex::decode("47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad000000000000000000000000000000000000000000000000000000000000001b650acf9d3f5f0a2c799776a1254355d5f4061762a237396a99a0e0e3fc2bcd6729514a0dacb2e623ac4abd157cb18163ff942280db4d5caad66ddf941ba12e03").unwrap();
 
-        let res = ECRecover::run(&input, 2_999, &new_context(), &mut new_state(), false);
+        let res = ECRecover::run(&input, 2_999, &new_context(), false);
         assert!(matches!(res, Err(ExitError::OutOfGas)));
 
         // bad inputs
@@ -149,7 +146,7 @@ mod tests {
             hex::decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
                 .unwrap();
 
-        let res = ECRecover::run(&input, 3_000, &new_context(), &mut new_state(), false)
+        let res = ECRecover::run(&input, 3_000, &new_context(), false)
             .unwrap()
             .output;
         assert_eq!(res, expected);
@@ -159,7 +156,7 @@ mod tests {
             hex::decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
                 .unwrap();
 
-        let res = ECRecover::run(&input, 3_000, &new_context(), &mut new_state(), false)
+        let res = ECRecover::run(&input, 3_000, &new_context(), false)
             .unwrap()
             .output;
         assert_eq!(res, expected);
@@ -169,7 +166,7 @@ mod tests {
             hex::decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
                 .unwrap();
 
-        let res = ECRecover::run(&input, 3_000, &new_context(), &mut new_state(), false)
+        let res = ECRecover::run(&input, 3_000, &new_context(), false)
             .unwrap()
             .output;
         assert_eq!(res, expected);
@@ -179,7 +176,7 @@ mod tests {
             hex::decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
                 .unwrap();
 
-        let res = ECRecover::run(&input, 3_000, &new_context(), &mut new_state(), false)
+        let res = ECRecover::run(&input, 3_000, &new_context(), false)
             .unwrap()
             .output;
         assert_eq!(res, expected);

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -49,7 +49,8 @@ pub use primitive_types::{H160, H256, U256};
 pub type Address = H160;
 
 #[allow(non_snake_case, dead_code)]
-pub fn Address(input: [u8; 20]) -> Address {
+// Gets around the fact that you can't contract pub fields with types.
+pub const fn Address(input: [u8; 20]) -> Address {
     H160(input)
 }
 

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -13,13 +13,13 @@ use rlp::RlpStream;
 use secp256k1::{self, Message, PublicKey, SecretKey};
 
 use crate::fungible_token::FungibleToken;
-use crate::parameters::{InitCallArgs, NewCallArgs, PromiseCreateArgs, SubmitResult};
+use crate::parameters::{InitCallArgs, NewCallArgs, SubmitResult};
 use crate::prelude::Address;
+use crate::storage;
 use crate::test_utils::solidity::{ContractConstructor, DeployedContract};
 use crate::transaction::{LegacyEthSignedTransaction, LegacyEthTransaction};
 use crate::types;
 use crate::types::AccountId;
-use crate::{storage, AuroraState};
 
 lazy_static_include::lazy_static_include_bytes! {
     EVM_WASM_BYTES => "release.wasm"
@@ -438,15 +438,4 @@ pub fn new_context() -> Context {
         caller: Default::default(),
         apparent_value: Default::default(),
     }
-}
-
-#[derive(Default)]
-pub struct MockState;
-
-impl AuroraState for MockState {
-    fn add_promise(&mut self, _promise: PromiseCreateArgs) {}
-}
-
-pub fn new_state() -> MockState {
-    Default::default()
 }


### PR DESCRIPTION
This is a bit of a catch-all and will have solutions to outstanding problems that I have been aware of but hadn't realised that it will meet its limitations now.

This is intended to be added to the `develop` branch after https://github.com/aurora-is-near/aurora-engine/pull/181. It just kept growing until it virtually refactored all of the precompile library.

Shortlist of changes:
* Removes the state generic from everything
* Reduces and implies a lot of the code. Code reduction of around 325 lines.
* Easier to read
* No duplicate code