### PR TITLE
Fix return format of `ft_balance_of`

### DIFF
--- a/src/connector.rs
+++ b/src/connector.rs
@@ -416,14 +416,14 @@ impl EthConnectorContract {
     pub fn ft_total_eth_supply_on_near(&self) {
         let total_supply = self.ft.ft_total_eth_supply_on_near();
         crate::log!(&format!("Total ETH supply on NEAR: {}", total_supply));
-        sdk::return_output(total_supply.to_string().as_bytes());
+        sdk::return_output(format!("\"{}\"", total_supply.to_string()).as_bytes());
     }
 
     /// Returns total ETH supply on Aurora (ETH in Aurora EVM)
     pub fn ft_total_eth_supply_on_aurora(&self) {
         let total_supply = self.ft.ft_total_eth_supply_on_aurora();
         crate::log!(&format!("Total ETH supply on Aurora: {}", total_supply));
-        sdk::return_output(total_supply.to_string().as_bytes());
+        sdk::return_output(format!("\"{}\"", total_supply.to_string()).as_bytes());
     }
 
     /// Return balance of nETH (ETH on Near)
@@ -453,7 +453,7 @@ impl EthConnectorContract {
             hex::encode(args.address),
             balance
         ));
-        sdk::return_output(balance.to_string().as_bytes());
+        sdk::return_output(format!("\"{}\"", balance.to_string()).as_bytes());
     }
 
     /// Transfer between NEAR accounts

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -438,7 +438,7 @@ impl EthConnectorContract {
             args.account_id, balance
         ));
 
-        sdk::return_output(balance.to_string().as_bytes());
+        sdk::return_output(format!("\"{}\"", balance.to_string()).as_bytes());
     }
 
     /// Return balance of ETH (ETH in Aurora EVM)

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -487,7 +487,7 @@ impl EthConnectorContract {
         ));
         // `ft_resolve_transfer` can change `total_supply` so we should save the contract
         self.save_ft_contract();
-        sdk::return_output(amount.to_string().as_bytes());
+        sdk::return_output(format!("\"{}\"", amount.to_string()).as_bytes());
     }
 
     /// FT transfer call from sender account (invoker account) to receiver

--- a/src/tests/eth_connector.rs
+++ b/src/tests/eth_connector.rs
@@ -159,7 +159,6 @@ fn call_deposit_eth_to_aurora(master_account: &UserAccount, contract: &str) {
         10,
     );
     res.assert_success();
-    //println!("{:#?}", res.promise_results());
 }
 
 fn get_eth_on_near_balance(master_account: &UserAccount, acc: &str, contract: &str) -> u128 {
@@ -173,10 +172,9 @@ fn get_eth_on_near_balance(master_account: &UserAccount, acc: &str, contract: &s
         "ft_balance_of",
         json!({ "account_id": acc }).to_string().as_bytes(),
     );
-    String::from_utf8(balance.unwrap())
-        .unwrap()
-        .parse()
-        .unwrap()
+    let val_str = String::from_utf8(balance.unwrap()).unwrap();
+    let val = &val_str[1..val_str.len() - 1];
+    val.parse().unwrap()
 }
 
 fn get_eth_balance(master_account: &UserAccount, address: EthAddress, contract: &str) -> u128 {
@@ -190,18 +188,16 @@ fn get_eth_balance(master_account: &UserAccount, address: EthAddress, contract: 
         "ft_balance_of_eth",
         &BalanceOfEthCallArgs { address }.try_to_vec().unwrap(),
     );
-    String::from_utf8(balance.unwrap())
-        .unwrap()
-        .parse()
-        .unwrap()
+    let val_str = String::from_utf8(balance.unwrap()).unwrap();
+    let val = &val_str[1..val_str.len() - 1];
+    val.parse().unwrap()
 }
 
 fn total_supply(master_account: &UserAccount, contract: &str) -> u128 {
     let balance = master_account.view(contract.parse().unwrap(), "ft_total_supply", &[]);
-    String::from_utf8(balance.unwrap())
-        .unwrap()
-        .parse()
-        .unwrap()
+    let val_str = String::from_utf8(balance.unwrap()).unwrap();
+    let val = &val_str[1..val_str.len() - 1];
+    val.parse().unwrap()
 }
 
 fn total_eth_supply_on_near(master_account: &UserAccount, contract: &str) -> u128 {
@@ -210,10 +206,9 @@ fn total_eth_supply_on_near(master_account: &UserAccount, contract: &str) -> u12
         "ft_total_eth_supply_on_near",
         &[],
     );
-    String::from_utf8(balance.unwrap())
-        .unwrap()
-        .parse()
-        .unwrap()
+    let val_str = String::from_utf8(balance.unwrap()).unwrap();
+    let val = &val_str[1..val_str.len() - 1];
+    val.parse().unwrap()
 }
 
 fn total_eth_supply_on_aurora(master_account: &UserAccount, contract: &str) -> u128 {
@@ -222,10 +217,9 @@ fn total_eth_supply_on_aurora(master_account: &UserAccount, contract: &str) -> u
         "ft_total_eth_supply_on_aurora",
         &[],
     );
-    String::from_utf8(balance.unwrap())
-        .unwrap()
-        .parse()
-        .unwrap()
+    let val_str = String::from_utf8(balance.unwrap()).unwrap();
+    let val = &val_str[1..val_str.len() - 1];
+    val.parse().unwrap()
 }
 
 #[test]


### PR DESCRIPTION
There was a bit of confusion with the return required for `ft_balance_of`. It was initially interpreted that it needed simply to return the value as a string, but in fact, it needed to be returned surrounded by quotations.