### PR TITLE
Fix(blockhash): Move block height to the end of hashing data

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -332,9 +332,9 @@ impl Engine {
             BLOCK_HASH_PREFIX_SIZE + BLOCK_HEIGHT_SIZE + CHAIN_ID_SIZE + account_id.len(),
         );
         data.push(BLOCK_HASH_PREFIX);
-        data.extend_from_slice(&block_height.to_be_bytes());
         data.extend_from_slice(&chain_id);
         data.extend_from_slice(account_id);
+        data.extend_from_slice(&block_height.to_be_bytes());
 
         #[cfg(not(feature = "contract"))]
         {

--- a/src/tests/res/blockhash.sol
+++ b/src/tests/res/blockhash.sol
@@ -6,7 +6,7 @@ contract BlockHash {
 
   function test() public view {
     require(
-      blockhash(0) == hex"a7ac0e4bd5ad1654392b64ecd40a69f983e8ce7c315639a339d19a880902457a", 
+      blockhash(0) == hex"ec035c7409243a343a8fd798077fb0a5f879cc32c9cd31fd07baa2292e4d3d7c",
       "Bad block hash"
     );
   }

--- a/src/tests/sanity.rs
+++ b/src/tests/sanity.rs
@@ -290,7 +290,7 @@ fn test_block_hash() {
 
     assert_eq!(
         hex::encode(block_hash.0).as_str(),
-        "4c8a60b32b74f184438a5e450951570bc1bda37caa7b6a3f178b80395845fb80"
+        "c4a46f076b64877cbd8c5dbfd7bfbbea21a5653b79e3b6d06b6dfb5c88f1c384",
     );
 }
 


### PR DESCRIPTION
The reason for this change is to enable future micro-optimizations. We could cache the sha256 state which has all the static data already included in the hasher, then each hash computation only require pushing the block height and finalizing (rather than always needing to update the sha256 state with all the static data each time).