### PR TITLE
Revert #225

### DIFF
--- a/src/connector.rs
+++ b/src/connector.rs
@@ -26,7 +26,7 @@ pub(crate) const PAUSE_WITHDRAW: PausedMask = 1 << 1;
 #[derive(BorshSerialize, BorshDeserialize)]
 pub struct EthConnectorContract {
     contract: EthConnector,
-    pub ft: FungibleToken,
+    ft: FungibleToken,
     paused_mask: PausedMask,
 }
 
@@ -584,7 +584,7 @@ impl EthConnectorContract {
     }
 
     /// Save eth-connector contract data
-    pub(crate) fn save_ft_contract(&mut self) {
+    fn save_ft_contract(&mut self) {
         sdk::save_contract(
             &Self::get_contract_key(&EthConnectorStorageId::FungibleToken),
             &self.ft,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -645,43 +645,6 @@ mod contract {
         sdk::return_output(json_data.to_string().as_bytes())
     }
 
-    /// Due to the design change to stop minting and burning bridged ETH tokens
-    /// (see https://github.com/aurora-is-near/aurora-engine/pull/133 ),
-    /// there is currently an incorrect number of tokens in the Aurora NEP-141 token
-    /// account. This issue only impacts testnet because at the time the design was changed
-    /// the eth-connector had not been deployed to mainnet. The purpose of this function is
-    /// to mint the correct number of tokens in order to make up for the ones that were burned
-    /// before the design change in #133.
-    #[cfg(feature = "testnet")]
-    #[no_mangle]
-    pub extern "C" fn balance_evm_and_nep_141() {
-        use crate::precompiles::native::{ExitToEthereum, ExitToNear};
-        use crate::prelude::String;
-
-        let mut connector = EthConnectorContract::get_instance();
-        let aurora_account = unsafe { String::from_utf8_unchecked(sdk::current_account_id()) };
-        let aurora_nep_141_balance = connector.ft.ft_balance_of(&aurora_account);
-        let total_evm_balance = connector.ft.ft_total_eth_supply_on_aurora();
-        let exit_to_near_balance = Engine::get_balance(&ExitToNear::ADDRESS).raw().low_u128();
-        let exit_to_eth_balance = Engine::get_balance(&ExitToEthereum::ADDRESS)
-            .raw()
-            .low_u128();
-
-        // ETH sent to the exit precompiles is no longer accessible (and would have already been
-        // transferred from the Aurora account in the NEP-141 contract).
-        let available_evm_balance = total_evm_balance - exit_to_eth_balance - exit_to_near_balance;
-
-        // After #133 it should be true that `aurora_nep_141_balance == available_evm_balance`.
-        // If it is not then we mint tokens to make this the case.
-        if aurora_nep_141_balance < available_evm_balance {
-            let missing_balance = available_evm_balance - aurora_nep_141_balance;
-            connector
-                .ft
-                .internal_deposit_eth_to_near(&aurora_account, missing_balance);
-            connector.save_ft_contract();
-        }
-    }
-
     #[cfg(feature = "integration-test")]
     #[no_mangle]
     pub extern "C" fn verify_log_entry() {

--- a/src/precompiles/mod.rs
+++ b/src/precompiles/mod.rs
@@ -23,7 +23,7 @@ mod hash;
 mod identity;
 mod modexp;
 #[cfg_attr(not(feature = "contract"), allow(dead_code))]
-pub(crate) mod native;
+mod native;
 mod secp256k1;
 
 #[derive(Debug)]

--- a/src/precompiles/native.rs
+++ b/src/precompiles/native.rs
@@ -46,7 +46,7 @@ impl ExitToNear {
     ///
     /// Address: `0xe9217bc70b7ed1f598ddd3199e80b093fa71124f`
     /// This address is computed as: `&keccak("exitToNear")[12..]`
-    pub(crate) const ADDRESS: Address =
+    pub(super) const ADDRESS: Address =
         super::make_address(0xe9217bc7, 0x0b7ed1f598ddd3199e80b093fa71124f);
 }
 
@@ -188,7 +188,7 @@ impl ExitToEthereum {
     ///
     /// Address: `0xb0bd02f6a392af548bdf1cfaee5dfa0eefcc8eab`
     /// This address is computed as: `&keccak("exitToEthereum")[12..]`
-    pub(crate) const ADDRESS: Address =
+    pub(super) const ADDRESS: Address =
         super::make_address(0xb0bd02f6, 0xa392af548bdf1cfaee5dfa0eefcc8eab);
 }
 

--- a/src/tests/sanity.rs
+++ b/src/tests/sanity.rs
@@ -338,69 +338,6 @@ fn test_ft_metadata() {
     );
 }
 
-#[cfg(feature = "testnet-test")]
-#[test]
-fn test_balance_evm_and_nep_141() {
-    use crate::precompiles::native::{ExitToEthereum, ExitToNear};
-
-    let (mut runner, _, _) = initialize_transfer();
-    let caller = runner.aurora_account_id.clone();
-
-    // Include some ETH at the exit precompiles addresses for testing purposes
-    runner.create_address(ExitToNear::ADDRESS, TRANSFER_AMOUNT, U256::zero());
-    runner.create_address(
-        ExitToEthereum::ADDRESS,
-        TRANSFER_AMOUNT + TRANSFER_AMOUNT,
-        U256::zero(),
-    );
-
-    let aurora_balance = |runner: &mut test_utils::AuroraRunner| -> u128 {
-        let (maybe_result, maybe_err) = runner.call(
-            "ft_balance_of",
-            caller.clone(),
-            format!(r#"{{"account_id": "{}"}}"#, runner.aurora_account_id).into_bytes(),
-        );
-        assert!(maybe_err.is_none());
-        let result = maybe_result.unwrap();
-        String::from_utf8(result.return_data.as_value().unwrap())
-            .unwrap()
-            .parse()
-            .unwrap()
-    };
-
-    let evm_balance = |runner: &mut test_utils::AuroraRunner| -> u128 {
-        let exit_to_near_balance = runner.get_balance(ExitToNear::ADDRESS).raw().low_u128();
-        let exit_to_eth_balance = runner.get_balance(ExitToEthereum::ADDRESS).raw().low_u128();
-        let total_evm_balance: u128 = {
-            let (maybe_result, maybe_err) =
-                runner.call("ft_total_eth_supply_on_aurora", caller.clone(), Vec::new());
-            assert!(maybe_err.is_none());
-            let result = maybe_result.unwrap();
-            String::from_utf8(result.return_data.as_value().unwrap())
-                .unwrap()
-                .parse()
-                .unwrap()
-        };
-        total_evm_balance - exit_to_near_balance - exit_to_eth_balance
-    };
-
-    // There is not enough in the Aurora NEP-141 account, relative to how much is in the EVM;
-    assert_eq!(evm_balance(&mut runner), INITIAL_BALANCE.raw().low_u128());
-    assert_eq!(aurora_balance(&mut runner), 0);
-
-    // Call method to restore balance
-    let (_, maybe_err) = runner.call("balance_evm_and_nep_141", caller.clone(), Vec::new());
-    assert!(maybe_err.is_none());
-
-    // Balance is restored
-    assert_eq!(aurora_balance(&mut runner), evm_balance(&mut runner));
-
-    // Calling multiple times is a no-op
-    let (_, maybe_err) = runner.call("balance_evm_and_nep_141", caller.clone(), Vec::new());
-    assert!(maybe_err.is_none());
-    assert_eq!(aurora_balance(&mut runner), evm_balance(&mut runner));
-}
-
 // Same as `test_eth_transfer_insufficient_balance` above, except runs through
 // `near-sdk-sim` instead of `near-vm-runner`. This is important because `near-sdk-sim`
 // has more production logic, in particular, state revert on contract panic.


### PR DESCRIPTION
The `balance_evm_and_nep_141` was called successfully in [this transaction](https://explorer.testnet.near.org/transactions/6o3y937tvCUCD5fVuEFcUU49L6oE3cMXtFp3xCWxGkKB). You can see the balances are now restored from the following CLI output:

```
$ ./bin/near view aurora ft_total_eth_supply_on_aurora
View call: aurora.ft_total_eth_supply_on_aurora()
Log [aurora]: Total ETH supply on Aurora: 12752741701607000064610
1.2752741701607e+22

$ ./bin/near view aurora ft_balance_of '{"account_id" : "aurora"}'
View call: aurora.ft_balance_of({"account_id" : "aurora"})
Log [aurora]: Balance of nETH [aurora]: 12424204949453000064603
1.2424204949453e+22

$ ./lib/aurora.js --network testnet get-balance 0xe9217bc70b7ed1f598ddd3199e80b093fa71124f
55857632000000000007

$ ./lib/aurora.js --network testnet get-balance 0xb0bd02f6a392af548bdf1cfaee5dfa0eefcc8eab
272679120154000000000

$ python3 -c "(12424204949453000064603 + 55857632000000000007 + 272679120154000000000) == 12752741701607000064610"
True
```

Therefore, we can revert the changes made in #225 