### PR TITLE
Fix return format of `ft_balance_of`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `view` call has been correctly updated to return the Borsh serialization of `TransactionStatus`. Prior it was returning a string with the result of the transaction by name. 
 
+- `ft_balance_of` return was changed as prior it was returning a non-JSON string value `0`. This has been fixed to return `"0"`.
+
 ## [1.6.0] - 2021-08-13
 
 ### Breaking changes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2021-08-20
+
+### Breaking changes
+
+- The `view` call has been correctly updated to return the Borsh serialization of `TransactionStatus`. Prior it was returning a string with the result of the transaction by name. 
+
 ## [1.6.0] - 2021-08-13
+
+### Breaking changes
+
+- The transaction status of `submit` was changed as running out of gas, funds, or being out of the offset are not errors but failed executions.
+
+`submit` call must altered the `SubmitResult` object to the following format:
+
+```rust
+enum TransactionStatus {
+    Succeed(Vec<u8>),
+    Revert(Vec<u8>),
+    OutOfGas,
+    OutOfFund,
+    OutOfOffset,
+    CallTooDeep,
+}
+
+struct ResultLog {
+    topics: Vec<[u8; 32]>,
+    data: Vec<u8>,
+}
+
+struct SubmitResult {
+    status: TransactionStatus, // above
+    gas_used: u64,
+    logs: Vec<ResultLog>,
+}
+```
 
 ## [1.5.0] - 2021-07-30
 

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -416,14 +416,14 @@ impl EthConnectorContract {
     pub fn ft_total_eth_supply_on_near(&self) {
         let total_supply = self.ft.ft_total_eth_supply_on_near();
         crate::log!(&format!("Total ETH supply on NEAR: {}", total_supply));
-        sdk::return_output(total_supply.to_string().as_bytes());
+        sdk::return_output(format!("\"{}\"", total_supply.to_string()).as_bytes());
     }
 
     /// Returns total ETH supply on Aurora (ETH in Aurora EVM)
     pub fn ft_total_eth_supply_on_aurora(&self) {
         let total_supply = self.ft.ft_total_eth_supply_on_aurora();
         crate::log!(&format!("Total ETH supply on Aurora: {}", total_supply));
-        sdk::return_output(total_supply.to_string().as_bytes());
+        sdk::return_output(format!("\"{}\"", total_supply.to_string()).as_bytes());
     }
 
     /// Return balance of nETH (ETH on Near)
@@ -438,7 +438,7 @@ impl EthConnectorContract {
             args.account_id, balance
         ));
 
-        sdk::return_output(balance.to_string().as_bytes());
+        sdk::return_output(format!("\"{}\"", balance.to_string()).as_bytes());
     }
 
     /// Return balance of ETH (ETH in Aurora EVM)
@@ -453,7 +453,7 @@ impl EthConnectorContract {
             hex::encode(args.address),
             balance
         ));
-        sdk::return_output(balance.to_string().as_bytes());
+        sdk::return_output(format!("\"{}\"", balance.to_string()).as_bytes());
     }
 
     /// Transfer between NEAR accounts
@@ -487,7 +487,7 @@ impl EthConnectorContract {
         ));
         // `ft_resolve_transfer` can change `total_supply` so we should save the contract
         self.save_ft_contract();
