### PR TITLE
Drop lazy static in test-utils

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,7 @@ jobs:
       - run: cargo test --features ${{ matrix.net }}net-test
 #      - run: make test-${{ matrix.net }}net
 #      - run: rm -rf target/solidity_build/
+#      - run: rm -rf etc/eth-contracts/res
       - name: Save cache
         run: |
           cache-util save cargo_git cargo_registry sccache yarn_cache
@@ -48,6 +49,7 @@ jobs:
       - run: make mainnet-debug evm-bully=yes
       - run: ls -lH mainnet-debug.wasm
 #      - run: rm -rf target/solidity_build/
+#      - run: rm -rf etc/eth-contracts/res
       - name: Save cache
         run: |
           cache-util save cargo_git cargo_registry sccache yarn_cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,9 +29,6 @@ jobs:
           ls -la target/wasm32-unknown-unknown/release
           ls -la
       - run: cargo test --features ${{ matrix.net }}net-test
-#      - run: make test-${{ matrix.net }}net
-#      - run: rm -rf target/solidity_build/
-#      - run: rm -rf etc/eth-contracts/res
       - name: Save cache
         run: |
           cache-util save cargo_git cargo_registry sccache yarn_cache
@@ -48,8 +45,6 @@ jobs:
           cache-util restore aurora-engine-target@bully@${{ hashFiles('**/Cargo.lock') }}:target
       - run: make mainnet-debug evm-bully=yes
       - run: ls -lH mainnet-debug.wasm
-#      - run: rm -rf target/solidity_build/
-#      - run: rm -rf etc/eth-contracts/res
       - name: Save cache
         run: |
           cache-util save cargo_git cargo_registry sccache yarn_cache

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,7 +129,6 @@ dependencies = [
  "evm-core",
  "git2",
  "hex",
- "lazy-static-include",
  "libsecp256k1",
  "logos",
  "near-crypto 0.1.0 (git+https://github.com/near/nearcore.git?branch=1.20.1)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,6 @@ libsecp256k1 = "0.3.5"
 rand = "0.7.3"
 criterion = "0.3.4"
 git2 = "0.13"
-lazy-static-include = "3.1.1"
 
 [features]
 default = ["sha2", "std"]


### PR DESCRIPTION
As per the CI issues we are having, it is suspected that this may be the cause. So in response, this drops lazy static and instead uses a different kind of conditional compilation.