### PR TITLE
Run all tests for all networks in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,8 +15,14 @@ jobs:
           ln -s ~/build-cache/aurora-engine/debug/ target/debug
           ln -s ~/build-cache/aurora-engine/release/ target/release
       - run: make mainnet-test-build
-      - name: Run cargo test
+      - run: make testnet-test-build
+      - run: make betanet-test-build
+      - name: Run mainnet cargo test
         run: cargo test --locked --verbose --features mainnet-test
+      - name: Run testnet cargo test
+        run: cargo test --locked --verbose --features testnet-test
+      - name: Run betanet cargo test
+        run: cargo test --locked --verbose --features betanet-test
   bully-build:
     name: Bully build
     runs-on: self-hosted

--- a/Makefile
+++ b/Makefile
@@ -79,10 +79,10 @@ testnet-test-build: testnet-release.wasm
 test-mainnet: mainnet-test-build
 	$(CARGO) test --features mainnet-test
 
-test-testnet: betanet-test-build
+test-testnet: testnet-test-build
 	$(CARGO) test --features testnet-test
 
-test-betanet: testnet-test-build
+test-betanet: betanet-test-build
 	$(CARGO) test --features betanet-test
 
 deploy: mainnet-release.wasm


### PR DESCRIPTION
With new changes to have tests run with different feature flags, we should run all tests in CI.