### PR TITLE
Remove rust toolchain installation in workflow

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -11,12 +11,7 @@ jobs:
     steps:
       - name: Clone the repository
         uses: actions/checkout@v2
-      - name: Install the toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2021-03-25
-          override: true
+      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: make release
       - run: ls -lH mainnet-release.wasm
       - name: Upload the mainnet-release.wasm artifact
@@ -39,12 +34,7 @@ jobs:
     steps:
       - name: Clone the repository
         uses: actions/checkout@v2
-      - name: Install the toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2021-03-25
-          override: true
+      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: make debug
       - run: ls -lH mainnet-debug.wasm
       - name: Upload the mainnet-debug.wasm artifact

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -9,41 +9,21 @@ jobs:
     steps:
       - name: Clone the repository
         uses: actions/checkout@v2
-      - name: Install the toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2021-03-25
-          override: true
-          components: rustfmt
+      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
   clippy:
     name: Clippy
     runs-on: self-hosted
     steps:
       - name: Clone the repository
         uses: actions/checkout@v2
-      - name: Install the toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2021-03-25
-          override: true
-          components: clippy
+      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: make etc/eth-contracts/res/EvmErc20.bin
       - name: Run Contract cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --no-default-features --features=contract -- -D warnings
+        run: cargo clippy --no-default-features --features=contract -- -D warnings
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
+        run: cargo clippy
 
   contracts:
     name: eth-contracts

--- a/.github/workflows/scheduled_lints.yml
+++ b/.github/workflows/scheduled_lints.yml
@@ -10,16 +10,7 @@ jobs:
     steps:
       - name: Clone the repository
         uses: actions/checkout@v2
-      - name: Install the toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-          components: clippy
+      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: make etc/eth-contracts/res/EvmErc20.bin
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --no-default-features --features=mainnet -- -D warnings
+        run: cargo clippy --no-default-features --features=mainnet -- -D warnings

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,40 +8,27 @@ jobs:
     steps:
       - name: Clone the repository
         uses: actions/checkout@v2
+      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Prepare target directory
         run: |
           rm -rf target && mkdir target
           ln -s ~/build-cache/aurora-engine/debug/ target/debug
           ln -s ~/build-cache/aurora-engine/release/ target/release
-      - name: Install the toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2021-03-25
-          override: true
       - run: make mainnet-test-build
       - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --locked --verbose --features mainnet-test
+        run: cargo test --locked --verbose --features mainnet-test
   bully-build:
     name: Bully build
     runs-on: self-hosted
     steps:
       - name: Clone the repository
         uses: actions/checkout@v2
+      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Prepare target directory
         run: |
           rm -rf target && mkdir target
           ln -s ~/build-cache/aurora-engine-bully/debug/ target/debug
           ln -s ~/build-cache/aurora-engine-bully/release/ target/release
-      - name: Install the toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2021-03-25
-          override: true
       - run: make mainnet-debug evm-bully=yes
       - run: ls -lH mainnet-debug.wasm
 env:


### PR DESCRIPTION
Makes no sense after migrating to self-hosted runner (local runtime already have this toolchain).
Furthermore, it creates unwanted data-races