### PR TITLE
Fix(testnet): Method to fix balance of aurora account

### DIFF
--- a/src/connector.rs
+++ b/src/connector.rs
@@ -26,7 +26,7 @@ pub(crate) const PAUSE_WITHDRAW: PausedMask = 1 << 1;
 #[derive(BorshSerialize, BorshDeserialize)]
 pub struct EthConnectorContract {
     contract: EthConnector,
-    ft: FungibleToken,
+    pub ft: FungibleToken,
     paused_mask: PausedMask,
 }
 
@@ -578,7 +578,7 @@ impl EthConnectorContract {
     }
 
     /// Save eth-connector contract data
-    fn save_ft_contract(&mut self) {
+    pub(crate) fn save_ft_contract(&mut self) {
         sdk::save_contract(
             &Self::get_contract_key(&EthConnectorStorageId::FungibleToken),
             &self.ft,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -637,6 +637,43 @@ mod contract {
         );
     }
 
+    /// Due to the design change to stop minting and burning bridged ETH tokens
+    /// (see https://github.com/aurora-is-near/aurora-engine/pull/133 ),
+    /// there is currently an incorrect number of tokens in the Aurora NEP-141 token
+    /// account. This issue only impacts testnet because at the time the design was changed
+    /// the eth-connector had not been deployed to mainnet. The purpose of this function is
+    /// to mint the correct number of tokens in order to make up for the ones that were burned
+    /// before the design change in #133.
+    #[cfg(feature = "testnet")]
+    #[no_mangle]
+    pub extern "C" fn balance_evm_and_nep_141() {
+        use crate::precompiles::native::{ExitToEthereum, ExitToNear};
+        use crate::prelude::String;
+
+        let mut connector = EthConnectorContract::get_instance();
+        let aurora_account = unsafe { String::from_utf8_unchecked(sdk::current_account_id()) };
+        let aurora_nep_141_balance = connector.ft.ft_balance_of(&aurora_account);
+        let total_evm_balance = connector.ft.ft_total_eth_supply_on_aurora();
+        let exit_to_near_balance = Engine::get_balance(&ExitToNear::ADDRESS).raw().low_u128();
+        let exit_to_eth_balance = Engine::get_balance(&ExitToEthereum::ADDRESS)
+            .raw()
+            .low_u128();
+
+        // ETH sent to the exit precompiles is no longer accessible (and would have already been
+        // transferred from the Aurora account in the NEP-141 contract).
+        let available_evm_balance = total_evm_balance - exit_to_eth_balance - exit_to_near_balance;
+
+        // After #133 it should be true that `aurora_nep_141_balance == available_evm_balance`.
+        // If it is not then we mint tokens to make this the case.
+        if aurora_nep_141_balance < available_evm_balance {
+            let missing_balance = available_evm_balance - aurora_nep_141_balance;
+            connector
+                .ft
+                .internal_deposit_eth_to_near(&aurora_account, missing_balance);
+            connector.save_ft_contract();
+        }
+    }
+
     #[cfg(feature = "integration-test")]
     #[no_mangle]
     pub extern "C" fn verify_log_entry() {

--- a/src/precompiles/mod.rs
+++ b/src/precompiles/mod.rs
@@ -23,7 +23,7 @@ mod hash;
 mod identity;
 mod modexp;
 #[cfg_attr(not(feature = "contract"), allow(dead_code))]
-mod native;
+pub(crate) mod native;
 mod secp256k1;
 
 #[derive(Debug)]

--- a/src/precompiles/native.rs
+++ b/src/precompiles/native.rs
@@ -46,7 +46,7 @@ impl ExitToNear {
     ///
     /// Address: `0xe9217bc70b7ed1f598ddd3199e80b093fa71124f`
     /// This address is computed as: `&keccak("exitToNear")[12..]`
-    pub(super) const ADDRESS: Address =
+    pub(crate) const ADDRESS: Address =
         super::make_address(0xe9217bc7, 0x0b7ed1f598ddd3199e80b093fa71124f);
 }
 
@@ -188,7 +188,7 @@ impl ExitToEthereum {
     ///
     /// Address: `0xb0bd02f6a392af548bdf1cfaee5dfa0eefcc8eab`
     /// This address is computed as: `&keccak("exitToEthereum")[12..]`
-    pub(super) const ADDRESS: Address =
+    pub(crate) const ADDRESS: Address =
         super::make_address(0xb0bd02f6, 0xa392af548bdf1cfaee5dfa0eefcc8eab);
 }
 


### PR DESCRIPTION
**Background:**

Previously we minted and burned bridged ETH in the NEP-141 contract when it became usable in the EVM. However, in #133 we changed that design to instead hold all the ETH currently available in the EVM in the Aurora account on the NEP-141 contract. This change was made because it makes the `ExitToNear` logic much simpler (it is simply a transfer from the Aurora account to the destination account in the NEP-141 contract).

However we did not mint tokens to cover the ones that were burned when they entered the EVM prior to #133. This includes the over 12k ETH that is held by the faucet.

**Issue:**

As a result, the `ExitToNear` functionality is now broken on testnet because the Aurora account in the NEP-141 contract has run out of tokens. Note: this only impacts testnet because #133 was merged before the eth-connector was deployed to mainnet, so mainnet has always had the updated design.

**Solution (this PR):**

This PR introduces a method for testnet only which mints tokens to the Aurora account in the NEP-141 contract, restoring the invariant which exists with the `ExitToNear` design change introduced in #133. Namely, this invariant is that the total available amount of ETH (ETH sent to the exit precompile addresses is no longer available) in the EVM is equal to the balance of the Aurora account in the NEP-141 contract. A test is included to show the method works properly.

This new method only needs to be called one time on testnet, so after this has happened we can revert this PR to avoid confusion in the future.