### PR TITLE
Return view of transaction result as borsh

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2021-08-20
+
+### Breaking changes
+
+- The `view` call has been correctly updated to return the Borsh serialization of `TransactionStatus`. Prior it was returning a string with the result of the transaction by name. 
+
 ## [1.6.0] - 2021-08-13
+
+### Breaking changes
+
+- The transaction status of `submit` was changed as running out of gas, funds, or being out of the offset are not errors but failed executions.
+
+`submit` call must altered the `SubmitResult` object to the following format:
+
+```rust
+enum TransactionStatus {
+    Succeed(Vec<u8>),
+    Revert(Vec<u8>),
+    OutOfGas,
+    OutOfFund,
+    OutOfOffset,
+    CallTooDeep,
+}
+
+struct ResultLog {
+    topics: Vec<[u8; 32]>,
+    data: Vec<u8>,
+}
+
+struct SubmitResult {
+    status: TransactionStatus, // above
+    gas_used: u64,
+    logs: Vec<ResultLog>,
+}
+```
 
 ## [1.5.0] - 2021-07-30
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -421,8 +421,8 @@ mod contract {
     pub extern "C" fn view() {
         let args: ViewCallArgs = sdk::read_input_borsh().sdk_unwrap();
         let engine = Engine::new(Address::from_slice(&args.sender)).sdk_unwrap();
-        let result = Engine::view_with_args(&engine, args);
-        result.sdk_process()
+        let result = Engine::view_with_args(&engine, args).sdk_unwrap();
+        sdk::return_output(&result.try_to_vec().sdk_expect("ERR_SERIALIZE"));
     }
 
     #[no_mangle]


### PR DESCRIPTION
This fixes an issue where the public `view` call was returning the result by name, but not the actual Borsh serialization. This fixes that.

**BREAKING**

Unfortunately, this breaks public API but for the better. The status return must be serialised to the equivalent of:
```rust
pub enum TransactionStatus {
    Succeed(Vec<u8>),
    Revert(Vec<u8>),
    OutOfGas,
    OutOfFund,
    OutOfOffset,
    CallTooDeep,
}
```

In a follow-up PR, a tests ensuring that we are not breaking API must be made.