### PR TITLE
feat(engine): Blockhash definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@
 artifacts/
 cache/
 node_modules/
-res/
+etc/eth-contracts/res/
 
 # Other
 etc/state-migration-test/target/

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -260,11 +260,11 @@ impl Engine {
     ///     engine_account_id,
     /// ))
     /// ```
-    pub fn compute_block_hash(&self, block_height: u64, account_id: &[u8]) -> H256 {
+    pub fn compute_block_hash(chain_id: [u8; 32], block_height: u64, account_id: &[u8]) -> H256 {
         let mut data = Vec::with_capacity(1 + 8 + 32 + account_id.len());
         data.push(BLOCK_HASH_PREFIX);
         data.extend_from_slice(&block_height.to_be_bytes());
-        data.extend_from_slice(&self.state.chain_id);
+        data.extend_from_slice(&chain_id);
         data.extend_from_slice(account_id);
 
         #[cfg(not(feature = "contract"))]
@@ -743,11 +743,11 @@ impl evm::backend::Backend for Engine {
             #[cfg(feature = "contract")]
             {
                 let account_id = sdk::current_account_id();
-                self.compute_block_hash(number.low_u64(), &account_id)
+                Self::compute_block_hash(self.state.chain_id, number.low_u64(), &account_id)
             }
 
             #[cfg(not(feature = "contract"))]
-            self.compute_block_hash(number.low_u64(), b"aurora")
+            Self::compute_block_hash(self.state.chain_id, number.low_u64(), b"aurora")
         } else {
             H256::zero()
         }

--- a/src/test_utils/solidity.rs
+++ b/src/test_utils/solidity.rs
@@ -1,4 +1,5 @@
-use crate::prelude::Address;
+use crate::prelude::{Address, U256};
+use crate::transaction::LegacyEthTransaction;
 use near_sdk::serde_json;
 use serde::Deserialize;
 use std::fs;
@@ -71,6 +72,42 @@ impl ContractConstructor {
         DeployedContract {
             abi: self.abi.clone(),
             address,
+        }
+    }
+
+    pub fn deploy_without_args(&self, nonce: U256) -> LegacyEthTransaction {
+        let data = self
+            .abi
+            .constructor()
+            .unwrap()
+            .encode_input(self.code.clone(), &[])
+            .unwrap();
+        LegacyEthTransaction {
+            nonce,
+            gas_price: Default::default(),
+            gas: u64::MAX.into(),
+            to: None,
+            value: Default::default(),
+            data,
+        }
+    }
+}
+
+impl DeployedContract {
+    pub fn call_method_without_args(&self, method_name: &str, nonce: U256) -> LegacyEthTransaction {
+        let data = self
+            .abi
+            .function(method_name)
+            .unwrap()
+            .encode_input(&[])
+            .unwrap();
+        LegacyEthTransaction {
+            nonce,
+            gas_price: Default::default(),
+            gas: u64::MAX.into(),
+            to: Some(self.address),
+            value: Default::default(),
+            data,
         }
     }
 }

--- a/src/test_utils/standard_precompiles.rs
+++ b/src/test_utils/standard_precompiles.rs
@@ -24,21 +24,7 @@ impl PrecompilesConstructor {
     }
 
     pub fn deploy(&self, nonce: U256) -> LegacyEthTransaction {
-        let data = self
-            .0
-            .abi
-            .constructor()
-            .unwrap()
-            .encode_input(self.0.code.clone(), &[])
-            .unwrap();
-        LegacyEthTransaction {
-            nonce,
-            gas_price: Default::default(),
-            gas: u64::MAX.into(),
-            to: None,
-            value: Default::default(),
-            data,
-        }
+        self.0.deploy_without_args(nonce)
     }
 
     fn solidity_artifacts_path() -> PathBuf {
@@ -52,21 +38,7 @@ impl PrecompilesConstructor {
 
 impl PrecompilesContract {
     pub fn call_method(&self, method_name: &str, nonce: U256) -> LegacyEthTransaction {
-        let data = self
-            .0
-            .abi
-            .function(method_name)
-            .unwrap()
-            .encode_input(&[])
-            .unwrap();
-        LegacyEthTransaction {
-            nonce,
-            gas_price: Default::default(),
-            gas: u64::MAX.into(),
-            to: Some(self.0.address),
-            value: Default::default(),
-            data,
-        }
+        self.0.call_method_without_args(method_name, nonce)
     }
 
     pub fn all_method_names() -> &'static [&'static str] {

--- a/src/tests/res/blockhash.sol
+++ b/src/tests/res/blockhash.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+contract BlockHash {
+  constructor() payable {}
+
+  function test() public view {
+    require(
+      blockhash(0) == hex"a7ac0e4bd5ad1654392b64ecd40a69f983e8ce7c315639a339d19a880902457a", 
+      "Bad block hash"
+    );
+  }
+}


### PR DESCRIPTION
This PR defines an Aurora block hash for each height of the NEAR blockchain (including skipped ones). This definition is unique on different networks (via chain_id) and different accounts on the same network(*). It also includes a prefix byte which may allow us to change this scheme in the future and verify the change is implemented based on the hash output.

(*) Note: in the future, when we have sharding, this may need to change because there could be multiple Aurora accounts on the same network that are contributing to the same set of blocks.