### PR TITLE
Add options to bench profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ codegen-units = 1
 rpath = false
 
 [profile.dev]
+# Due to a strange bug, setting this to 3 will cause test failures
 opt-level = "z"
 debug = false
 debug-assertions = true
@@ -36,6 +37,12 @@ panic = "abort"
 incremental = false
 codegen-units = 1
 rpath = false
+
+[profile.bench]
+# lto must be enabled in the bench profile as well for
+# it to actually happen when running tests with --release
+lto = true
+opt-level = 3
 
 [dependencies]
 blake2 = { git = "https://github.com/near/near-blake2.git", version = "0.9.1", default-features = false }


### PR DESCRIPTION
Context: @joshuajbouw asked if we should set the `opt-level` in the `dev` profile to match `release`, for consistency. I didn't see the harm, so gave it a shot, and it turns out this is not possible because of a complex interaction between wasmer's handling of panics and the rust compiler.

This is not a big deal because the wasm binaries we use in tests are still compiled with `--release`; it is only the test code that consumes and runs the wasm which will not be optimized, and that does not matter because performance of test execution is not particularly important.

As a result of this issue, I learned from @matklad that we need to enable `lto` on the `bench` profile in order to actually get link time optimization when running tests with `--release` (because compiling with `test` and `--release` together sometimes means some crates will be compiled under `bench` for some reason). This is important for us because we do have benchmarks which are run as tests with `--release`. This is fixed in this PR. With this change, the benchmarks measuring the wall-clock performance of NEAR runtime should be more accurate.