### PR TITLE
Use math api host functions on mainnet

### DIFF
--- a/src/precompiles/hash.rs
+++ b/src/precompiles/hash.rs
@@ -87,7 +87,7 @@ pub struct RIPEMD160;
 impl RIPEMD160 {
     pub(super) const ADDRESS: Address = super::make_address(0, 3);
 
-    #[cfg(not(feature = "testnet"))]
+    #[cfg(not(feature = "contract"))]
     fn internal_impl(input: &[u8]) -> [u8; 20] {
         use ripemd160::Digest;
         let hash = ripemd160::Ripemd160::digest(input);
@@ -119,9 +119,9 @@ impl Precompile for RIPEMD160 {
         if cost > target_gas {
             Err(ExitError::OutOfGas)
         } else {
-            #[cfg(not(feature = "testnet"))]
+            #[cfg(not(feature = "contract"))]
             let hash = Self::internal_impl(input);
-            #[cfg(feature = "testnet")]
+            #[cfg(feature = "contract")]
             let hash = crate::sdk::ripemd160(input);
             // The result needs to be padded with leading zeros because it is only 20 bytes, but
             // the evm works with 32-byte words.

--- a/src/precompiles/secp256k1.rs
+++ b/src/precompiles/secp256k1.rs
@@ -19,15 +19,15 @@ mod consts {
 pub(crate) fn ecrecover(hash: H256, signature: &[u8]) -> Result<Address, ExitError> {
     assert_eq!(signature.len(), 65);
 
-    #[cfg(feature = "testnet")]
+    #[cfg(feature = "contract")]
     return crate::sdk::ecrecover(hash, signature)
         .map_err(|e| ExitError::Other(Borrowed(e.as_str())));
 
-    #[cfg(not(feature = "testnet"))]
+    #[cfg(not(feature = "contract"))]
     internal_impl(hash, signature)
 }
 
-#[cfg(not(feature = "testnet"))]
+#[cfg(not(feature = "contract"))]
 fn internal_impl(hash: H256, signature: &[u8]) -> Result<Address, ExitError> {
     use sha3::Digest;
 

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -5,11 +5,8 @@ use borsh::{BorshDeserialize, BorshSerialize};
 
 const READ_STORAGE_REGISTER_ID: u64 = 0;
 const INPUT_REGISTER_ID: u64 = 0;
-#[cfg(feature = "testnet")]
 const ECRECOVER_MESSAGE_SIZE: u64 = 32;
-#[cfg(feature = "testnet")]
 const ECRECOVER_SIGNATURE_LENGTH: u64 = 64;
-#[cfg(feature = "testnet")]
 const ECRECOVER_MALLEABILITY_FLAG: u64 = 1;
 
 /// Register used to record evicted values from the storage.
@@ -51,9 +48,7 @@ mod exports {
         fn random_seed(register_id: u64);
         pub(crate) fn sha256(value_len: u64, value_ptr: u64, register_id: u64);
         pub(crate) fn keccak256(value_len: u64, value_ptr: u64, register_id: u64);
-        #[cfg(feature = "testnet")]
         pub(crate) fn ripemd160(value_len: u64, value_ptr: u64, register_id: u64);
-        #[cfg(feature = "testnet")]
         pub(crate) fn ecrecover(
             hash_len: u64,
             hash_ptr: u64,
@@ -393,7 +388,6 @@ pub fn keccak(input: &[u8]) -> H256 {
 }
 
 /// Calls environment ripemd160 on given input.
-#[cfg(feature = "testnet")]
 pub fn ripemd160(input: &[u8]) -> [u8; 20] {
     unsafe {
         const REGISTER_ID: u64 = 1;
@@ -405,7 +399,6 @@ pub fn ripemd160(input: &[u8]) -> [u8; 20] {
 }
 
 /// Recover address from message hash and signature.
-#[cfg(feature = "testnet")]
 pub fn ecrecover(hash: H256, signature: &[u8]) -> Result<crate::prelude::Address, ECRecoverErr> {
     unsafe {
         let hash_ptr = hash.as_ptr() as u64;


### PR DESCRIPTION
NEAR Protocol version 46 is now [live on mainnet](https://explorer.near.org/stats) so we can remove the testnet restriction on `ecrecover` and `ripemd` host functions.