### PR TITLE
Fix(deploy benchmark): Realistic deploy transaction

### DIFF
--- a/src/benches/eth_deploy_code.rs
+++ b/src/benches/eth_deploy_code.rs
@@ -1,12 +1,13 @@
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput};
 use secp256k1::SecretKey;
 
-use crate::test_utils::{address_from_secret_key, create_eth_transaction, deploy_evm, SUBMIT};
+use crate::test_utils::{
+    address_from_secret_key, create_deploy_transaction, deploy_evm, sign_transaction, SUBMIT,
+};
 use crate::types::Wei;
 
 const INITIAL_BALANCE: Wei = Wei::new_u64(1000);
 const INITIAL_NONCE: u64 = 0;
-const TRANSFER_AMOUNT: Wei = Wei::zero();
 
 pub(crate) fn eth_deploy_code_benchmark(c: &mut Criterion) {
     let mut runner = deploy_evm();
@@ -17,20 +18,16 @@ pub(crate) fn eth_deploy_code_benchmark(c: &mut Criterion) {
         INITIAL_BALANCE,
         INITIAL_NONCE.into(),
     );
-    let inputs: Vec<_> = [1, 4, 8, 12, 16]
+    let inputs: Vec<_> = [1, 4, 8, 10, 13, 14]
         .iter()
         .copied()
         .map(|n| {
             let code_size = 2usize.pow(n);
             let code: Vec<u8> = vec![0; code_size];
-            let transaction = create_eth_transaction(
-                None,
-                TRANSFER_AMOUNT.into(),
-                code,
-                Some(runner.chain_id),
-                &source_account,
-            );
-            rlp::encode(&transaction).to_vec()
+            let transaction = create_deploy_transaction(code, INITIAL_NONCE.into());
+            let signed_transaction =
+                sign_transaction(transaction, Some(runner.chain_id), &source_account);
+            rlp::encode(&signed_transaction).to_vec()
         })
         .collect();
     let calling_account_id = "some-account.near";

--- a/src/tests/sanity.rs
+++ b/src/tests/sanity.rs
@@ -5,6 +5,7 @@ use crate::test_utils;
 use crate::tests::state_migration;
 use crate::types::{self, Wei, ERC20_MINT_SELECTOR};
 use borsh::{BorshDeserialize, BorshSerialize};
+use rand::RngCore;
 use secp256k1::SecretKey;
 use std::path::{Path, PathBuf};
 
@@ -12,6 +13,32 @@ const INITIAL_BALANCE: Wei = Wei::new_u64(1_000_000);
 const INITIAL_NONCE: u64 = 0;
 const TRANSFER_AMOUNT: Wei = Wei::new_u64(123);
 const GAS_PRICE: u64 = 10;
+
+#[test]
+fn test_deploy_contract() {
+    let (mut runner, mut signer, _) = initialize_transfer();
+
+    // Randomly generate some "contract code"
+    const LEN: usize = 567;
+    let code: Vec<u8> = {
+        let mut rng = rand::thread_rng();
+        let mut buf = vec![0u8; LEN];
+        rng.fill_bytes(&mut buf);
+        buf
+    };
+
+    // Deploy that code
+    let result = runner
+        .submit_with_signer(&mut signer, |nonce| {
+            test_utils::create_deploy_transaction(code.clone(), nonce)
+        })
+        .unwrap();
+    let address = Address::from_slice(test_utils::unwrap_success_slice(&result));
+
+    // Confirm the code stored at that address is equal to the input code.
+    let stored_code = runner.get_code(address);
+    assert_eq!(code, stored_code);
+}
 
 #[test]
 fn test_override_state() {


### PR DESCRIPTION
The original benchmark did not attempt to make the code to deploy a valid EVM program. For some reason this still returned successfully and burned lots of gas, so I didn't think anything of it. However, my recent work with the 1inch contract showed that deploying a real contract was possible even if it consumed a lot of EVM gas. In this PR I make the deploy transactions used in the benchmark more realistic (actually writing some bytes into the code field of the created account).

As a result of this change we can establish a more accurate number for the EVM gas limit we can support within the 200 Tgas limit on NEAR. Based on fitting a line to the data point from this new benchmark (see plot below), I conclude we can support deploy transactions which consume more than 20 million EVM gas.

Note: this does not tell us anything about the gas limit for compute-heavy transactions. We still need performance improvements from NEAR to execute some UniswapV3 transactions for example.

![deploy_benchamrk](https://user-images.githubusercontent.com/13788876/133681581-02ffc777-ea34-4f45-80c8-11dfff6a61be.PNG)
