### PR TITLE
Fix: Update lock files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1461,9 +1461,9 @@ checksum = "0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189"
 
 [[package]]
 name = "git2"
-version = "0.13.19"
+version = "0.13.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17929de7239dea9f68aa14f94b2ab4974e7b24c1314275ffcc12a7758172fa18"
+checksum = "d9831e983241f8c5591ed53f17d874833e2fa82cac2625f3888c50cbfe136cba"
 dependencies = [
  "bitflags",
  "libc",
@@ -1734,9 +1734,9 @@ checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.20+1.1.0"
+version = "0.12.21+1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e2f09917e00b9ad194ae72072bb5ada2cca16d8171a43e91ddba2afbb02664b"
+checksum = "86271bacd72b2b9e854c3dcfb82efd538f15f870e4c11af66900effb462f6825"
 dependencies = [
  "cc",
  "libc",

--- a/etc/state-migration-test/Cargo.lock
+++ b/etc/state-migration-test/Cargo.lock
@@ -708,7 +708,7 @@ dependencies = [
 [[package]]
 name = "rjson"
 version = "0.3.2"
-source = "git+https://github.com/aurora-is-near/rjson#cc3da9495e7e520900d66d2b517539f74fff93cf"
+source = "git+https://github.com/aurora-is-near/rjson?rev=cc3da949#cc3da9495e7e520900d66d2b517539f74fff93cf"
 
 [[package]]
 name = "rlp"


### PR DESCRIPTION
`make check` was not working after #221 because `git2` needs to also be updated.