### PR TITLE
Fix issue with admin only contract call

### DIFF
--- a/src/connector.rs
+++ b/src/connector.rs
@@ -13,7 +13,6 @@ use crate::prelude::*;
 use crate::storage::{self, EthConnectorStorageId, KeyPrefix};
 use borsh::{BorshDeserialize, BorshSerialize};
 
-pub(crate) const ERC20_ADMIN_PREFIX: &str = "erc20.";
 pub(crate) const ERR_NOT_ENOUGH_BALANCE_FOR_FEE: &str = "ERR_NOT_ENOUGH_BALANCE_FOR_FEE";
 pub const NO_DEPOSIT: Balance = 0;
 const GAS_FOR_FINISH_DEPOSIT: Gas = 50_000_000_000_000;
@@ -631,11 +630,6 @@ impl EthConnectorContract {
         ))
         .and_then(|data| FungibleTokenMetadata::try_from_slice(&data).ok())
     }
-}
-
-pub(crate) fn erc20_admin_address(base_account_id: &[u8]) -> Address {
-    let erc20_admin_account_id = [ERC20_ADMIN_PREFIX.as_bytes(), base_account_id].concat();
-    crate::types::near_account_to_evm_address(erc20_admin_account_id.as_slice())
 }
 
 impl AdminControlled for EthConnectorContract {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -5,13 +5,14 @@ use evm::executor::{MemoryStackState, StackExecutor, StackSubstateMetadata};
 use evm::ExitFatal;
 use evm::{Config, CreateScheme, ExitError, ExitReason};
 
-use crate::connector::{self, EthConnectorContract};
+use crate::connector::EthConnectorContract;
+#[cfg(feature = "contract")]
+use crate::contract::current_address;
 use crate::map::{BijectionMap, LookupMap};
 use crate::parameters::{
     FunctionCallArgs, NEP141FtOnTransferArgs, NewCallArgs, PromiseCreateArgs, ResultLog,
     SubmitResult, TransactionStatus, ViewCallArgs,
 };
-
 use crate::precompiles::native::{ExitToEthereum, ExitToNear};
 use crate::precompiles::Precompiles;
 use crate::prelude::{is_valid_account_id, Address, Cow, String, TryInto, Vec, H256, U256};
@@ -789,7 +790,7 @@ impl Engine {
             ethabi::Token::Uint(args.amount.into()),
         ]);
 
-        let erc20_admin_address = connector::erc20_admin_address(&sdk::current_account_id());
+        let erc20_admin_address = current_address();
         unwrap_res_or_finish!(
             self.call(
                 erc20_admin_address,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ pub unsafe fn on_alloc_error(_: core::alloc::Layout) -> ! {
 mod contract {
     use borsh::{BorshDeserialize, BorshSerialize};
 
-    use crate::connector::{self, EthConnectorContract};
+    use crate::connector::EthConnectorContract;
     use crate::engine::{Engine, EngineState, GasPaymentError};
     use crate::fungible_token::FungibleTokenMetadata;
     #[cfg(feature = "evm_bully")]
@@ -382,7 +382,7 @@ mod contract {
 
         let mut engine = Engine::new(predecessor_address()).sdk_unwrap();
 
-        let erc20_admin_address = connector::erc20_admin_address(&sdk::current_account_id());
+        let erc20_admin_address = current_address();
         let erc20_contract = include_bytes!("../etc/eth-contracts/res/EvmErc20.bin");
         let deploy_args = ethabi::encode(&[
             ethabi::Token::String("Empty".to_string()),
@@ -694,6 +694,10 @@ mod contract {
 
     fn predecessor_address() -> Address {
         near_account_to_evm_address(&sdk::predecessor_account_id())
+    }
+
+    pub fn current_address() -> Address {
+        near_account_to_evm_address(&sdk::current_account_id())
     }
 }
 

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -30,10 +30,6 @@ pub fn origin() -> AccountId {
     "aurora".to_string()
 }
 
-pub fn erc20_admin_account() -> AccountId {
-    [crate::connector::ERC20_ADMIN_PREFIX, &origin()].concat()
-}
-
 pub(crate) const SUBMIT: &str = "submit";
 
 pub(crate) mod erc20;

--- a/src/tests/contract_call.rs
+++ b/src/tests/contract_call.rs
@@ -1,4 +1,4 @@
-use crate::test_utils::{AuroraRunner, Signer};
+use crate::test_utils::{origin, AuroraRunner, Signer};
 
 use crate::test_utils;
 use crate::test_utils::exit_precompile::{Tester, TesterConstructor};
@@ -23,7 +23,7 @@ fn setup_test() -> (AuroraRunner, Signer, [u8; 20], Tester) {
         token,
         tester.contract.address.into(),
         1_000_000_000,
-        test_utils::erc20_admin_account(),
+        origin(),
     );
 
     (runner, signer, token, tester)

--- a/src/tests/erc20_connector.rs
+++ b/src/tests/erc20_connector.rs
@@ -245,7 +245,7 @@ fn test_mint() {
     let balance = runner.balance_of(token, address, origin());
     assert_eq!(balance, U256::from(0));
     let amount = 10;
-    let _result = runner.mint(token, address, amount, test_utils::erc20_admin_account());
+    let _result = runner.mint(token, address, amount, origin());
     let balance = runner.balance_of(token, address, origin());
     assert_eq!(balance, U256::from(amount));
 }
@@ -361,12 +361,7 @@ fn test_transfer_erc20_token() {
         U256::zero()
     );
 
-    runner.mint(
-        token,
-        peer0.address,
-        to_mint,
-        test_utils::erc20_admin_account(),
-    );
+    runner.mint(token, peer0.address, to_mint, origin());
 
     assert_eq!(
         runner.balance_of(token, peer0.address, origin()),

--- a/src/tests/sanity.rs
+++ b/src/tests/sanity.rs
@@ -21,8 +21,7 @@ fn test_num_wasm_functions() {
     let artifact = get_compiled_artifact(&runner);
     let module_info = artifact.info();
     let num_functions = module_info.func_assoc.len();
-    println!("num functions: {}", num_functions);
-    assert!(num_functions <= 1280);
+    assert!(num_functions <= 1281);
 }
 
 /// Tests we can transfer Eth from one account to another and that the balances are correctly

--- a/src/tests/sanity.rs
+++ b/src/tests/sanity.rs
@@ -21,6 +21,7 @@ fn test_num_wasm_functions() {
     let artifact = get_compiled_artifact(&runner);
     let module_info = artifact.info();
     let num_functions = module_info.func_assoc.len();
+    println!("num functions: {}", num_functions);
     assert!(num_functions <= 1280);
 }
 


### PR DESCRIPTION
While going through the nep-141 contract failure, it was discovered that while code itself was fine in the Engine, there was a requirement in the ERC-20 deploy contract for a `mint` method to only be called by an admin. Through continual improvements to the engine, we worked on removing this requirement to improve the user experience.

This reverts some changes from https://github.com/aurora-is-near/aurora-engine/pull/184 while we work on a script to change this data for all previously deployed ERC-20 contracts.