### PR TITLE
Speed up workflow build caching

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,14 +8,12 @@ jobs:
     steps:
       - name: Clone the repository
         uses: actions/checkout@v2
-      - name: Cache Cargo artifacts
+      - name: Cache target artifacts
         uses: actions/cache@v2
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-aurora-engine-target-${{ hashFiles('**/Cargo.lock') }}
       - name: Install the toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,12 +8,11 @@ jobs:
     steps:
       - name: Clone the repository
         uses: actions/checkout@v2
-      - name: Cache target artifacts
-        uses: actions/cache@v2
-        with:
-          path: |
-            target
-          key: ${{ runner.os }}-aurora-engine-target-${{ hashFiles('**/Cargo.lock') }}
+      - name: Prepare target directory
+        run: |
+          rm -rf target && mkdir target
+          ln -s ~/build-cache/aurora-engine/debug/ target/debug
+          ln -s ~/build-cache/aurora-engine/release/ target/release
       - name: Install the toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -32,6 +31,11 @@ jobs:
     steps:
       - name: Clone the repository
         uses: actions/checkout@v2
+      - name: Prepare target directory
+        run: |
+          rm -rf target && mkdir target
+          ln -s ~/build-cache/aurora-engine/debug/ target/debug
+          ln -s ~/build-cache/aurora-engine/release/ target/release
       - name: Install the toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -43,3 +47,4 @@ jobs:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
+  RUSTC_WRAPPER: sccache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Prepare target directory
         run: |
           rm -rf target && mkdir target
-          ln -s ~/build-cache/aurora-engine/debug/ target/debug
-          ln -s ~/build-cache/aurora-engine/release/ target/release
+          ln -s ~/build-cache/aurora-engine-bully/debug/ target/debug
+          ln -s ~/build-cache/aurora-engine-bully/release/ target/release
       - name: Install the toolchain
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
- Remove default caching mechanism. Contents of `~/.cargo` are now shared across runs since all runners are now on the same machine. Caching of `target` directory using remote storage is not efficient and can be implemented faster as written below.
- Wrap Rust compiler with [sccache](https://github.com/mozilla/sccache), which partly allows to reuse compiled dependencies ([it's also mentioned here](https://doc.rust-lang.org/cargo/guide/build-cache.html)). Currently, there are 481mb of cache-hittable artifacts.
- Share `target/debug` and `target/release` across runs. This allows profits even on partial cache-hit from previous builds + saves a lot of disk space for us :)