### PR TITLE
Return actual status of a transaction

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -130,6 +130,9 @@ impl ExitIntoResult for ExitReason {
         use ExitReason::*;
         match self {
             Succeed(_) | Revert(_) => Ok(()),
+            Error(ExitError::OutOfOffset)
+            | Error(ExitError::OutOfFund)
+            | Error(ExitError::OutOfGas) => Ok(()),
             Error(e) => Err(e.into()),
             Fatal(e) => Err(e.into()),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -607,21 +607,6 @@ mod contract {
         sdk::return_output(&data[..]);
     }
 
-    #[cfg(feature = "integration-test")]
-    #[no_mangle]
-    pub extern "C" fn mint_account() {
-        use crate::parameters::WithdrawCallArgs;
-        // This function has nothing to do with withdraw, it just so happens that
-        // `WithdrawCallArgs` contains all the information I need, and I am being lazy since
-        // this is meant to be a minimal reproduction of a bug.
-        let args: WithdrawCallArgs = sdk::read_input_borsh().sdk_expect("yo");
-        let amount = crate::types::Wei::new(args.amount.into());
-        let address = Address(args.recipient_address);
-        Engine::set_balance(&address, &amount);
-        Engine::set_nonce(&address, &U256::zero());
-        Engine::set_code(&address, &[]);
-    }
-
     ///
     /// Utility methods.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -607,6 +607,21 @@ mod contract {
         sdk::return_output(&data[..]);
     }
 
+    #[cfg(feature = "integration-test")]
+    #[no_mangle]
+    pub extern "C" fn mint_account() {
+        use crate::parameters::WithdrawCallArgs;
+        // This function has nothing to do with withdraw, it just so happens that
+        // `WithdrawCallArgs` contains all the information I need, and I am being lazy since
+        // this is meant to be a minimal reproduction of a bug.
+        let args: WithdrawCallArgs = sdk::read_input_borsh().sdk_expect("yo");
+        let amount = crate::types::Wei::new(args.amount.into());
+        let address = Address(args.recipient_address);
+        Engine::set_balance(&address, &amount);
+        Engine::set_nonce(&address, &U256::zero());
+        Engine::set_code(&address, &[]);
+    }
+
     ///
     /// Utility methods.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -607,6 +607,27 @@ mod contract {
         sdk::return_output(&data[..]);
     }
 
+    /// Function used to create accounts for tests
+    #[cfg(feature = "integration-test")]
+    #[no_mangle]
+    pub extern "C" fn mint_account() {
+        use evm::backend::ApplyBackend;
+
+        let args: ([u8; 20], u64, u64) = sdk::read_input_borsh().sdk_expect("ERR_ARGS");
+        let address = Address(args.0);
+        let nonce = U256::from(args.1);
+        let balance = U256::from(args.2);
+        let mut engine = Engine::new(address).sdk_unwrap();
+        let state_change = evm::backend::Apply::Modify {
+            address,
+            basic: evm::backend::Basic { balance, nonce },
+            code: None,
+            storage: core::iter::empty(),
+            reset_storage: false,
+        };
+        engine.apply(core::iter::once(state_change), core::iter::empty(), false);
+    }
+
     ///
     /// Utility methods.
     ///

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -61,28 +61,31 @@ impl From<Log> for ResultLog {
     }
 }
 
+/// The status of a transaction.
 #[derive(Debug, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
