### PR TITLE
Timestamp should be in milliseconds for Ethereum compatibility

### DIFF
--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -315,7 +315,9 @@ pub fn remove_storage_with_result(key: &[u8]) -> Option<Vec<u8>> {
 
 #[allow(dead_code)]
 pub fn block_timestamp() -> u64 {
-    unsafe { exports::block_timestamp() }
+    // NEAR timestamp is in nanoseconds
+    let timestamp_ns = unsafe { exports::block_timestamp() };
+    timestamp_ns / 1000 // convert to milliseconds for Ethereum compatibility
 }
 
 pub fn block_index() -> u64 {


### PR DESCRIPTION
This was caught during the IOSG hackathon. It's something we probably would have caught ourselves if we had better compatibility test coverage, e.g. #170 