### PR TITLE
Remove duplicate test

### DIFF
--- a/src/tests/standard_precompiles.rs
+++ b/src/tests/standard_precompiles.rs
@@ -36,32 +36,3 @@ fn standard_precompiles() {
         panic!("{}", String::from_utf8_lossy(&outcome.result))
     }
 }
-
-#[test]
-fn precompile_late_promise_create() {
-    let mut runner = test_utils::deploy_evm();
-    let mut rng = rand::thread_rng();
-    let source_account = SecretKey::random(&mut rng);
-    runner.create_address(
-        test_utils::address_from_secret_key(&source_account),
-        INITIAL_BALANCE.into(),
-        INITIAL_NONCE.into(),
-    );
-
-    let constructor = PrecompilesConstructor::load();
-    let contract = PrecompilesContract(runner.deploy_contract(
-        &source_account,
-        |c| c.deploy(INITIAL_NONCE.into()),
-        constructor,
-    ));
-
-    let test_all_tx = contract.call_method("test_all", (INITIAL_NONCE + 1).into());
-    let outcome = runner
-        .submit_transaction(&source_account, test_all_tx)
-        .unwrap();
-
-    // status == false indicates failure
-    if !outcome.status {
-        panic!("{}", String::from_utf8_lossy(&outcome.result))
-    }
-}


### PR DESCRIPTION
This test is being removed because it is line-for-line identical to the one above it and therefore does not add any value.

Based on its name, it seems the intention is that it was going to test we properly create promises (and do not create them in the case of revert). This functionality is tested in `src/tests/call_contract.rs` (not the most descriptive name), so it is safe to delete this duplicate test.