### PR TITLE
Fix(CI): Scheduled lint is supposed to run nightly clippy

### DIFF
--- a/.github/workflows/scheduled_lints.yml
+++ b/.github/workflows/scheduled_lints.yml
@@ -12,5 +12,7 @@ jobs:
         uses: actions/checkout@v2
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: make etc/eth-contracts/res/EvmErc20.bin
+      - name: Update toolchain
+        run: rustup update nightly
       - name: Run cargo clippy
-        run: cargo clippy --no-default-features --features=mainnet -- -D warnings
+        run: cargo +nightly clippy --no-default-features --features=mainnet -- -D warnings


### PR DESCRIPTION
When we stopped installing the toolchain as part of the Action, we accidentally stopped running `clippy` with nightly in the scheduled lint. The whole point of this lint is to occasionally check if there are any new errors in our codebase with later versions of clippy.