-pub enum EvmStatus {
-    Succeed,
-    Revert,
+pub enum TransactionStatus {
+    Succeed(Vec<u8>),
+    Revert(Vec<u8>),
     OutOfGas,
     OutOfFund,
     OutOfOffset,
+    CallTooDeep,
 }
 
-impl EvmStatus {
+impl TransactionStatus {
     pub fn is_ok(&self) -> bool {
-        *self == EvmStatus::Succeed
+        matches!(*self, TransactionStatus::Succeed(_))
     }
 
     pub fn is_revert(&self) -> bool {
-        *self == EvmStatus::Revert
+        matches!(*self, TransactionStatus::Revert(_))
     }
 
     pub fn is_fail(&self) -> bool {
-        *self == EvmStatus::OutOfGas
-            || *self == EvmStatus::OutOfFund
-            || *self == EvmStatus::OutOfOffset
+        *self == TransactionStatus::OutOfGas
+            || *self == TransactionStatus::OutOfFund
+            || *self == TransactionStatus::OutOfOffset
+            || *self == TransactionStatus::CallTooDeep
     }
 }
 
@@ -90,9 +93,8 @@ impl EvmStatus {
 /// and `deploy_with_input` methods.
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 pub struct SubmitResult {
-    pub status: EvmStatus,
+    pub status: TransactionStatus,
     pub gas_used: u64,
-    pub result: Vec<u8>,
     pub logs: Vec<ResultLog>,
 }
 

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -89,6 +89,19 @@ impl TransactionStatus {
     }
 }
 
+impl AsRef<[u8]> for TransactionStatus {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            Self::Succeed(_) => b"SUCCESS",
+            Self::Revert(_) => b"ERR_REVERT",
+            Self::OutOfFund => b"ERR_OUT_OF_FUND",
+            Self::OutOfGas => b"ERR_OUT_OF_GAS",
+            Self::OutOfOffset => b"ERR_OUT_OF_OFFSET",
+            Self::CallTooDeep => b"ERR_CALL_TOO_DEEP",
+        }
+    }
+}
+
 /// Borsh-encoded parameters for the `call`, `call_with_args`, `deploy_code`,
 /// and `deploy_with_input` methods.
 #[derive(Debug, BorshSerialize, BorshDeserialize)]

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -61,11 +61,36 @@ impl From<Log> for ResultLog {
     }
 }
 
