### PR TITLE
Update etc/state-migration-test/Cargo.lock

### DIFF
--- a/etc/state-migration-test/Cargo.lock
+++ b/etc/state-migration-test/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-engine"
-version = "1.0.0"
+version = "1.5.0"
 dependencies = [
  "aurora-bn",
  "blake2",


### PR DESCRIPTION
Looks like this was missed during the version upgrade.