### PR TITLE
Feat(engine): Relayer payment

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -354,25 +354,25 @@ impl Engine {
             return Ok(Wei::zero());
         }
 
-        let eth_amount = Wei::new(
+        let payment_for_gas = Wei::new(
             gas_limit
                 .checked_mul(gas_price)
                 .ok_or(GasPaymentError::EthAmountOverflow)?,
         );
         let account_balance = Self::get_balance(sender);
         let remaining_balance = account_balance
-            .checked_sub(eth_amount)
+            .checked_sub(payment_for_gas)
             .ok_or(GasPaymentError::OutOfFund)?;
 
         Self::set_balance(sender, &remaining_balance);
 
-        Ok(eth_amount)
+        Ok(payment_for_gas)
     }
 
     pub fn refund_unused_gas(
         sender: &Address,
         relayer: &Address,
-        prepaid_eth: Wei,
+        prepaid_amount: Wei,
         used_gas: u64,
         gas_price: U256,
     ) -> Result<(), GasPaymentError> {
@@ -387,8 +387,8 @@ impl Engine {
                 .ok_or(GasPaymentError::EthAmountOverflow)?,
         );
         // We cannot have used more than the gas_limit
-        debug_assert!(used_amount <= prepaid_eth);
-        let refund_amount = prepaid_eth - used_amount;
+        debug_assert!(used_amount <= prepaid_amount);
+        let refund_amount = prepaid_amount - used_amount;
 
         Self::add_balance(sender, refund_amount)?;
         Self::add_balance(relayer, used_amount)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,6 +251,12 @@ mod contract {
         let gas_price = *signed_transaction.gas_price();
         let prepaid_amount =
             Engine::charge_gas_limit(&sender, *signed_transaction.gas_limit(), gas_price)
+                .map_err(|e| {
+                    // In the error case we still need to increment the nonce since the transaction
+                    // was valid except for a property of the current state (the balance)
+                    Engine::increment_nonce(&sender);
+                    e
+                })
                 .sdk_unwrap();
 
         // Figure out what kind of a transaction this is, and execute it:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,16 +241,16 @@ mod contract {
         match signed_transaction.intrinsic_gas(crate::engine::CONFIG) {
             None => sdk::panic_utf8(GAS_OVERFLOW.as_bytes()),
             Some(intrinsic_gas) => {
-                if signed_transaction.gas_limit() < &intrinsic_gas.into() {
+                if signed_transaction.gas_limit() < intrinsic_gas.into() {
                     sdk::panic_utf8(b"ERR_INTRINSIC_GAS")
                 }
             }
         }
 
         // Pay for gas
-        let gas_price = *signed_transaction.gas_price();
+        let gas_price = signed_transaction.gas_price();
         let prepaid_amount =
-            Engine::charge_gas_limit(&sender, *signed_transaction.gas_limit(), gas_price)
+            Engine::charge_gas_limit(&sender, signed_transaction.gas_limit(), gas_price)
                 .map_err(|e| {
                     // In the error case we still need to increment the nonce since the transaction
                     // was valid except for a property of the current state (the balance)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,11 +281,12 @@ mod contract {
 
         // Give refund
         let relayer = predecessor_address();
-        // TODO: need to handle charging gas in the error case too
-        if let Ok(x) = &result {
-            Engine::refund_unused_gas(&sender, &relayer, prepaid_amount, x.gas_used, gas_price)
-                .sdk_unwrap();
-        }
+        let gas_used = match &result {
+            Ok(submit_result) => submit_result.gas_used,
+            Err(engine_err) => engine_err.gas_used,
+        };
+        Engine::refund_unused_gas(&sender, &relayer, prepaid_amount, gas_used, gas_price)
+            .sdk_unwrap();
 
         // return result to user
         result

--- a/src/tests/sanity.rs
+++ b/src/tests/sanity.rs
@@ -1,12 +1,13 @@
 use crate::prelude::Address;
 use crate::test_utils;
-use crate::types::{Wei, ERC20_MINT_SELECTOR};
+use crate::types::{self, Wei, ERC20_MINT_SELECTOR};
 use secp256k1::SecretKey;
 use std::path::{Path, PathBuf};
 
-const INITIAL_BALANCE: Wei = Wei::new_u64(1000);
+const INITIAL_BALANCE: Wei = Wei::new_u64(1_000_000);
 const INITIAL_NONCE: u64 = 0;
 const TRANSFER_AMOUNT: Wei = Wei::new_u64(123);
+const GAS_PRICE: u64 = 10;
 
 /// Tests we can transfer Eth from one account to another and that the balances are correctly
 /// updated.
@@ -152,6 +153,101 @@ fn test_eth_transfer_not_enough_gas() {
         INITIAL_NONCE.into(),
     );
     test_utils::validate_address_balance_and_nonce(&runner, dest_address, Wei::zero(), 0.into());
+}
+
+#[test]
+fn test_transfer_charging_gas_success() {
+    let (mut runner, mut source_account, dest_address) = initialize_transfer();
+    let source_address = test_utils::address_from_secret_key(&source_account.secret_key);
+    let transaction = |nonce| {
+        let mut tx = test_utils::transfer(dest_address, TRANSFER_AMOUNT, nonce);
+        tx.gas = 30_000.into();
+        tx.gas_price = GAS_PRICE.into();
+        tx
+    };
+
+    // validate pre-state
+    test_utils::validate_address_balance_and_nonce(
+        &runner,
+        source_address,
+        INITIAL_BALANCE,
+        INITIAL_NONCE.into(),
+    );
+    test_utils::validate_address_balance_and_nonce(&runner, dest_address, Wei::zero(), 0.into());
+
+    // do transfer
+    let result = runner
+        .submit_with_signer(&mut source_account, transaction)
+        .unwrap();
+    let spent_amount = Wei::new_u64(GAS_PRICE * result.gas_used);
+    let expected_source_balance = INITIAL_BALANCE - TRANSFER_AMOUNT - spent_amount;
+    let expected_dest_balance = TRANSFER_AMOUNT;
+    let expected_relayer_balance = spent_amount;
+    let relayer_address =
+        types::near_account_to_evm_address(runner.context.predecessor_account_id.as_bytes());
+
+    // validate post-state
+    test_utils::validate_address_balance_and_nonce(
+        &runner,
+        source_address,
+        expected_source_balance,
+        (INITIAL_NONCE + 1).into(),
+    );
+    test_utils::validate_address_balance_and_nonce(
+        &runner,
+        dest_address,
+        expected_dest_balance,
+        0.into(),
+    );
+    test_utils::validate_address_balance_and_nonce(
+        &runner,
+        relayer_address,
+        expected_relayer_balance,
+        0.into(),
+    );
+}
+
+#[test]
+fn test_eth_transfer_charging_gas_not_enough_balance() {
+    let (mut runner, mut source_account, dest_address) = initialize_transfer();
+    let source_address = test_utils::address_from_secret_key(&source_account.secret_key);
+    let transaction = |nonce| {
+        let mut tx = test_utils::transfer(dest_address, TRANSFER_AMOUNT, nonce);
+        // With this gas limit and price the account does not
+        // have enough balance to cover the gas cost
+        tx.gas = 3_000_000.into();
+        tx.gas_price = GAS_PRICE.into();
+        tx
+    };
+
+    // validate pre-state
+    test_utils::validate_address_balance_and_nonce(
+        &runner,
+        source_address,
+        INITIAL_BALANCE,
+        INITIAL_NONCE.into(),
+    );
+    test_utils::validate_address_balance_and_nonce(&runner, dest_address, Wei::zero(), 0.into());
+
+    // attempt transfer
+    let err = runner
+        .submit_with_signer(&mut source_account, transaction)
+        .unwrap_err();
+    let error_message = format!("{:?}", err);
+    assert!(error_message.contains("ERR_OUT_OF_FUND"));
+
+    // validate post-state
+    let relayer =
+        types::near_account_to_evm_address(runner.context.predecessor_account_id.as_bytes());
+    test_utils::validate_address_balance_and_nonce(
+        &runner,
+        source_address,
+        INITIAL_BALANCE,
+        // nonce is still incremented since the transaction was otherwise valid
+        (INITIAL_NONCE + 1).into(),
+    );
+    test_utils::validate_address_balance_and_nonce(&runner, dest_address, Wei::zero(), 0.into());
+    test_utils::validate_address_balance_and_nonce(&runner, relayer, Wei::zero(), 0.into());
 }
 
 fn initialize_transfer() -> (test_utils::AuroraRunner, test_utils::Signer, Address) {

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -43,17 +43,17 @@ impl EthTransaction {
         }
     }
 
-    pub fn gas_limit(&self) -> &U256 {
+    pub fn gas_limit(&self) -> U256 {
         match self {
-            Self::Legacy(tx) => &tx.transaction.gas,
-            Self::AccessList(tx) => &tx.transaction_data.gas_limit,
+            Self::Legacy(tx) => tx.transaction.gas,
+            Self::AccessList(tx) => tx.transaction_data.gas_limit,
         }
     }
 
-    pub fn gas_price(&self) -> &U256 {
+    pub fn gas_price(&self) -> U256 {
         match self {
-            Self::Legacy(tx) => &tx.transaction.gas_price,
-            Self::AccessList(tx) => &tx.transaction_data.gas_price,
+            Self::Legacy(tx) => tx.transaction.gas_price,
+            Self::AccessList(tx) => tx.transaction_data.gas_price,
         }
     }
 

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -50,6 +50,13 @@ impl EthTransaction {
         }
     }
 
+    pub fn gas_price(&self) -> &U256 {
+        match self {
+            Self::Legacy(tx) => &tx.transaction.gas_price,
+            Self::AccessList(tx) => &tx.transaction_data.gas_price,
+        }
+    }
+
     pub fn destructure(
         self,
     ) -> (

--- a/src/types.rs
+++ b/src/types.rs
@@ -12,7 +12,6 @@ use ethabi::{ParamType, Token};
 #[cfg(not(feature = "contract"))]
 use sha3::{Digest, Keccak256};
 
-use crate::engine::EngineResult;
 use crate::log_entry::LogEntry;
 use crate::sdk;
 
@@ -422,7 +421,7 @@ pub(crate) trait SdkProcess<T> {
     fn sdk_process(self);
 }
 
-impl<T: AsRef<[u8]>> SdkProcess<T> for EngineResult<T> {
+impl<T: AsRef<[u8]>, E: AsRef<[u8]>> SdkProcess<T> for Result<T, E> {
     fn sdk_process(self) {
         match self {
             Ok(r) => sdk::return_output(r.as_ref()),

--- a/src/types.rs
+++ b/src/types.rs
@@ -169,7 +169,7 @@ impl Proof {
 }
 
 /// Newtype to distinguish balances (denominated in Wei) from other U256 types.
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Default)]
+#[derive(Debug, Eq, PartialEq, PartialOrd, Ord, Copy, Clone, Default)]
 pub struct Wei(U256);
 impl Wei {
     const ETH_TO_WEI: U256 = U256([1_000_000_000_000_000_000, 0, 0, 0]);
@@ -205,6 +205,14 @@ impl Wei {
 
     pub fn raw(self) -> U256 {
         self.0
+    }
+
+    pub fn checked_sub(self, other: Self) -> Option<Self> {
+        self.0.checked_sub(other.0).map(Self)
+    }
+
+    pub fn checked_add(self, other: Self) -> Option<Self> {
+        self.0.checked_add(other.0).map(Self)
     }
 }
 impl prelude::Sub for Wei {


### PR DESCRIPTION
Someday we will require gas prices to be non-zero in order to cover the cost of running transactions on NEAR. This PR adds functionality to charge the transaction signer's address according to the gas limit and price, then pay the relayer's address based on the used gas, refunding the rest to the transaction signer.

Note: it is intentional that this only impacts the `submit` function because `call` is near-native in the sense that the NEAR transaction must have been signed by an access key for the corresponding account, therefore the caller is covering their own NEAR costs.