+#[derive(Debug, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
+pub enum EvmStatus {
+    Succeed,
+    Revert,
+    OutOfGas,
+    OutOfFund,
+    OutOfOffset,
+}
+
+impl EvmStatus {
+    pub fn is_ok(&self) -> bool {
+        *self == EvmStatus::Succeed
+    }
+
+    pub fn is_revert(&self) -> bool {
+        *self == EvmStatus::Revert
+    }
+
+    pub fn is_fail(&self) -> bool {
+        *self == EvmStatus::OutOfGas
+            || *self == EvmStatus::OutOfFund
+            || *self == EvmStatus::OutOfOffset
+    }
+}
+
 /// Borsh-encoded parameters for the `call`, `call_with_args`, `deploy_code`,
 /// and `deploy_with_input` methods.
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 pub struct SubmitResult {
-    pub status: bool,
+    pub status: EvmStatus,
     pub gas_used: u64,
     pub result: Vec<u8>,
     pub logs: Vec<ResultLog>,

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -94,7 +94,7 @@ impl AsRef<[u8]> for TransactionStatus {
         match self {
             Self::Succeed(_) => b"SUCCESS",
             Self::Revert(_) => b"ERR_REVERT",
-            Self::OutOfFund => b"ERR_OUT_OF_FUND",
+            Self::OutOfFund => b"ERR_OUT_OF_FUNDS",
             Self::OutOfGas => b"ERR_OUT_OF_GAS",
             Self::OutOfOffset => b"ERR_OUT_OF_OFFSET",
             Self::CallTooDeep => b"ERR_CALL_TOO_DEEP",

--- a/src/test_utils/exit_precompile.rs
+++ b/src/test_utils/exit_precompile.rs
@@ -78,7 +78,7 @@ impl Tester {
 
         let result = runner.submit_transaction(&signer.secret_key, tx).unwrap();
 
-        if result.status {
+        if result.status.is_ok() {
             Ok(ethabi::decode(output_type, result.result.as_slice()).unwrap())
         } else {
             Err(result)

--- a/src/test_utils/exit_precompile.rs
+++ b/src/test_utils/exit_precompile.rs
@@ -1,6 +1,6 @@
 use crate::parameters::SubmitResult;
 use crate::prelude::{Address, U256};
-use crate::test_utils::{solidity, AuroraRunner, Signer};
+use crate::test_utils::{self, solidity, AuroraRunner, Signer};
 use crate::transaction::LegacyEthTransaction;
 
 pub(crate) struct TesterConstructor(pub solidity::ContractConstructor);
@@ -79,7 +79,8 @@ impl Tester {
         let result = runner.submit_transaction(&signer.secret_key, tx).unwrap();
 
         if result.status.is_ok() {
-            Ok(ethabi::decode(output_type, result.result.as_slice()).unwrap())
+            let result = test_utils::unwrap_success(result);
+            Ok(ethabi::decode(output_type, result.as_slice()).unwrap())
         } else {
             Err(result)
         }

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -281,7 +281,7 @@ impl AuroraRunner {
         assert!(maybe_err.is_none());
         let submit_result =
             SubmitResult::try_from_slice(&output.unwrap().return_data.as_value().unwrap()).unwrap();
-        let address = Address::from_slice(&submit_result.result);
+        let address = Address::from_slice(&submit_result);
         let contract_constructor: ContractConstructor = contract_constructor.into();
         DeployedContract {
             abi: contract_constructor.abi,

--- a/src/test_utils/self_destruct.rs
+++ b/src/test_utils/self_destruct.rs
@@ -1,6 +1,6 @@
 use crate::parameters::FunctionCallArgs;
 use crate::prelude::Address;
-use crate::test_utils::{solidity, AuroraRunner, Signer};
+use crate::test_utils::{self, solidity, AuroraRunner, Signer};
 use crate::transaction::LegacyEthTransaction;
 use borsh::BorshSerialize;
 use primitive_types::U256;
@@ -73,8 +73,9 @@ impl SelfDestructFactory {
         };
 
         let result = runner.submit_transaction(&signer.secret_key, tx).unwrap();
+        let result = test_utils::unwrap_success(result);
 
-        Address::from_slice(&result.result[12..])
+        Address::from_slice(&result[12..])
     }
 }
 
@@ -111,11 +112,10 @@ impl SelfDestruct {
         };
 
         let result = runner.submit_transaction(&signer.secret_key, tx).unwrap();
+        let result = test_utils::unwrap_success(result);
 
-        if result.result.len() == 32 {
-            Some(u128::from_be_bytes(
-                result.result[16..32].try_into().unwrap(),
-            ))
+        if result.len() == 32 {
+            Some(u128::from_be_bytes(result[16..32].try_into().unwrap()))
         } else {
             None
         }

--- a/src/tests/erc20.rs
+++ b/src/tests/erc20.rs
@@ -139,8 +139,7 @@ fn erc20_transfer_insufficient_balance() {
             contract.transfer(dest_address, (2 * INITIAL_BALANCE).into(), nonce)
         })
         .unwrap();
-    assert!(outcome.status.is_revert()); // status == false means execution error
-    let message = parse_erc20_error_message(&outcome.result);
+    let message = parse_erc20_error_message(&test_utils::unwrap_revert(outcome));
     assert_eq!(&message, "&ERC20: transfer amount exceeds balance");
 
     // Validate post-state
@@ -201,9 +200,11 @@ fn get_address_erc20_balance(
     address: Address,
     contract: &ERC20,
 ) -> U256 {
-    let outcome = runner.submit_with_signer(signer, |nonce| contract.balance_of(address, nonce));
-    assert!(outcome.is_ok());
-    U256::from_big_endian(&outcome.unwrap().result)
+    let outcome = runner
+        .submit_with_signer(signer, |nonce| contract.balance_of(address, nonce))
+        .unwrap();
+    let output = test_utils::unwrap_success(outcome);
+    U256::from_big_endian(&output)
 }
 
 fn parse_erc20_error_message(result: &[u8]) -> String {

--- a/src/tests/erc20.rs
+++ b/src/tests/erc20.rs
@@ -1,4 +1,4 @@
-use crate::parameters::EvmStatus;
+use crate::parameters::TransactionStatus;
 use crate::prelude::{Address, U256};
 use crate::test_utils::{
     self,
@@ -63,7 +63,7 @@ fn erc20_mint_out_of_gas() {
     mint_tx.gas = U256::from(67_000);
     let outcome = runner.submit_transaction(&source_account.secret_key, mint_tx);
     let error = outcome.unwrap();
-    assert_eq!(error.status, EvmStatus::OutOfGas);
+    assert_eq!(error.status, TransactionStatus::OutOfGas);
 
     // Validate post-state
     test_utils::validate_address_balance_and_nonce(
@@ -184,7 +184,7 @@ fn deploy_erc_20_out_of_gas() {
     deploy_transaction.gas = U256::from(3_200_000);
     let outcome = runner.submit_transaction(&source_account, deploy_transaction);
     let error = outcome.unwrap();
-    assert_eq!(error.status, EvmStatus::OutOfGas);
+    assert_eq!(error.status, TransactionStatus::OutOfGas);
 
     // Validate post-state
     test_utils::validate_address_balance_and_nonce(

--- a/src/tests/erc20_connector.rs
+++ b/src/tests/erc20_connector.rs
@@ -139,7 +139,8 @@ impl test_utils::AuroraRunner {
         let input = build_input("balanceOf(address)", &[Token::Address(target.into())]);
         let result = self.evm_call(token, input, origin);
         result.check_ok();
-        U256::from_big_endian(result.submit_result().result.as_slice())
+        let output = test_utils::unwrap_success(result.submit_result());
+        U256::from_big_endian(output.as_slice())
     }
 
     pub fn mint(

--- a/src/tests/sanity.rs
+++ b/src/tests/sanity.rs
@@ -1,5 +1,5 @@
-use crate::parameters::{EvmStatus, SubmitResult};
-use crate::prelude::{Address, U256};
+use crate::parameters::TransactionStatus;
+use crate::prelude::Address;
 use crate::test_utils;
 use crate::types::{Wei, ERC20_MINT_SELECTOR};
 use borsh::BorshSerialize;
@@ -71,7 +71,7 @@ fn test_eth_transfer_insufficient_balance() {
             test_utils::transfer(dest_address, INITIAL_BALANCE + INITIAL_BALANCE, nonce)
         })
         .unwrap();
-    assert_eq!(result.status, EvmStatus::OutOfFund);
+    assert_eq!(result.status, TransactionStatus::OutOfFund);
 
     // validate post-state
     test_utils::validate_address_balance_and_nonce(

--- a/src/tests/sanity.rs
+++ b/src/tests/sanity.rs
@@ -1,7 +1,8 @@
-use crate::parameters::EvmStatus;
-use crate::prelude::Address;
+use crate::parameters::{EvmStatus, SubmitResult};
+use crate::prelude::{Address, U256};
 use crate::test_utils;
 use crate::types::{Wei, ERC20_MINT_SELECTOR};
+use borsh::BorshSerialize;
 use secp256k1::SecretKey;
 use std::path::{Path, PathBuf};
 
@@ -220,5 +221,76 @@ fn test_block_hash_contract() {
 
     if result.status.is_fail() {
         panic!("{}", String::from_utf8_lossy(&result.result));
+    }
+}
+
+// Same as `test_eth_transfer_insufficient_balance` above, except runs through
+// `near-sdk-sim` instead of `near-vm-runner`. This is important because `near-sdk-sim`
+// has more production logic, in particular, state revert on contract panic.
+// TODO: should be able to generalize the `call` backend of `AuroraRunner` so that this
+//       test does not need to be written twice.
+#[test]
+fn test_eth_transfer_insufficient_balance_sim() {
+    use crate::tests::state_migration;
+
+    // initalize engine contract
+    let aurora = state_migration::deploy_evm();
+    let mut signer = test_utils::Signer::random();
+    let address = test_utils::address_from_secret_key(&signer.secret_key);
+
+    let args = (address.0, INITIAL_NONCE, INITIAL_BALANCE.raw().low_u64());
+    aurora
+        .call("mint_account", &args.try_to_vec().unwrap())
+        .assert_success();
+
+    // validate pre-state
+    assert_eq!(
+        query_address(&address, "get_nonce", &aurora),
+        U256::from(INITIAL_NONCE),
+    );
+    assert_eq!(
+        query_address(&address, "get_balance", &aurora),
+        INITIAL_BALANCE.raw(),
+    );
+
+    // Run transaction which will fail (transfer more than current balance)
+    let nonce = signer.use_nonce();
+    let tx = test_utils::transfer(
+        Address([1; 20]),
+        INITIAL_BALANCE + INITIAL_BALANCE,
+        nonce.into(),
+    );
+    let signed_tx = test_utils::sign_transaction(
+        tx,
+        Some(test_utils::AuroraRunner::default().chain_id),
+        &signer.secret_key,
+    );
+    let call_result = aurora.call("submit", rlp::encode(&signed_tx).as_ref());
+    let result: SubmitResult = call_result.unwrap_borsh();
+    assert_eq!(result.status, EvmStatus::OutOfFund);
+
+    // validate post-state
+    assert_eq!(
+        query_address(&address, "get_nonce", &aurora),
+        U256::from(INITIAL_NONCE + 1),
+    );
+    assert_eq!(
+        query_address(&address, "get_balance", &aurora),
+        INITIAL_BALANCE.raw(),
+    );
+
+    // helper function
+    fn query_address(
+        address: &Address,
+        method: &str,
+        aurora: &state_migration::AuroraAccount,
+    ) -> U256 {
+        let x = aurora.call(method, &address.0);
+        match &x.outcome().status {
+            near_sdk_sim::transaction::ExecutionStatus::SuccessValue(b) => {
+                U256::from_big_endian(&b)
+            }
+            other => panic!("Unexpected outcome: {:?}", other),
+        }
     }
 }

--- a/src/tests/sanity.rs
+++ b/src/tests/sanity.rs
@@ -1,5 +1,5 @@
-use crate::parameters::TransactionStatus;
-use crate::prelude::Address;
+use crate::parameters::{SubmitResult, TransactionStatus};
+use crate::prelude::{Address, U256};
 use crate::test_utils;
 use crate::types::{Wei, ERC20_MINT_SELECTOR};
 use borsh::BorshSerialize;
@@ -219,9 +219,7 @@ fn test_block_hash_contract() {
         })
         .unwrap();
 
-    if result.status.is_fail() {
-        panic!("{}", String::from_utf8_lossy(&result.result));
-    }
+    test_utils::panic_on_fail(result.status);
 }
 
 // Same as `test_eth_transfer_insufficient_balance` above, except runs through
@@ -267,7 +265,7 @@ fn test_eth_transfer_insufficient_balance_sim() {
     );
     let call_result = aurora.call("submit", rlp::encode(&signed_tx).as_ref());
     let result: SubmitResult = call_result.unwrap_borsh();
-    assert_eq!(result.status, EvmStatus::OutOfFund);
+    assert_eq!(result.status, TransactionStatus::OutOfFund);
 
     // validate post-state
     assert_eq!(

--- a/src/tests/standard_precompiles.rs
+++ b/src/tests/standard_precompiles.rs
@@ -32,7 +32,7 @@ fn standard_precompiles() {
         .unwrap();
 
     // status == false indicates failure
-    if !outcome.status {
+    if outcome.status.is_fail() {
         panic!("{}", String::from_utf8_lossy(&outcome.result))
     }
 }

--- a/src/tests/standard_precompiles.rs
+++ b/src/tests/standard_precompiles.rs
@@ -31,8 +31,5 @@ fn standard_precompiles() {
         .submit_transaction(&source_account, test_all_tx)
         .unwrap();
 
-    // status == false indicates failure
-    if outcome.status.is_fail() {
-        panic!("{}", String::from_utf8_lossy(&outcome.result))
-    }
+    test_utils::panic_on_fail(outcome.status);
 }

--- a/src/tests/state_migration.rs
+++ b/src/tests/state_migration.rs
@@ -2,12 +2,12 @@ use crate::parameters::NewCallArgs;
 use crate::prelude::U256;
 use crate::test_utils::{self, AuroraRunner};
 use crate::types;
+use crate::types::Wei;
 use borsh::BorshSerialize;
 use near_sdk_sim::{ExecutionResult, UserAccount};
 use std::fs;
 use std::path::Path;
 use std::process::Command;
-use crate::types::Wei;
 
 #[test]
 fn test_state_migration() {
@@ -39,9 +39,11 @@ fn test_state_revert() {
     // create account
     let args = crate::parameters::WithdrawCallArgs {
         recipient_address: address.0,
-        amount: 1_000_000
+        amount: 1_000_000,
     };
-    aurora.call("mint_account", &args.try_to_vec().unwrap()).assert_success();
+    aurora
+        .call("mint_account", &args.try_to_vec().unwrap())
+        .assert_success();
 
     // confirm nonce is zero
     let x = aurora.call("get_nonce", &address.0);
@@ -53,8 +55,16 @@ fn test_state_revert() {
 
     // try operation that fails (transfer more eth than we have)
     let nonce = signer.use_nonce();
-    let tx = test_utils::transfer(crate::prelude::Address([0; 20]), Wei::new_u64(2_000_000), nonce.into());
-    let signed_tx = test_utils::sign_transaction(tx, Some(AuroraRunner::default().chain_id), &signer.secret_key);
+    let tx = test_utils::transfer(
+        crate::prelude::Address([0; 20]),
+        Wei::new_u64(2_000_000),
+        nonce.into(),
+    );
+    let signed_tx = test_utils::sign_transaction(
+        tx,
+        Some(AuroraRunner::default().chain_id),
+        &signer.secret_key,
+    );
     let x = aurora.call("submit", rlp::encode(&signed_tx).as_ref());
     println!("{:?}", x);
 

--- a/src/tests/state_migration.rs
+++ b/src/tests/state_migration.rs
@@ -1,8 +1,7 @@
-use crate::parameters::NewCallArgs;
+use crate::parameters::{InitCallArgs, NewCallArgs};
 use crate::prelude::U256;
 use crate::test_utils::AuroraRunner;
 use crate::types;
-use crate::types::Wei;
 use borsh::BorshSerialize;
 use near_sdk_sim::{ExecutionResult, UserAccount};
 use std::fs;
@@ -27,7 +26,7 @@ fn test_state_migration() {
     assert_eq!(some_numbers, [3, 1, 4, 1, 5, 9, 2]);
 }
 
-fn deploy_evm() -> AuroraAccount {
+pub fn deploy_evm() -> AuroraAccount {
     let aurora_runner = AuroraRunner::default();
     let main_account = near_sdk_sim::init_simulator(None);
     let contract_account = main_account.deploy(
@@ -35,10 +34,11 @@ fn deploy_evm() -> AuroraAccount {
         aurora_runner.aurora_account_id.parse().unwrap(),
         5 * near_sdk_sim::STORAGE_AMOUNT,
     );
+    let prover_account = "prover.near".to_string();
     let new_args = NewCallArgs {
         chain_id: types::u256_to_arr(&U256::from(aurora_runner.chain_id)),
         owner_id: main_account.account_id.clone().into(),
-        bridge_prover_id: "prover.near".to_string(),
+        bridge_prover_id: prover_account.clone(),
         upgrade_delay_blocks: 1,
     };
     main_account
@@ -50,19 +50,32 @@ fn deploy_evm() -> AuroraAccount {
             0,
         )
         .assert_success();
+    let init_args = InitCallArgs {
+        prover_account,
+        eth_custodian_address: "d045f7e19B2488924B97F9c145b5E51D0D895A65".to_string(),
+    };
+    contract_account
+        .call(
+            contract_account.account_id.clone(),
+            "new_eth_connector",
+            &init_args.try_to_vec().unwrap(),
+            near_sdk_sim::DEFAULT_GAS,
+            0,
+        )
+        .assert_success();
     AuroraAccount {
         user: main_account,
         contract: contract_account,
     }
 }
 
-struct AuroraAccount {
+pub struct AuroraAccount {
     user: UserAccount,
     contract: UserAccount,
 }
 
 impl AuroraAccount {
-    fn call(&self, method: &str, args: &[u8]) -> ExecutionResult {
+    pub fn call(&self, method: &str, args: &[u8]) -> ExecutionResult {
         self.user.call(
             self.contract.account_id.clone(),
             method,

--- a/src/tests/state_migration.rs
+++ b/src/tests/state_migration.rs
@@ -1,6 +1,6 @@
 use crate::parameters::NewCallArgs;
 use crate::prelude::U256;
-use crate::test_utils::{self, AuroraRunner};
+use crate::test_utils::AuroraRunner;
 use crate::types;
 use crate::types::Wei;
 use borsh::BorshSerialize;
@@ -25,57 +25,6 @@ fn test_state_migration() {
     result.assert_success();
     let some_numbers: [u32; 7] = result.unwrap_borsh();
     assert_eq!(some_numbers, [3, 1, 4, 1, 5, 9, 2]);
-}
-
-// This test has nothing to do with migration. I'm just putting it here for convenience
-// because it does require near-sdk-sim and the state migration test already had the
-// `deploy_evm()` function to set everything up.
-#[test]
-fn test_state_revert() {
-    let aurora = deploy_evm();
-    let mut signer = test_utils::Signer::random();
-    let address = test_utils::address_from_secret_key(&signer.secret_key);
-
-    // create account
-    let args = crate::parameters::WithdrawCallArgs {
-        recipient_address: address.0,
-        amount: 1_000_000,
-    };
-    aurora
-        .call("mint_account", &args.try_to_vec().unwrap())
-        .assert_success();
-
-    // confirm nonce is zero
-    let x = aurora.call("get_nonce", &address.0);
-    let observed_nonce = match &x.outcome().status {
-        near_sdk_sim::transaction::ExecutionStatus::SuccessValue(b) => U256::from_big_endian(&b),
-        _ => panic!("?"),
-    };
-    assert_eq!(observed_nonce, U256::zero());
-
-    // try operation that fails (transfer more eth than we have)
-    let nonce = signer.use_nonce();
-    let tx = test_utils::transfer(
-        crate::prelude::Address([0; 20]),
-        Wei::new_u64(2_000_000),
-        nonce.into(),
-    );
-    let signed_tx = test_utils::sign_transaction(
-        tx,
-        Some(AuroraRunner::default().chain_id),
-        &signer.secret_key,
-    );
-    let x = aurora.call("submit", rlp::encode(&signed_tx).as_ref());
-    println!("{:?}", x);
-
-    // check nonce again; it should have incremented because the transaction was valid
-    // (even though its execution failed)
-    let x = aurora.call("get_nonce", &address.0);
-    let observed_nonce = match &x.outcome().status {
-        near_sdk_sim::transaction::ExecutionStatus::SuccessValue(b) => U256::from_big_endian(&b),
-        _ => panic!("?"),
-    };
-    assert_eq!(observed_nonce, U256::one());
 }
 
 fn deploy_evm() -> AuroraAccount {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,8 +1,6 @@
-use crate::prelude::{self, Address, String, ToString, Vec, H256, U256};
+use crate::prelude::{self, str, Address, String, ToString, Vec, H256, U256};
 #[cfg(not(feature = "contract"))]
 use crate::prelude::{format, vec};
-
-use crate::prelude::str;
 use borsh::{BorshDeserialize, BorshSerialize};
 use ethabi::{Event, EventParam, Hash, Log, RawLog};
 


### PR DESCRIPTION
In response to the issue https://github.com/aurora-is-near/aurora-engine/issues/216 that @birchmd had found, it is true that certain errors should still be considered "successful" even though the execution had in fact failed. This fixes that.

Unfortunately, this is a breaking pub API change, but functionally similar.

DO note that this is missing an [important test](https://github.com/birchmd/aurora-engine/blob/state-revert-bug/src/tests/state_migration.rs#L34) which @birchmd had created as I am unsure if this test is actually correct, but I am currently unsure how such a test could be created.

Closes https://github.com/aurora-is-near/aurora-engine/issues/216.