### PR TITLE
Fix(CI): Ensure solidity artifacts are always recompiled

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,7 @@ jobs:
         run: |
           cache-util restore cargo_git cargo_registry sccache yarn_cache
           cache-util restore aurora-engine-target@${{ matrix.net }}net@${{ hashFiles('**/Cargo.lock') }}:target
+      - run: rm -rf target/solidity_build/
       - run: make ${{ matrix.net }}net-test-build
       - name: Run ${{ matrix.net }}net cargo test
         run: cargo test --locked --verbose --features ${{ matrix.net }}net-test
@@ -32,6 +33,7 @@ jobs:
         run: |
           cache-util restore cargo_git cargo_registry sccache yarn_cache
           cache-util restore aurora-engine-target@bully@${{ hashFiles('**/Cargo.lock') }}:target
+      - run: rm -rf target/solidity_build/
       - run: make mainnet-debug evm-bully=yes
       - run: ls -lH mainnet-debug.wasm
       - name: Save cache


### PR DESCRIPTION
#233 Changed a solidity contract, but the test failed in CI because it did not get recompiled (the compilation step does not happen when the artifact already exists). This ensures solidity artifacts are always recompiled.

An optimization to this would be to check if a `.sol` file was actually changed in the diff and only recompile if there is one.