### PR TITLE
Chore: Upgrade nearcore dependencies to latest commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ dependencies = [
  "aurora-bn",
  "base64 0.13.0",
  "blake2 0.9.1 (git+https://github.com/near/near-blake2.git)",
- "borsh",
+ "borsh 0.8.2",
  "bstr",
  "byte-slice-cast",
  "criterion",
@@ -131,14 +131,14 @@ dependencies = [
  "hex",
  "libsecp256k1",
  "logos",
- "near-crypto 0.1.0 (git+https://github.com/near/nearcore.git?branch=1.20.1)",
- "near-primitives-core 0.1.0 (git+https://github.com/near/nearcore.git?branch=1.20.1)",
+ "near-crypto 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9)",
+ "near-primitives-core 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9)",
  "near-sdk",
  "near-sdk-sim",
- "near-vm-logic 3.0.0 (git+https://github.com/near/nearcore.git?branch=1.20.1)",
- "near-vm-runner 3.0.0 (git+https://github.com/near/nearcore.git?branch=1.20.1)",
+ "near-vm-logic 3.0.0 (git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9)",
+ "near-vm-runner",
  "num",
- "primitive-types",
+ "primitive-types 0.9.0",
  "rand 0.7.3",
  "ripemd160",
  "rjson",
@@ -314,7 +314,17 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a7111f797cc721407885a323fb071636aee57f750b1a4ddc27397eba168a74"
 dependencies = [
- "borsh-derive",
+ "borsh-derive 0.8.2",
+ "hashbrown",
+]
+
+[[package]]
+name = "borsh"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dda7dc709193c0d86a1a51050a926dc3df1cf262ec46a23a25dba421ea1924"
+dependencies = [
+ "borsh-derive 0.9.1",
  "hashbrown",
 ]
 
@@ -324,8 +334,21 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "307f3740906bac2c118a8122fe22681232b244f1369273e45f1156b45c43d2dd"
 dependencies = [
- "borsh-derive-internal",
- "borsh-schema-derive-internal",
+ "borsh-derive-internal 0.8.2",
+ "borsh-schema-derive-internal 0.8.2",
+ "proc-macro-crate",
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "684155372435f578c0fa1acd13ebbb182cc19d6b38b64ae7901da4393217d264"
+dependencies = [
+ "borsh-derive-internal 0.9.1",
+ "borsh-schema-derive-internal 0.9.1",
  "proc-macro-crate",
  "proc-macro2",
  "syn",
@@ -343,10 +366,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh-derive-internal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2102f62f8b6d3edeab871830782285b64cc1830168094db05c8e458f209bc5c3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "borsh-schema-derive-internal"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae29eb8418fcd46f723f8691a2ac06857d31179d33d2f2d91eb13967de97c728"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "borsh-schema-derive-internal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "196c978c4c9b0b142d446ef3240690bf5a8a33497074a113ff9a337ccb750483"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1164,7 +1209,7 @@ dependencies = [
  "fixed-hash",
  "impl-rlp",
  "impl-serde",
- "primitive-types",
+ "primitive-types 0.9.0",
  "uint",
 ]
 
@@ -1186,7 +1231,7 @@ dependencies = [
  "evm-runtime",
  "log",
  "parity-scale-codec",
- "primitive-types",
+ "primitive-types 0.9.0",
  "rlp",
  "serde",
  "sha3 0.8.2",
@@ -1199,7 +1244,7 @@ source = "git+https://github.com/aurora-is-near/sputnikvm.git?rev=01e000cbf081da
 dependencies = [
  "funty",
  "parity-scale-codec",
- "primitive-types",
+ "primitive-types 0.9.0",
  "serde",
 ]
 
@@ -1211,7 +1256,7 @@ dependencies = [
  "environmental",
  "evm-core",
  "evm-runtime",
- "primitive-types",
+ "primitive-types 0.9.0",
 ]
 
 [[package]]
@@ -1221,7 +1266,7 @@ source = "git+https://github.com/aurora-is-near/sputnikvm.git?rev=01e000cbf081da
 dependencies = [
  "environmental",
  "evm-core",
- "primitive-types",
+ "primitive-types 0.9.0",
  "sha3 0.8.2",
 ]
 
@@ -1683,9 +1728,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.49"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc15e39392125075f60c95ba416f5381ff6c3a948ff02ab12464715adf56c821"
+checksum = "e4bf49d50e2961077d9c99f4b7997d770a1114f087c3c2e0069b36c13fc2979d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1954,14 +1999,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
 
 [[package]]
+name = "near-account-id"
+version = "0.1.0"
+source = "git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9#8a377fda0b4ce319385c463f1ae46e4b0b29dcd9"
+dependencies = [
+ "borsh 0.8.2",
+ "serde",
+]
+
+[[package]]
 name = "near-chain-configs"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90#8a37d39629885a41dde58b60642bcf1e99407d90"
+source = "git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9#8a377fda0b4ce319385c463f1ae46e4b0b29dcd9"
 dependencies = [
  "chrono",
  "derive_more",
- "near-crypto 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90)",
- "near-primitives 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90)",
+ "near-crypto 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9)",
+ "near-primitives 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9)",
  "num-rational 0.3.2",
  "serde",
  "serde_json",
@@ -1972,20 +2026,21 @@ dependencies = [
 [[package]]
 name = "near-crypto"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore.git?branch=1.20.1#dde3ad6ad954d333407159225f712df379f186e2"
+source = "git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9#8a377fda0b4ce319385c463f1ae46e4b0b29dcd9"
 dependencies = [
  "arrayref",
  "blake2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "borsh",
+ "borsh 0.8.2",
  "bs58",
  "c2-chacha",
  "curve25519-dalek",
  "derive_more",
  "ed25519-dalek",
- "ethereum-types",
  "lazy_static",
  "libc",
+ "near-account-id",
  "parity-secp256k1",
+ "primitive-types 0.10.0",
  "rand 0.7.3",
  "rand_core 0.5.1",
  "serde",
@@ -2001,7 +2056,7 @@ source = "git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b606
 dependencies = [
  "arrayref",
  "blake2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "borsh",
+ "borsh 0.8.2",
  "bs58",
  "c2-chacha",
  "curve25519-dalek",
@@ -2022,7 +2077,7 @@ dependencies = [
 [[package]]
 name = "near-metrics"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90#8a37d39629885a41dde58b60642bcf1e99407d90"
+source = "git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9#8a377fda0b4ce319385c463f1ae46e4b0b29dcd9"
 dependencies = [
  "lazy_static",
  "log",
@@ -2032,21 +2087,21 @@ dependencies = [
 [[package]]
 name = "near-pool"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90#8a37d39629885a41dde58b60642bcf1e99407d90"
+source = "git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9#8a377fda0b4ce319385c463f1ae46e4b0b29dcd9"
 dependencies = [
- "borsh",
- "near-crypto 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90)",
- "near-primitives 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90)",
+ "borsh 0.8.2",
+ "near-crypto 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9)",
+ "near-primitives 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9)",
  "rand 0.7.3",
 ]
 
 [[package]]
 name = "near-primitives"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore.git?branch=1.20.1#dde3ad6ad954d333407159225f712df379f186e2"
+source = "git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9#8a377fda0b4ce319385c463f1ae46e4b0b29dcd9"
 dependencies = [
  "base64 0.13.0",
- "borsh",
+ "borsh 0.8.2",
  "bs58",
  "byteorder",
  "chrono",
@@ -2054,13 +2109,12 @@ dependencies = [
  "easy-ext",
  "hex",
  "jemallocator",
- "lazy_static",
- "near-crypto 0.1.0 (git+https://github.com/near/nearcore.git?branch=1.20.1)",
- "near-primitives-core 0.1.0 (git+https://github.com/near/nearcore.git?branch=1.20.1)",
- "near-rpc-error-macro 0.1.0 (git+https://github.com/near/nearcore.git?branch=1.20.1)",
- "near-vm-errors 3.0.0 (git+https://github.com/near/nearcore.git?branch=1.20.1)",
+ "near-crypto 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9)",
+ "near-primitives-core 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9)",
+ "near-rpc-error-macro 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9)",
+ "near-vm-errors 3.0.0 (git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9)",
  "num-rational 0.3.2",
- "primitive-types",
+ "primitive-types 0.10.0",
  "rand 0.7.3",
  "reed-solomon-erasure",
  "regex",
@@ -2077,7 +2131,7 @@ version = "0.1.0"
 source = "git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90#8a37d39629885a41dde58b60642bcf1e99407d90"
 dependencies = [
  "base64 0.13.0",
- "borsh",
+ "borsh 0.8.2",
  "bs58",
  "byteorder",
  "chrono",
@@ -2090,7 +2144,7 @@ dependencies = [
  "near-rpc-error-macro 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90)",
  "near-vm-errors 3.0.0 (git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90)",
  "num-rational 0.3.2",
- "primitive-types",
+ "primitive-types 0.9.0",
  "rand 0.7.3",
  "reed-solomon-erasure",
  "regex",
@@ -2104,14 +2158,15 @@ dependencies = [
 [[package]]
 name = "near-primitives-core"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore.git?branch=1.20.1#dde3ad6ad954d333407159225f712df379f186e2"
+source = "git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9#8a377fda0b4ce319385c463f1ae46e4b0b29dcd9"
 dependencies = [
  "base64 0.11.0",
- "borsh",
+ "borsh 0.8.2",
  "bs58",
  "derive_more",
  "hex",
  "lazy_static",
+ "near-account-id",
  "num-rational 0.3.2",
  "serde",
  "serde_json",
@@ -2124,7 +2179,7 @@ version = "0.1.0"
 source = "git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90#8a37d39629885a41dde58b60642bcf1e99407d90"
 dependencies = [
  "base64 0.11.0",
- "borsh",
+ "borsh 0.8.2",
  "bs58",
  "derive_more",
  "hex",
@@ -2138,7 +2193,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-core"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore.git?branch=1.20.1#dde3ad6ad954d333407159225f712df379f186e2"
+source = "git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9#8a377fda0b4ce319385c463f1ae46e4b0b29dcd9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2160,9 +2215,9 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-macro"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore.git?branch=1.20.1#dde3ad6ad954d333407159225f712df379f186e2"
+source = "git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9#8a377fda0b4ce319385c463f1ae46e4b0b29dcd9"
 dependencies = [
- "near-rpc-error-core 0.1.0 (git+https://github.com/near/nearcore.git?branch=1.20.1)",
+ "near-rpc-error-core 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9)",
  "proc-macro2",
  "quote",
  "serde",
@@ -2186,15 +2241,6 @@ dependencies = [
 [[package]]
 name = "near-runtime-utils"
 version = "3.0.0"
-source = "git+https://github.com/near/nearcore.git?branch=1.20.1#dde3ad6ad954d333407159225f712df379f186e2"
-dependencies = [
- "lazy_static",
- "regex",
-]
-
-[[package]]
-name = "near-runtime-utils"
-version = "3.0.0"
 source = "git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90#8a37d39629885a41dde58b60642bcf1e99407d90"
 dependencies = [
  "lazy_static",
@@ -2204,10 +2250,10 @@ dependencies = [
 [[package]]
 name = "near-sdk"
 version = "3.1.0"
-source = "git+https://github.com/aurora-is-near/near-sdk-rs.git?rev=1b9843fe5b652928582e33879fc92ba87a639450#1b9843fe5b652928582e33879fc92ba87a639450"
+source = "git+https://github.com/aurora-is-near/near-sdk-rs.git?rev=5e58722bd61d9d24ae6293326146c751f0a814fb#5e58722bd61d9d24ae6293326146c751f0a814fb"
 dependencies = [
  "base64 0.13.0",
- "borsh",
+ "borsh 0.8.2",
  "bs58",
  "near-primitives-core 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90)",
  "near-sdk-macros",
@@ -2220,7 +2266,7 @@ dependencies = [
 [[package]]
 name = "near-sdk-core"
 version = "3.1.0"
-source = "git+https://github.com/aurora-is-near/near-sdk-rs.git?rev=1b9843fe5b652928582e33879fc92ba87a639450#1b9843fe5b652928582e33879fc92ba87a639450"
+source = "git+https://github.com/aurora-is-near/near-sdk-rs.git?rev=5e58722bd61d9d24ae6293326146c751f0a814fb#5e58722bd61d9d24ae6293326146c751f0a814fb"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -2231,7 +2277,7 @@ dependencies = [
 [[package]]
 name = "near-sdk-macros"
 version = "3.1.0"
-source = "git+https://github.com/aurora-is-near/near-sdk-rs.git?rev=1b9843fe5b652928582e33879fc92ba87a639450#1b9843fe5b652928582e33879fc92ba87a639450"
+source = "git+https://github.com/aurora-is-near/near-sdk-rs.git?rev=5e58722bd61d9d24ae6293326146c751f0a814fb#5e58722bd61d9d24ae6293326146c751f0a814fb"
 dependencies = [
  "near-sdk-core",
  "proc-macro2",
@@ -2242,27 +2288,27 @@ dependencies = [
 [[package]]
 name = "near-sdk-sim"
 version = "3.2.0"
-source = "git+https://github.com/aurora-is-near/near-sdk-rs.git?rev=1b9843fe5b652928582e33879fc92ba87a639450#1b9843fe5b652928582e33879fc92ba87a639450"
+source = "git+https://github.com/aurora-is-near/near-sdk-rs.git?rev=5e58722bd61d9d24ae6293326146c751f0a814fb#5e58722bd61d9d24ae6293326146c751f0a814fb"
 dependencies = [
  "chrono",
  "funty",
  "lazy-static-include",
  "near-chain-configs",
- "near-crypto 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90)",
+ "near-crypto 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9)",
  "near-pool",
- "near-primitives 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90)",
+ "near-primitives 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9)",
  "near-sdk",
  "near-store",
- "near-vm-logic 3.0.0 (git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90)",
+ "near-vm-logic 3.0.0 (git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9)",
  "node-runtime",
 ]
 
 [[package]]
 name = "near-store"
 version = "2.2.0"
-source = "git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90#8a37d39629885a41dde58b60642bcf1e99407d90"
+source = "git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9#8a377fda0b4ce319385c463f1ae46e4b0b29dcd9"
 dependencies = [
- "borsh",
+ "borsh 0.8.2",
  "byteorder",
  "bytesize",
  "cached",
@@ -2270,13 +2316,14 @@ dependencies = [
  "elastic-array",
  "fs2",
  "lazy_static",
- "near-crypto 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90)",
- "near-primitives 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90)",
+ "near-crypto 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9)",
+ "near-primitives 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9)",
  "num_cpus",
  "rand 0.7.3",
  "rocksdb",
  "serde",
  "serde_json",
+ "smart-default",
  "strum",
  "thiserror",
  "tracing",
@@ -2285,11 +2332,12 @@ dependencies = [
 [[package]]
 name = "near-vm-errors"
 version = "3.0.0"
-source = "git+https://github.com/near/nearcore.git?branch=1.20.1#dde3ad6ad954d333407159225f712df379f186e2"
+source = "git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9#8a377fda0b4ce319385c463f1ae46e4b0b29dcd9"
 dependencies = [
- "borsh",
+ "borsh 0.8.2",
  "hex",
- "near-rpc-error-macro 0.1.0 (git+https://github.com/near/nearcore.git?branch=1.20.1)",
+ "near-account-id",
+ "near-rpc-error-macro 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9)",
  "serde",
 ]
 
@@ -2298,7 +2346,7 @@ name = "near-vm-errors"
 version = "3.0.0"
 source = "git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90#8a37d39629885a41dde58b60642bcf1e99407d90"
 dependencies = [
- "borsh",
+ "borsh 0.8.2",
  "hex",
  "near-rpc-error-macro 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90)",
  "serde",
@@ -2307,21 +2355,21 @@ dependencies = [
 [[package]]
 name = "near-vm-logic"
 version = "3.0.0"
-source = "git+https://github.com/near/nearcore.git?branch=1.20.1#dde3ad6ad954d333407159225f712df379f186e2"
+source = "git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9#8a377fda0b4ce319385c463f1ae46e4b0b29dcd9"
 dependencies = [
  "base64 0.13.0",
- "borsh",
+ "borsh 0.8.2",
  "bs58",
  "byteorder",
- "near-crypto 0.1.0 (git+https://github.com/near/nearcore.git?branch=1.20.1)",
- "near-primitives 0.1.0 (git+https://github.com/near/nearcore.git?branch=1.20.1)",
- "near-primitives-core 0.1.0 (git+https://github.com/near/nearcore.git?branch=1.20.1)",
- "near-runtime-utils 3.0.0 (git+https://github.com/near/nearcore.git?branch=1.20.1)",
- "near-vm-errors 3.0.0 (git+https://github.com/near/nearcore.git?branch=1.20.1)",
+ "near-account-id",
+ "near-crypto 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9)",
+ "near-primitives 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9)",
+ "near-primitives-core 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9)",
+ "near-vm-errors 3.0.0 (git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9)",
  "ripemd160",
  "serde",
- "sha2 0.9.5",
- "sha3 0.9.1",
+ "sha2 0.8.2",
+ "sha3 0.8.2",
 ]
 
 [[package]]
@@ -2330,13 +2378,13 @@ version = "3.0.0"
 source = "git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90#8a37d39629885a41dde58b60642bcf1e99407d90"
 dependencies = [
  "base64 0.13.0",
- "borsh",
+ "borsh 0.8.2",
  "bs58",
  "byteorder",
  "near-crypto 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90)",
  "near-primitives 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90)",
  "near-primitives-core 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90)",
- "near-runtime-utils 3.0.0 (git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90)",
+ "near-runtime-utils",
  "near-vm-errors 3.0.0 (git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90)",
  "ripemd160",
  "serde",
@@ -2347,41 +2395,14 @@ dependencies = [
 [[package]]
 name = "near-vm-runner"
 version = "3.0.0"
-source = "git+https://github.com/near/nearcore.git?branch=1.20.1#dde3ad6ad954d333407159225f712df379f186e2"
+source = "git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9#8a377fda0b4ce319385c463f1ae46e4b0b29dcd9"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.8.2",
  "cached",
- "near-primitives 0.1.0 (git+https://github.com/near/nearcore.git?branch=1.20.1)",
- "near-vm-errors 3.0.0 (git+https://github.com/near/nearcore.git?branch=1.20.1)",
- "near-vm-logic 3.0.0 (git+https://github.com/near/nearcore.git?branch=1.20.1)",
- "parity-wasm",
- "pwasm-utils",
- "serde",
- "threadpool",
- "tracing",
- "wasmer",
- "wasmer-compiler-cranelift",
- "wasmer-compiler-singlepass",
- "wasmer-engine-native",
- "wasmer-runtime-core-near",
- "wasmer-runtime-near",
- "wasmer-types",
- "wasmer-vm",
- "wasmtime",
-]
-
-[[package]]
-name = "near-vm-runner"
-version = "3.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90#8a37d39629885a41dde58b60642bcf1e99407d90"
-dependencies = [
- "anyhow",
- "borsh",
- "cached",
- "near-primitives 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90)",
- "near-vm-errors 3.0.0 (git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90)",
- "near-vm-logic 3.0.0 (git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90)",
+ "near-primitives 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9)",
+ "near-vm-errors 3.0.0 (git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9)",
+ "near-vm-logic 3.0.0 (git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9)",
  "parity-wasm",
  "pwasm-utils",
  "serde",
@@ -2415,23 +2436,21 @@ dependencies = [
 [[package]]
 name = "node-runtime"
 version = "3.0.0"
-source = "git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90#8a37d39629885a41dde58b60642bcf1e99407d90"
+source = "git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9#8a377fda0b4ce319385c463f1ae46e4b0b29dcd9"
 dependencies = [
- "borsh",
+ "borsh 0.8.2",
  "byteorder",
- "ethereum-types",
  "hex",
  "lazy_static",
  "log",
  "near-chain-configs",
- "near-crypto 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90)",
+ "near-crypto 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9)",
  "near-metrics",
- "near-primitives 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90)",
- "near-runtime-utils 3.0.0 (git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90)",
+ "near-primitives 0.1.0 (git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9)",
  "near-store",
- "near-vm-errors 3.0.0 (git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90)",
- "near-vm-logic 3.0.0 (git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90)",
- "near-vm-runner 3.0.0 (git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90)",
+ "near-vm-errors 3.0.0 (git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9)",
+ "near-vm-logic 3.0.0 (git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9)",
+ "near-vm-runner",
  "num-bigint 0.3.2",
  "num-rational 0.3.2",
  "num-traits",
@@ -2814,6 +2833,17 @@ dependencies = [
  "impl-codec",
  "impl-rlp",
  "impl-serde",
+ "uint",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e90f6931e6b3051e208a449c342246cb7c786ef300789b95619f46f1dd75d9b0"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
  "uint",
 ]
 
@@ -3431,9 +3461,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.57"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4211ce9909eb971f111059df92c45640aad50a619cf55cd76476be803c4c68e6"
+checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3754,9 +3784,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.72"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe8f61dba8e5d645a4d8132dc7a0a66861ed5e1045d2c0ed940fab33bac0fbe"
+checksum = "8ce9b1b516211d33767048e5d47fa2a381ed8b76fc48d2ce4aa39877f9f183e0"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -3764,9 +3794,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.72"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046ceba58ff062da072c7cb4ba5b22a37f00a302483f7e2a6cdc18fedbdc1fd3"
+checksum = "cfe8dc78e2326ba5f845f4b5bf548401604fa20b1dd1d365fb73b6c1d6364041"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3779,9 +3809,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.72"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9aa01d36cda046f797c57959ff5f3c615c9cc63997a8d545831ec7976819b"
+checksum = "44468aa53335841d9d6b6c023eaab07c0cd4bddbcfdee3e2bb1e8d2cb8069fef"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3789,9 +3819,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.72"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96eb45c1b2ee33545a813a92dbb53856418bf7eb54ab34f7f7ff1448a5b3735d"
+checksum = "0195807922713af1e67dc66132c7328206ed9766af3858164fb583eedc25fbad"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3802,9 +3832,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.72"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7148f4696fb4960a346eaa60bbfb42a1ac4ebba21f750f75fc1375b098d5ffa"
+checksum = "acdb075a845574a1fa5f09fd77e43f7747599301ea3417a9fbffdeedfc1f4a29"
 
 [[package]]
 name = "wasmer"
@@ -3970,12 +4000,13 @@ dependencies = [
 
 [[package]]
 name = "wasmer-runtime-core-near"
-version = "0.17.4"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ff9059d479dbff357e1953edbde198453d5421274119230c50754e61e8ec9f"
+checksum = "2cf26de331c8ef4257bef33649b4665535b105c927ab2e00715f17891362efe8"
 dependencies = [
  "bincode",
  "blake3",
+ "borsh 0.9.1",
  "cc",
  "digest 0.8.1",
  "errno",
@@ -3999,9 +4030,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-runtime-near"
-version = "0.17.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6660e86bc7697fa29bab902214d5b33d394a990826c401b10816bcd285f938f"
+checksum = "158e6fff11e5e1ef805af50637374d5bd43d92017beafa18992cdf7f3f7ae3e4"
 dependencies = [
  "lazy_static",
  "memmap",
@@ -4013,11 +4044,12 @@ dependencies = [
 
 [[package]]
 name = "wasmer-singlepass-backend-near"
-version = "0.17.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3f23543ef8f59667be4945c22eb4b1a50a79ff340555f6f23354223d2695541"
+checksum = "5f6edd0ba6c0bcf9b279186d4dbe81649dda3e5ef38f586865943de4dcd653f8"
 dependencies = [
  "bincode",
+ "borsh 0.9.1",
  "byteorder",
  "dynasm",
  "dynasmrt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,12 +70,12 @@ bstr = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 hex = { version = "0.4.3", default-features = false }
-near-sdk = { git = "https://github.com/aurora-is-near/near-sdk-rs.git", rev = "1b9843fe5b652928582e33879fc92ba87a639450" }
-near-sdk-sim = { git = "https://github.com/aurora-is-near/near-sdk-rs.git", rev = "1b9843fe5b652928582e33879fc92ba87a639450" }
-near-crypto = { git = "https://github.com/near/nearcore.git", branch = "1.20.1"}
-near-vm-runner = { git = "https://github.com/near/nearcore.git", branch = "1.20.1"}
-near-vm-logic = { git = "https://github.com/near/nearcore.git", branch = "1.20.1"}
-near-primitives-core = { git = "https://github.com/near/nearcore.git", branch = "1.20.1"}
+near-sdk = { git = "https://github.com/aurora-is-near/near-sdk-rs.git", rev = "5e58722bd61d9d24ae6293326146c751f0a814fb" }
+near-sdk-sim = { git = "https://github.com/aurora-is-near/near-sdk-rs.git", rev = "5e58722bd61d9d24ae6293326146c751f0a814fb" }
+near-crypto = { git = "https://github.com/near/nearcore.git", rev = "8a377fda0b4ce319385c463f1ae46e4b0b29dcd9"}
+near-vm-runner = { git = "https://github.com/near/nearcore.git", rev = "8a377fda0b4ce319385c463f1ae46e4b0b29dcd9"}
+near-vm-logic = { git = "https://github.com/near/nearcore.git", rev = "8a377fda0b4ce319385c463f1ae46e4b0b29dcd9"}
+near-primitives-core = { git = "https://github.com/near/nearcore.git", rev = "8a377fda0b4ce319385c463f1ae46e4b0b29dcd9"}
 libsecp256k1 = "0.3.5"
 rand = "0.7.3"
 criterion = "0.3.4"

--- a/src/benches/eth_deploy_code.rs
+++ b/src/benches/eth_deploy_code.rs
@@ -33,15 +33,14 @@ pub(crate) fn eth_deploy_code_benchmark(c: &mut Criterion) {
             rlp::encode(&transaction).to_vec()
         })
         .collect();
-    let calling_account_id = "some-account.near".to_string();
+    let calling_account_id = "some-account.near";
 
     // measure gas usage
     for input in inputs.iter() {
         let input_size = input.len();
-        let (output, maybe_err) =
-            runner
-                .one_shot()
-                .call(SUBMIT, calling_account_id.clone(), input.clone());
+        let (output, maybe_err) = runner
+            .one_shot()
+            .call(SUBMIT, calling_account_id, input.clone());
         assert!(maybe_err.is_none());
         let output = output.unwrap();
         let gas = output.burnt_gas;
@@ -59,7 +58,7 @@ pub(crate) fn eth_deploy_code_benchmark(c: &mut Criterion) {
         group.throughput(Throughput::Bytes(input_size));
         group.bench_function(id, |b| {
             b.iter_batched(
-                || (runner.one_shot(), calling_account_id.clone(), input.clone()),
+                || (runner.one_shot(), calling_account_id, input.clone()),
                 |(r, c, i)| r.call(SUBMIT, c, i),
                 BatchSize::SmallInput,
             )

--- a/src/benches/eth_erc20.rs
+++ b/src/benches/eth_erc20.rs
@@ -18,7 +18,7 @@ pub(crate) fn eth_erc20_benchmark(c: &mut Criterion) {
         crate::types::Wei::new_u64(INITIAL_BALANCE),
         INITIAL_NONCE.into(),
     );
-    let calling_account_id = "some-account.near".to_string();
+    let calling_account_id = "some-account.near";
 
     // deploy the erc20 contract
     let constructor = ERC20Constructor::load();
@@ -54,13 +54,7 @@ pub(crate) fn eth_erc20_benchmark(c: &mut Criterion) {
     // measure mint wall-clock time
     group.bench_function(mint_id, |b| {
         b.iter_batched(
-            || {
-                (
-                    runner.one_shot(),
-                    calling_account_id.clone(),
-                    mint_tx_bytes.clone(),
-                )
-            },
+            || (runner.one_shot(), calling_account_id, mint_tx_bytes.clone()),
             |(r, c, i)| r.call(SUBMIT, c, i),
             BatchSize::SmallInput,
         )
@@ -68,8 +62,7 @@ pub(crate) fn eth_erc20_benchmark(c: &mut Criterion) {
 
     // Measure mint gas usage; don't use `one_shot` because we want to keep this state change for
     // the next benchmark where we transfer some of the minted tokens.
-    let (output, maybe_error) =
-        runner.call(SUBMIT, calling_account_id.clone(), mint_tx_bytes.clone());
+    let (output, maybe_error) = runner.call(SUBMIT, calling_account_id, mint_tx_bytes.clone());
     assert!(maybe_error.is_none());
     let output = output.unwrap();
     let gas = output.burnt_gas;
@@ -79,11 +72,10 @@ pub(crate) fn eth_erc20_benchmark(c: &mut Criterion) {
     println!("ETH_ERC20_MINT ETH GAS: {:?}", eth_gas);
 
     // Measure transfer gas usage
-    let (output, maybe_err) = runner.one_shot().call(
-        SUBMIT,
-        calling_account_id.clone(),
-        transfer_tx_bytes.clone(),
-    );
+    let (output, maybe_err) =
+        runner
+            .one_shot()
+            .call(SUBMIT, calling_account_id, transfer_tx_bytes.clone());
     assert!(maybe_err.is_none());
     let output = output.unwrap();
     let gas = output.burnt_gas;
@@ -98,7 +90,7 @@ pub(crate) fn eth_erc20_benchmark(c: &mut Criterion) {
             || {
                 (
                     runner.one_shot(),
-                    calling_account_id.clone(),
+                    calling_account_id,
                     transfer_tx_bytes.clone(),
                 )
             },

--- a/src/benches/eth_standard_precompiles.rs
+++ b/src/benches/eth_standard_precompiles.rs
@@ -18,7 +18,7 @@ pub(crate) fn eth_standard_precompiles_benchmark(c: &mut Criterion) {
         INITIAL_BALANCE,
         INITIAL_NONCE.into(),
     );
-    let calling_account_id = "some-account.near".to_string();
+    let calling_account_id = "some-account.near";
 
     // deploy StandardPrecompiles contract
     let constructor = PrecompilesConstructor::load();
@@ -46,7 +46,7 @@ pub(crate) fn eth_standard_precompiles_benchmark(c: &mut Criterion) {
         let (output, maybe_err) =
             runner
                 .one_shot()
-                .call(SUBMIT, calling_account_id.clone(), tx_bytes.clone());
+                .call(SUBMIT, calling_account_id, tx_bytes.clone());
         assert!(maybe_err.is_none());
         let output = output.unwrap();
         let gas = output.burnt_gas;
@@ -62,13 +62,7 @@ pub(crate) fn eth_standard_precompiles_benchmark(c: &mut Criterion) {
     for (tx_bytes, id) in transactions.iter().zip(bench_ids.into_iter()) {
         group.bench_function(id, |b| {
             b.iter_batched(
-                || {
-                    (
-                        runner.one_shot(),
-                        calling_account_id.clone(),
-                        tx_bytes.clone(),
-                    )
-                },
+                || (runner.one_shot(), calling_account_id, tx_bytes.clone()),
                 |(r, c, i)| r.call(SUBMIT, c, i),
                 BatchSize::SmallInput,
             )

--- a/src/benches/eth_transfer.rs
+++ b/src/benches/eth_transfer.rs
@@ -26,13 +26,12 @@ pub(crate) fn eth_transfer_benchmark(c: &mut Criterion) {
         &source_account,
     );
     let input = rlp::encode(&transaction).to_vec();
-    let calling_account_id = "some-account.near".to_string();
+    let calling_account_id = "some-account.near";
 
     // measure gas usage
-    let (output, maybe_err) =
-        runner
-            .one_shot()
-            .call(SUBMIT, calling_account_id.clone(), input.clone());
+    let (output, maybe_err) = runner
+        .one_shot()
+        .call(SUBMIT, calling_account_id, input.clone());
     assert!(maybe_err.is_none());
     let gas = output.unwrap().burnt_gas;
     // TODO(#45): capture this in a file
@@ -42,7 +41,7 @@ pub(crate) fn eth_transfer_benchmark(c: &mut Criterion) {
     // measure wall-clock time
     c.bench_function("eth_transfer", |b| {
         b.iter_batched(
-            || (runner.one_shot(), calling_account_id.clone(), input.clone()),
+            || (runner.one_shot(), calling_account_id, input.clone()),
             |(r, c, i)| r.call(SUBMIT, c, i),
             BatchSize::SmallInput,
         )

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -11,7 +11,6 @@ use near_vm_runner::{MockCompiledContractCache, VMError};
 use primitive_types::U256;
 use rlp::RlpStream;
 use secp256k1::{self, Message, PublicKey, SecretKey};
-use std::borrow::Cow;
 
 use crate::fungible_token::{FungibleToken, FungibleTokenMetadata};
 use crate::parameters::{InitCallArgs, NewCallArgs, SubmitResult, TransactionStatus, ViewCallArgs};
@@ -92,42 +91,33 @@ pub(crate) struct OneShotAuroraRunner<'a> {
 }
 
 impl<'a> OneShotAuroraRunner<'a> {
-    pub fn call(
-        self,
-        method_name: &str,
-        caller_account_id: String,
-        input: Vec<u8>,
-    ) -> (Option<VMOutcome>, Option<VMError>) {
-        self.call_with_optional_profile(method_name, caller_account_id, input, None)
-    }
-
     pub fn profiled_call(
         self,
         method_name: &str,
-        caller_account_id: String,
+        caller_account_id: &str,
         input: Vec<u8>,
-    ) -> (Option<VMOutcome>, Option<VMError>, ProfileData) {
-        let profile = Default::default();
-        let (outcome, error) =
-            self.call_with_optional_profile(method_name, caller_account_id, input, Some(&profile));
+    ) -> (Option<VMOutcome>, Option<VMError>, ExecutionProfile) {
+        let (outcome, error) = self.call(method_name, caller_account_id, input);
+        let profile = outcome
+            .as_ref()
+            .map(ExecutionProfile::new)
+            .unwrap_or_default();
         (outcome, error, profile)
     }
 
-    fn call_with_optional_profile(
+    pub fn call(
         mut self,
         method_name: &str,
-        caller_account_id: String,
+        caller_account_id: &str,
         input: Vec<u8>,
-        maybe_profile: Option<&ProfileData>,
     ) -> (Option<VMOutcome>, Option<VMError>) {
         AuroraRunner::update_context(
             &mut self.context,
-            caller_account_id.clone(),
+            caller_account_id,
             caller_account_id,
             input,
         );
 
-        let profile = maybe_profile.map(Cow::Borrowed).unwrap_or_default();
         near_vm_runner::run(
             &self.base.code,
             method_name,
@@ -138,7 +128,6 @@ impl<'a> OneShotAuroraRunner<'a> {
             &[],
             self.base.current_protocol_version,
             Some(&self.base.cache),
-            profile.as_ref(),
         )
     }
 }
@@ -154,58 +143,32 @@ impl AuroraRunner {
 
     pub fn update_context(
         context: &mut VMContext,
-        caller_account_id: String,
-        signer_account_id: String,
+        caller_account_id: &str,
+        signer_account_id: &str,
         input: Vec<u8>,
     ) {
         context.block_index += 1;
         context.block_timestamp += 100;
         context.input = input;
-        context.signer_account_id = signer_account_id;
-        context.predecessor_account_id = caller_account_id;
+        context.signer_account_id = as_account_id(signer_account_id);
+        context.predecessor_account_id = as_account_id(caller_account_id);
     }
 
     pub fn call(
         &mut self,
         method_name: &str,
-        caller_account_id: String,
+        caller_account_id: &str,
         input: Vec<u8>,
     ) -> (Option<VMOutcome>, Option<VMError>) {
-        self.call_with_signer(
-            method_name,
-            caller_account_id.clone(),
-            caller_account_id,
-            input,
-            None,
-        )
-    }
-
-    // Might be useful for optimizing performance in the future
-    #[allow(dead_code)]
-    pub fn profiled_call(
-        &mut self,
-        method_name: &str,
-        caller_account_id: String,
-        input: Vec<u8>,
-    ) -> (Option<VMOutcome>, Option<VMError>, ProfileData) {
-        let profile = Default::default();
-        let (outcome, error) = self.call_with_signer(
-            method_name,
-            caller_account_id.clone(),
-            caller_account_id,
-            input,
-            Some(&profile),
-        );
-        (outcome, error, profile)
+        self.call_with_signer(method_name, caller_account_id, caller_account_id, input)
     }
 
     pub fn call_with_signer(
         &mut self,
         method_name: &str,
-        caller_account_id: String,
-        signer_account_id: String,
+        caller_account_id: &str,
+        signer_account_id: &str,
         input: Vec<u8>,
-        maybe_profile: Option<&ProfileData>,
     ) -> (Option<VMOutcome>, Option<VMError>) {
         Self::update_context(
             &mut self.context,
@@ -214,7 +177,6 @@ impl AuroraRunner {
             input,
         );
 
-        let profile = maybe_profile.map(Cow::Borrowed).unwrap_or_default();
         let (maybe_outcome, maybe_error) = near_vm_runner::run(
             &self.code,
             method_name,
@@ -225,7 +187,6 @@ impl AuroraRunner {
             &[],
             self.current_protocol_version,
             Some(&self.cache),
-            profile.as_ref(),
         );
         if let Some(outcome) = &maybe_outcome {
             self.context.storage_usage = outcome.storage_usage;
@@ -276,7 +237,7 @@ impl AuroraRunner {
         account: &SecretKey,
         transaction: LegacyEthTransaction,
     ) -> Result<SubmitResult, VMError> {
-        let calling_account_id = "some-account.near".to_string();
+        let calling_account_id = "some-account.near";
         let signed_tx = sign_transaction(transaction, Some(self.chain_id), account);
 
         let (output, maybe_err) =
@@ -298,7 +259,7 @@ impl AuroraRunner {
         constructor_tx: F,
         contract_constructor: T,
     ) -> DeployedContract {
-        let calling_account_id = "some-account.near".to_string();
+        let calling_account_id = "some-account.near";
         let tx = constructor_tx(&contract_constructor);
         let signed_tx = sign_transaction(tx, Some(self.chain_id), account);
         let (output, maybe_err) =
@@ -316,7 +277,7 @@ impl AuroraRunner {
 
     pub fn view_call(&self, args: ViewCallArgs) -> Result<TransactionStatus, VMError> {
         let input = args.try_to_vec().unwrap();
-        let (outcome, maybe_error) = self.one_shot().call("view", "VIEWER".to_string(), input);
+        let (outcome, maybe_error) = self.one_shot().call("view", "viewer", input);
         Ok(
             TransactionStatus::try_from_slice(&Self::bytes_from_outcome(outcome, maybe_error)?)
                 .unwrap(),
@@ -326,11 +287,10 @@ impl AuroraRunner {
     pub fn profiled_view_call(
         &self,
         args: ViewCallArgs,
-    ) -> (Result<TransactionStatus, VMError>, ProfileData) {
+    ) -> (Result<TransactionStatus, VMError>, ExecutionProfile) {
         let input = args.try_to_vec().unwrap();
         let (outcome, maybe_error, profile) =
-            self.one_shot()
-                .profiled_call("view", "VIEWER".to_string(), input);
+            self.one_shot().profiled_call("view", "viewer", input);
         let status = Self::bytes_from_outcome(outcome, maybe_error)
             .map(|bytes| TransactionStatus::try_from_slice(&bytes).unwrap());
 
@@ -348,11 +308,9 @@ impl AuroraRunner {
     // Used in `get_balance` and `get_nonce`. This function exists to avoid code duplication
     // since the contract's `get_nonce` and `get_balance` have the same type signature.
     fn getter_method_call(&self, method_name: &str, address: Address) -> U256 {
-        let (outcome, maybe_error) = self.one_shot().call(
-            method_name,
-            "GETTER".to_string(),
-            address.as_bytes().to_vec(),
-        );
+        let (outcome, maybe_error) =
+            self.one_shot()
+                .call(method_name, "getter", address.as_bytes().to_vec());
         assert!(maybe_error.is_none());
         let bytes = outcome.unwrap().return_data.as_value().unwrap();
         U256::from_big_endian(&bytes)
@@ -389,10 +347,10 @@ impl Default for AuroraRunner {
             cache: Default::default(),
             ext: Default::default(),
             context: VMContext {
-                current_account_id: aurora_account_id.clone(),
-                signer_account_id: aurora_account_id.clone(),
+                current_account_id: as_account_id(&aurora_account_id),
+                signer_account_id: as_account_id(&aurora_account_id),
                 signer_account_pk: vec![],
-                predecessor_account_id: aurora_account_id,
+                predecessor_account_id: as_account_id(&aurora_account_id),
                 input: vec![],
                 block_index: 0,
                 block_timestamp: 0,
@@ -403,7 +361,7 @@ impl Default for AuroraRunner {
                 attached_deposit: 0,
                 prepaid_gas: 10u64.pow(18),
                 random_seed: vec![],
-                is_view: false,
+                view_config: None,
                 output_data_receivers: vec![],
             },
             wasm_config: Default::default(),
@@ -411,6 +369,33 @@ impl Default for AuroraRunner {
             current_protocol_version: u32::MAX,
             previous_logs: Default::default(),
         }
+    }
+}
+
+/// Wrapper around `ProfileData` to still include the wasm gas usage
+/// (which was removed in https://github.com/near/nearcore/pull/4438).
+#[derive(Default, Clone)]
+pub(crate) struct ExecutionProfile {
+    host_breakdown: ProfileData,
+    wasm_gas: u64,
+}
+
+impl ExecutionProfile {
+    pub fn new(outcome: &VMOutcome) -> Self {
+        let wasm_gas =
+            outcome.burnt_gas - outcome.profile.host_gas() - outcome.profile.action_gas();
+        Self {
+            host_breakdown: outcome.profile.clone(),
+            wasm_gas,
+        }
+    }
+
+    pub fn wasm_gas(&self) -> u64 {
+        self.wasm_gas
+    }
+
+    pub fn all_gas(&self) -> u64 {
+        self.wasm_gas + self.host_breakdown.host_gas() + self.host_breakdown.action_gas()
     }
 }
 
@@ -423,11 +408,8 @@ pub(crate) fn deploy_evm() -> AuroraRunner {
         upgrade_delay_blocks: 1,
     };
 
-    let (_, maybe_error) = runner.call(
-        "new",
-        runner.aurora_account_id.clone(),
-        args.try_to_vec().unwrap(),
-    );
+    let account_id = runner.aurora_account_id.clone();
+    let (_, maybe_error) = runner.call("new", &account_id, args.try_to_vec().unwrap());
 
     assert!(maybe_error.is_none());
 
@@ -436,11 +418,8 @@ pub(crate) fn deploy_evm() -> AuroraRunner {
         eth_custodian_address: "d045f7e19B2488924B97F9c145b5E51D0D895A65".to_string(),
         metadata: FungibleTokenMetadata::default(),
     };
-    let (_, maybe_error) = runner.call(
-        "new_eth_connector",
-        runner.aurora_account_id.clone(),
-        args.try_to_vec().unwrap(),
-    );
+    let (_, maybe_error) =
+        runner.call("new_eth_connector", &account_id, args.try_to_vec().unwrap());
 
     assert!(maybe_error.is_none());
 
@@ -574,6 +553,10 @@ pub(crate) fn address_from_hex(address: &str) -> Address {
     };
 
     Address::from_slice(&bytes)
+}
+
+pub(crate) fn as_account_id(account_id: &str) -> near_primitives_core::types::AccountId {
+    account_id.parse().unwrap()
 }
 
 pub fn unwrap_success(result: SubmitResult) -> Vec<u8> {

--- a/src/test_utils/self_destruct.rs
+++ b/src/test_utils/self_destruct.rs
@@ -179,7 +179,7 @@ impl SelfDestruct {
         .try_to_vec()
         .unwrap();
 
-        runner.call("call", "anyone".to_string(), input);
+        runner.call("call", "anyone", input);
     }
 }
 

--- a/src/test_utils/solidity.rs
+++ b/src/test_utils/solidity.rs
@@ -1,6 +1,5 @@
 use crate::prelude::{Address, U256};
 use crate::transaction::LegacyEthTransaction;
-use near_sdk::serde_json;
 use serde::Deserialize;
 use std::fs;
 use std::path::Path;

--- a/src/tests/erc20.rs
+++ b/src/tests/erc20.rs
@@ -78,7 +78,9 @@ fn erc20_mint_out_of_gas() {
     );
     test_utils::validate_address_balance_and_nonce(
         &runner,
-        types::near_account_to_evm_address(runner.context.predecessor_account_id.as_bytes()),
+        types::near_account_to_evm_address(
+            runner.context.predecessor_account_id.as_ref().as_bytes(),
+        ),
         Wei::new_u64(GAS_LIMIT * GAS_PRICE),
         U256::zero(),
     );

--- a/src/tests/erc20_connector.rs
+++ b/src/tests/erc20_connector.rs
@@ -76,7 +76,7 @@ impl test_utils::AuroraRunner {
         caller_account_id: String,
         input: Vec<u8>,
     ) -> CallResult {
-        let (outcome, error) = self.call(method_name, caller_account_id, input);
+        let (outcome, error) = self.call(method_name, &caller_account_id, input);
         CallResult { outcome, error }
     }
 
@@ -87,13 +87,8 @@ impl test_utils::AuroraRunner {
         signer_account_id: String,
         input: Vec<u8>,
     ) -> CallResult {
-        let (outcome, error) = self.call_with_signer(
-            method_name,
-            caller_account_id,
-            signer_account_id,
-            input,
-            None,
-        );
+        let (outcome, error) =
+            self.call_with_signer(method_name, &caller_account_id, &signer_account_id, input);
         CallResult { outcome, error }
     }
 

--- a/src/tests/eth_connector.rs
+++ b/src/tests/eth_connector.rs
@@ -45,7 +45,7 @@ fn init_contract(
     custodian_address: &str,
 ) -> UserAccount {
     let contract_account = master_account.deploy(
-        &crate::test_utils::AuroraRunner::default().code.code,
+        crate::test_utils::AuroraRunner::default().code.code(),
         contract_name.parse().unwrap(),
         to_yocto("1000000"),
     );

--- a/src/tests/meta_parsing.rs
+++ b/src/tests/meta_parsing.rs
@@ -76,7 +76,7 @@ fn public_key_to_address(public_key: PublicKey) -> Address {
 #[test]
 fn test_meta_parsing() {
     let chain_id = 1313161555;
-    let signer = InMemorySigner::from_seed("doesnt", KeyType::SECP256K1, "a");
+    let signer = InMemorySigner::from_seed("doesnt".parse().unwrap(), KeyType::SECP256K1, "a");
     let signer_addr = public_key_to_address(signer.public_key.clone());
     let domain_separator = near_erc712_domain(U256::from(chain_id));
 

--- a/src/tests/sanity.rs
+++ b/src/tests/sanity.rs
@@ -186,8 +186,9 @@ fn test_transfer_charging_gas_success() {
     let expected_source_balance = INITIAL_BALANCE - TRANSFER_AMOUNT - spent_amount;
     let expected_dest_balance = TRANSFER_AMOUNT;
     let expected_relayer_balance = spent_amount;
-    let relayer_address =
-        types::near_account_to_evm_address(runner.context.predecessor_account_id.as_bytes());
+    let relayer_address = types::near_account_to_evm_address(
+        runner.context.predecessor_account_id.as_ref().as_bytes(),
+    );
 
     // validate post-state
     test_utils::validate_address_balance_and_nonce(
@@ -239,8 +240,9 @@ fn test_eth_transfer_charging_gas_not_enough_balance() {
     assert_eq!(result.status, TransactionStatus::OutOfFund);
 
     // validate post-state
-    let relayer =
-        types::near_account_to_evm_address(runner.context.predecessor_account_id.as_bytes());
+    let relayer = types::near_account_to_evm_address(
+        runner.context.predecessor_account_id.as_ref().as_bytes(),
+    );
     test_utils::validate_address_balance_and_nonce(
         &runner,
         source_address,
@@ -323,11 +325,8 @@ fn test_block_hash_contract() {
 fn test_ft_metadata() {
     let mut runner = test_utils::deploy_evm();
 
-    let (maybe_outcome, maybe_error) = runner.call(
-        "ft_metadata",
-        runner.context.signer_account_id.clone(),
-        Vec::new(),
-    );
+    let account_id: String = runner.context.signer_account_id.clone().into();
+    let (maybe_outcome, maybe_error) = runner.call("ft_metadata", &account_id, Vec::new());
     assert!(maybe_error.is_none());
     let outcome = maybe_outcome.unwrap();
     let json_value = crate::json::parse_json(&outcome.return_data.as_value().unwrap()).unwrap();

--- a/src/tests/state_migration.rs
+++ b/src/tests/state_migration.rs
@@ -30,7 +30,7 @@ pub fn deploy_evm() -> AuroraAccount {
     let aurora_runner = AuroraRunner::default();
     let main_account = near_sdk_sim::init_simulator(None);
     let contract_account = main_account.deploy(
-        &aurora_runner.code.code,
+        aurora_runner.code.code(),
         aurora_runner.aurora_account_id.parse().unwrap(),
         5 * near_sdk_sim::STORAGE_AMOUNT,
     );


### PR DESCRIPTION
There is an ongoing effort in the nearcore team to improve the runtime performance and this will ultimately lead to lower gas parameters; allowing us to fit more Ethereum gas per NEAR gas. In particular, preliminary results based on changes in https://github.com/near/nearcore/pull/4688 indicate that PR could increase the maximum Ethereum gas we can fit in one NEAR transaction by 7x.

In anticipation of that PR being merged in nearcore, we are upgrading our dependencies on nearcore to the latest commit. This will allow us to easily pull in new runtime changes to our benchmarks and thus measure their improvement.