-        sdk::return_output(amount.to_string().as_bytes());
+        sdk::return_output(format!("\"{}\"", amount.to_string()).as_bytes());
     }
 
     /// FT transfer call from sender account (invoker account) to receiver

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -421,8 +421,8 @@ mod contract {
     pub extern "C" fn view() {
         let args: ViewCallArgs = sdk::read_input_borsh().sdk_unwrap();
         let engine = Engine::new(Address::from_slice(&args.sender)).sdk_unwrap();
-        let result = Engine::view_with_args(&engine, args);
-        result.sdk_process()
+        let result = Engine::view_with_args(&engine, args).sdk_unwrap();
+        sdk::return_output(&result.try_to_vec().sdk_expect("ERR_SERIALIZE"));
     }
 
     #[no_mangle]

--- a/src/tests/eth_connector.rs
+++ b/src/tests/eth_connector.rs
@@ -159,7 +159,6 @@ fn call_deposit_eth_to_aurora(master_account: &UserAccount, contract: &str) {
         10,
     );
     res.assert_success();
-    //println!("{:#?}", res.promise_results());
 }
 
 fn get_eth_on_near_balance(master_account: &UserAccount, acc: &str, contract: &str) -> u128 {
@@ -173,10 +172,9 @@ fn get_eth_on_near_balance(master_account: &UserAccount, acc: &str, contract: &s
         "ft_balance_of",
         json!({ "account_id": acc }).to_string().as_bytes(),
     );
-    String::from_utf8(balance.unwrap())
-        .unwrap()
-        .parse()
-        .unwrap()
+    let val_str = String::from_utf8(balance.unwrap()).unwrap();
+    let val = &val_str[1..val_str.len() - 1];
+    val.parse().unwrap()
 }
 
 fn get_eth_balance(master_account: &UserAccount, address: EthAddress, contract: &str) -> u128 {
@@ -190,18 +188,16 @@ fn get_eth_balance(master_account: &UserAccount, address: EthAddress, contract: 
         "ft_balance_of_eth",
         &BalanceOfEthCallArgs { address }.try_to_vec().unwrap(),
     );
-    String::from_utf8(balance.unwrap())
-        .unwrap()
-        .parse()
-        .unwrap()
+    let val_str = String::from_utf8(balance.unwrap()).unwrap();
+    let val = &val_str[1..val_str.len() - 1];
+    val.parse().unwrap()
 }
 
 fn total_supply(master_account: &UserAccount, contract: &str) -> u128 {
     let balance = master_account.view(contract.parse().unwrap(), "ft_total_supply", &[]);
-    String::from_utf8(balance.unwrap())
-        .unwrap()
-        .parse()
-        .unwrap()
+    let val_str = String::from_utf8(balance.unwrap()).unwrap();
+    let val = &val_str[1..val_str.len() - 1];
+    val.parse().unwrap()
 }
 
 fn total_eth_supply_on_near(master_account: &UserAccount, contract: &str) -> u128 {
@@ -210,10 +206,9 @@ fn total_eth_supply_on_near(master_account: &UserAccount, contract: &str) -> u12
         "ft_total_eth_supply_on_near",
         &[],
     );
-    String::from_utf8(balance.unwrap())
-        .unwrap()
-        .parse()
-        .unwrap()
+    let val_str = String::from_utf8(balance.unwrap()).unwrap();
+    let val = &val_str[1..val_str.len() - 1];
+    val.parse().unwrap()
 }
 
 fn total_eth_supply_on_aurora(master_account: &UserAccount, contract: &str) -> u128 {
@@ -222,10 +217,9 @@ fn total_eth_supply_on_aurora(master_account: &UserAccount, contract: &str) -> u
         "ft_total_eth_supply_on_aurora",
         &[],
     );
-    String::from_utf8(balance.unwrap())
-        .unwrap()
-        .parse()
-        .unwrap()
+    let val_str = String::from_utf8(balance.unwrap()).unwrap();
+    let val = &val_str[1..val_str.len() - 1];
+    val.parse().unwrap()
 }
 
 #[test]

--- a/src/tests/sanity.rs
+++ b/src/tests/sanity.rs
@@ -362,7 +362,8 @@ fn test_balance_evm_and_nep_141() {
         );
         assert!(maybe_err.is_none());
         let result = maybe_result.unwrap();
-        String::from_utf8(result.return_data.as_value().unwrap())
+        let val = result.return_data.as_value().unwrap();
+        String::from_utf8(val[1..val.len() - 1].to_vec())
             .unwrap()
             .parse()
             .unwrap()
@@ -376,7 +377,8 @@ fn test_balance_evm_and_nep_141() {
                 runner.call("ft_total_eth_supply_on_aurora", caller.clone(), Vec::new());
             assert!(maybe_err.is_none());
             let result = maybe_result.unwrap();
-            String::from_utf8(result.return_data.as_value().unwrap())
+            let val = result.return_data.as_value().unwrap();
+            String::from_utf8(val[1..val.len() - 1].to_vec())
                 .unwrap()
                 .parse()
                 .unwrap()


### PR DESCRIPTION
This is a cherry-pick of #241 targeting the `1.6.1-hotfix` branch for the hotfix. Includes an update to the changelog.

This should be pulled in after #246.