### PR TITLE
Add build-caching to testing workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,11 +12,16 @@ jobs:
       - name: Clone the repository
         uses: actions/checkout@v2
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      - name: Clean target directory
-        run: rm -rf target
+      - name: Prepare target directory
+        run: |
+          rm -rf target
+          cache-util -restore -path target -key aurora-engine-target@${{ matrix.net }}net@${{ hashFiles('**/Cargo.lock') }}
       - run: make ${{ matrix.net }}net-test-build
       - name: Run ${{ matrix.net }}net cargo test
         run: cargo test --locked --verbose --features ${{ matrix.net }}net-test
+      - name: Cache target directory
+        run: |
+          cache-util -save -move -path target -key aurora-engine-target@${{ matrix.net }}net@${{ hashFiles('**/Cargo.lock') }}
   bully-build:
     name: Bully build
     runs-on: self-hosted
@@ -24,10 +29,15 @@ jobs:
       - name: Clone the repository
         uses: actions/checkout@v2
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      - name: Clean target directory
-        run: rm -rf target
+      - name: Prepare target directory
+        run: |
+          rm -rf target
+          cache-util -restore -path target -key aurora-engine-target@$bully@${{ hashFiles('**/Cargo.lock') }}
       - run: make mainnet-debug evm-bully=yes
       - run: ls -lH mainnet-debug.wasm
+      - name: Cache target directory
+        run: |
+          cache-util -save -move -path target -key aurora-engine-target@$bully@${{ hashFiles('**/Cargo.lock') }}
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,4 +41,3 @@ jobs:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
-  RUSTC_WRAPPER: sccache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,16 +12,13 @@ jobs:
       - name: Clone the repository
         uses: actions/checkout@v2
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      - name: Prepare target directory
-        run: |
-          rm -rf target
-          cache-util -restore -path target -key aurora-engine-target@${{ matrix.net }}net@${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache lookup for target dir
+        run: cache-util -restore -path target -key aurora-engine-target@${{ matrix.net }}net@${{ hashFiles('**/Cargo.lock') }}
       - run: make ${{ matrix.net }}net-test-build
       - name: Run ${{ matrix.net }}net cargo test
         run: cargo test --locked --verbose --features ${{ matrix.net }}net-test
-      - name: Cache target directory
-        run: |
-          cache-util -save -move -path target -key aurora-engine-target@${{ matrix.net }}net@${{ hashFiles('**/Cargo.lock') }}
+      - name: Caching target dir
+        run: cache-util -save -move -path target -key aurora-engine-target@${{ matrix.net }}net@${{ hashFiles('**/Cargo.lock') }}
   bully-build:
     name: Bully build
     runs-on: self-hosted
@@ -29,15 +26,12 @@ jobs:
       - name: Clone the repository
         uses: actions/checkout@v2
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      - name: Prepare target directory
-        run: |
-          rm -rf target
-          cache-util -restore -path target -key aurora-engine-target@bully@${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache lookup for target dir
+        run: cache-util -restore -path target -key aurora-engine-target@bully@${{ hashFiles('**/Cargo.lock') }}
       - run: make mainnet-debug evm-bully=yes
       - run: ls -lH mainnet-debug.wasm
-      - name: Cache target directory
-        run: |
-          cache-util -save -move -path target -key aurora-engine-target@bully@${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache target dir
+        run: cache-util -save -move -path target -key aurora-engine-target@bully@${{ hashFiles('**/Cargo.lock') }}
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,12 +32,12 @@ jobs:
       - name: Prepare target directory
         run: |
           rm -rf target
-          cache-util -restore -path target -key aurora-engine-target@$bully@${{ hashFiles('**/Cargo.lock') }}
+          cache-util -restore -path target -key aurora-engine-target@bully@${{ hashFiles('**/Cargo.lock') }}
       - run: make mainnet-debug evm-bully=yes
       - run: ls -lH mainnet-debug.wasm
       - name: Cache target directory
         run: |
-          cache-util -save -move -path target -key aurora-engine-target@$bully@${{ hashFiles('**/Cargo.lock') }}
+          cache-util -save -move -path target -key aurora-engine-target@bully@${{ hashFiles('**/Cargo.lock') }}
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,3 +27,4 @@ jobs:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
+  RUSTC_WRAPPER: sccache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,16 +12,9 @@ jobs:
       - name: Clone the repository
         uses: actions/checkout@v2
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      - name: Prepare target directory
-        run: |
-          rm -rf target
-          cache-util -restore -path target -key aurora-engine-target@${{ matrix.net }}net@${{ hashFiles('**/Cargo.lock') }}
       - run: make ${{ matrix.net }}net-test-build
       - name: Run ${{ matrix.net }}net cargo test
         run: cargo test --locked --verbose --features ${{ matrix.net }}net-test
-      - name: Cache target directory
-        run: |
-          cache-util -save -move -path target -key aurora-engine-target@${{ matrix.net }}net@${{ hashFiles('**/Cargo.lock') }}
   bully-build:
     name: Bully build
     runs-on: self-hosted
@@ -29,15 +22,8 @@ jobs:
       - name: Clone the repository
         uses: actions/checkout@v2
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      - name: Prepare target directory
-        run: |
-          rm -rf target
-          cache-util -restore -path target -key aurora-engine-target@bully@${{ hashFiles('**/Cargo.lock') }}
       - run: make mainnet-debug evm-bully=yes
       - run: ls -lH mainnet-debug.wasm
-      - name: Cache target directory
-        run: |
-          cache-util -save -move -path target -key aurora-engine-target@bully@${{ hashFiles('**/Cargo.lock') }}
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,9 +12,16 @@ jobs:
       - name: Clone the repository
         uses: actions/checkout@v2
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - name: Prepare target directory
+        run: |
+          rm -rf target
+          cache-util -restore -path target -key aurora-engine-target@${{ matrix.net }}net@${{ hashFiles('**/Cargo.lock') }}
       - run: make ${{ matrix.net }}net-test-build
       - name: Run ${{ matrix.net }}net cargo test
         run: cargo test --locked --verbose --features ${{ matrix.net }}net-test
+      - name: Cache target directory
+        run: |
+          cache-util -save -move -path target -key aurora-engine-target@${{ matrix.net }}net@${{ hashFiles('**/Cargo.lock') }}
   bully-build:
     name: Bully build
     runs-on: self-hosted
@@ -22,8 +29,15 @@ jobs:
       - name: Clone the repository
         uses: actions/checkout@v2
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - name: Prepare target directory
+        run: |
+          rm -rf target
+          cache-util -restore -path target -key aurora-engine-target@$bully@${{ hashFiles('**/Cargo.lock') }}
       - run: make mainnet-debug evm-bully=yes
       - run: ls -lH mainnet-debug.wasm
+      - name: Cache target directory
+        run: |
+          cache-util -save -move -path target -key aurora-engine-target@$bully@${{ hashFiles('**/Cargo.lock') }}
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0


### PR DESCRIPTION
Implement same thing that we had with [actions/cache](https://github.com/actions/cache), but use locally installed [cache-util](https://github.com/aurora-is-near/devops-stuff/tree/main/cache-util) instead.

~4m -> ~1m