### PR TITLE
Adapt workflows to dockerized runners

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -11,7 +11,6 @@ jobs:
     steps:
       - name: Clone the repository
         uses: actions/checkout@v2
-      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: make release
       - run: ls -lH mainnet-release.wasm
       - name: Upload the mainnet-release.wasm artifact
@@ -34,7 +33,6 @@ jobs:
     steps:
       - name: Clone the repository
         uses: actions/checkout@v2
-      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: make debug
       - run: ls -lH mainnet-debug.wasm
       - name: Upload the mainnet-debug.wasm artifact

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -9,7 +9,6 @@ jobs:
     steps:
       - name: Clone the repository
         uses: actions/checkout@v2
-      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
   clippy:
@@ -18,7 +17,6 @@ jobs:
     steps:
       - name: Clone the repository
         uses: actions/checkout@v2
-      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: make etc/eth-contracts/res/EvmErc20.bin
       - name: Run Contract cargo clippy
         run: cargo clippy --no-default-features --features=contract -- -D warnings

--- a/.github/workflows/scheduled_lints.yml
+++ b/.github/workflows/scheduled_lints.yml
@@ -10,7 +10,6 @@ jobs:
     steps:
       - name: Clone the repository
         uses: actions/checkout@v2
-      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: make etc/eth-contracts/res/EvmErc20.bin
       - name: Update toolchain
         run: rustup update nightly

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,27 +11,33 @@ jobs:
     steps:
       - name: Clone the repository
         uses: actions/checkout@v2
-      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      - name: Cache lookup for target dir
-        run: cache-util -restore -path target -key aurora-engine-target@${{ matrix.net }}net@${{ hashFiles('**/Cargo.lock') }}
+      - name: Restore cache
+        run: |
+          cache-util restore cargo_git cargo_registry sccache yarn_cache
+          cache-util restore aurora-engine-target@${{ matrix.net }}net@${{ hashFiles('**/Cargo.lock') }}:target
       - run: make ${{ matrix.net }}net-test-build
       - name: Run ${{ matrix.net }}net cargo test
         run: cargo test --locked --verbose --features ${{ matrix.net }}net-test
-      - name: Caching target dir
-        run: cache-util -save -move -path target -key aurora-engine-target@${{ matrix.net }}net@${{ hashFiles('**/Cargo.lock') }}
+      - name: Save cache
+        run: |
+          cache-util save cargo_git cargo_registry sccache yarn_cache
+          cache-util msave aurora-engine-target@${{ matrix.net }}net@${{ hashFiles('**/Cargo.lock') }}:target
   bully-build:
     name: Bully build
     runs-on: self-hosted
     steps:
       - name: Clone the repository
         uses: actions/checkout@v2
-      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      - name: Cache lookup for target dir
-        run: cache-util -restore -path target -key aurora-engine-target@bully@${{ hashFiles('**/Cargo.lock') }}
+      - name: Restore cache
+        run: |
+          cache-util restore cargo_git cargo_registry sccache yarn_cache
+          cache-util restore aurora-engine-target@bully@${{ hashFiles('**/Cargo.lock') }}:target
       - run: make mainnet-debug evm-bully=yes
       - run: ls -lH mainnet-debug.wasm
-      - name: Cache target dir
-        run: cache-util -save -move -path target -key aurora-engine-target@bully@${{ hashFiles('**/Cargo.lock') }}
+      - name: Save cache
+        run: |
+          cache-util save cargo_git cargo_registry sccache yarn_cache
+          cache-util msave aurora-engine-target@bully@${{ hashFiles('**/Cargo.lock') }}:target
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0


### PR DESCRIPTION
Runners are finally isolated, so I don't expect problems with sccache anymore.
This commit does:
- Update `cache-util` usage. We need to cache more [things](https://github.com/aurora-is-near/devops-stuff/blob/main/runners/actions-runner/injected/configs/cache-util.json#L3), since runners don't share anything anymore with each other.
- Get rid of manual adding cargo binaries to `$HOME`