### PR TITLE
Feat(exit precompile): Events for exit precompile calls.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,7 @@ name = "aurora-engine-tests"
 version = "1.0.0"
 dependencies = [
  "aurora-engine",
+ "aurora-engine-precompiles",
  "aurora-engine-sdk",
  "aurora-engine-types",
  "borsh 0.8.2",

--- a/engine-precompiles/src/lib.rs
+++ b/engine-precompiles/src/lib.rs
@@ -206,7 +206,7 @@ impl Precompiles {
 /// const fn for making an address by concatenating the bytes from two given numbers,
 /// Note that 32 + 128 = 160 = 20 bytes (the length of an address). This function is used
 /// as a convenience for specifying the addresses of the various precompiles.
-const fn make_address(x: u32, y: u128) -> prelude::Address {
+pub const fn make_address(x: u32, y: u128) -> prelude::Address {
     let x_bytes = x.to_be_bytes();
     let y_bytes = y.to_be_bytes();
     prelude::Address([

--- a/engine-precompiles/src/lib.rs
+++ b/engine-precompiles/src/lib.rs
@@ -233,6 +233,45 @@ const fn make_address(x: u32, y: u128) -> prelude::Address {
     ])
 }
 
+const fn make_h256(x: u128, y: u128) -> prelude::H256 {
+    let x_bytes = x.to_be_bytes();
+    let y_bytes = y.to_be_bytes();
+    prelude::H256([
+        x_bytes[0],
+        x_bytes[1],
+        x_bytes[2],
+        x_bytes[3],
+        x_bytes[4],
+        x_bytes[5],
+        x_bytes[6],
+        x_bytes[7],
+        x_bytes[8],
+        x_bytes[9],
+        x_bytes[10],
+        x_bytes[11],
+        x_bytes[12],
+        x_bytes[13],
+        x_bytes[14],
+        x_bytes[15],
+        y_bytes[0],
+        y_bytes[1],
+        y_bytes[2],
+        y_bytes[3],
+        y_bytes[4],
+        y_bytes[5],
+        y_bytes[6],
+        y_bytes[7],
+        y_bytes[8],
+        y_bytes[9],
+        y_bytes[10],
+        y_bytes[11],
+        y_bytes[12],
+        y_bytes[13],
+        y_bytes[14],
+        y_bytes[15],
+    ])
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{prelude, Byzantium, Istanbul};

--- a/engine-precompiles/src/native.rs
+++ b/engine-precompiles/src/native.rs
@@ -33,18 +33,18 @@ mod costs {
     pub(super) const WITHDRAWAL_GAS: Gas = 100_000_000_000_000;
 }
 
-pub(crate) mod events {
-    use crate::prelude::{vec, Address, String, H256, U256};
+pub mod events {
+    use crate::prelude::{vec, Address, String, ToString, H256, U256};
 
     /// Derived from event signature (see tests::test_exit_signatures)
     pub const EXIT_TO_NEAR_SIGNATURE: H256 = crate::make_h256(
-        0xbe5650b8d0ad81b6b2807ab7c8f2892d,
-        0xdb19f1b8174ea910f914d5103e196cce,
+        0x4bd8f58b14f86d1103530f22f339e5ae,
+        0xcfb084f432b43f6fdda8abe6d1ffa1c3,
     );
     /// Derived from event signature (see tests::test_exit_signatures)
     pub const EXIT_TO_ETH_SIGNATURE: H256 = crate::make_h256(
-        0x4c58d7f2fd84892be1460b9ed55b722b,
-        0x7f7c790c0bd00cd06aadff27ca3bdb2e,
+        0x03069c4a74ef98a028eacca7d6190516,
+        0x64e2c62a0c357b9644a33466c1014b5e,
     );
 
     /// ExitToNear(bool indexed is_erc20, string indexed dest, uint amount)
@@ -99,6 +99,54 @@ pub(crate) mod events {
         let mut result = [0u8; 32];
         result[12..].copy_from_slice(a.as_ref());
         H256(result)
+    }
+
+    pub fn exit_to_near_schema() -> ethabi::Event {
+        ethabi::Event {
+            name: "ExitToNear".to_string(),
+            inputs: vec![
+                ethabi::EventParam {
+                    name: "is_erc20".to_string(),
+                    kind: ethabi::ParamType::Bool,
+                    indexed: true,
+                },
+                ethabi::EventParam {
+                    name: "dest".to_string(),
+                    kind: ethabi::ParamType::String,
+                    indexed: true,
+                },
+                ethabi::EventParam {
+                    name: "amount".to_string(),
+                    kind: ethabi::ParamType::Uint(256),
+                    indexed: false,
+                },
+            ],
+            anonymous: false,
+        }
+    }
+
+    pub fn exit_to_eth_schema() -> ethabi::Event {
+        ethabi::Event {
+            name: "ExitToEth".to_string(),
+            inputs: vec![
+                ethabi::EventParam {
+                    name: "is_erc20".to_string(),
+                    kind: ethabi::ParamType::Bool,
+                    indexed: true,
+                },
+                ethabi::EventParam {
+                    name: "dest".to_string(),
+                    kind: ethabi::ParamType::Address,
+                    indexed: true,
+                },
+                ethabi::EventParam {
+                    name: "amount".to_string(),
+                    kind: ethabi::ParamType::Uint(256),
+                    indexed: false,
+                },
+            ],
+            anonymous: false,
+        }
     }
 }
 
@@ -444,7 +492,6 @@ impl Precompile for ExitToEthereum {
 mod tests {
     use super::{ExitToEthereum, ExitToNear};
     use crate::prelude::sdk::types::near_account_to_evm_address;
-    use crate::prelude::{vec, ToString};
 
     #[test]
     fn test_precompile_id() {
@@ -460,49 +507,8 @@ mod tests {
 
     #[test]
     fn test_exit_signatures() {
-        let exit_to_near = ethabi::Event {
-            name: "ExitToNear".to_string(),
-            inputs: vec![
-                ethabi::EventParam {
-                    name: "is_erc20".to_string(),
-                    kind: ethabi::ParamType::Bool,
-                    indexed: true,
-                },
-                ethabi::EventParam {
-                    name: "dest".to_string(),
-                    kind: ethabi::ParamType::String,
-                    indexed: true,
-                },
-                ethabi::EventParam {
-                    name: "amount".to_string(),
-                    kind: ethabi::ParamType::Int(256),
-                    indexed: false,
-                },
-            ],
-            anonymous: false,
-        };
-
-        let exit_to_eth = ethabi::Event {
-            name: "ExitToEth".to_string(),
-            inputs: vec![
-                ethabi::EventParam {
-                    name: "is_erc20".to_string(),
-                    kind: ethabi::ParamType::Bool,
-                    indexed: true,
-                },
-                ethabi::EventParam {
-                    name: "dest".to_string(),
-                    kind: ethabi::ParamType::Address,
-                    indexed: true,
-                },
-                ethabi::EventParam {
-                    name: "amount".to_string(),
-                    kind: ethabi::ParamType::Int(256),
-                    indexed: false,
-                },
-            ],
-            anonymous: false,
-        };
+        let exit_to_near = super::events::exit_to_near_schema();
+        let exit_to_eth = super::events::exit_to_eth_schema();
 
         assert_eq!(
             exit_to_near.signature(),

--- a/engine-tests/Cargo.toml
+++ b/engine-tests/Cargo.toml
@@ -16,6 +16,7 @@ autobenches = false
 aurora-engine = { path = "../engine", default-features = false, features=["sha2"] }
 aurora-engine-types = { path = "../engine-types", default-features = false }
 aurora-engine-sdk = { path = "../engine-sdk", default-features = false }
+aurora-engine-precompiles = { path = "../engine-precompiles", default-features = false }
 borsh = { version = "0.8.2", default-features = false }
 byte-slice-cast = { version = "1.0", default-features = false }
 sha3 = { version = "0.9.1", default-features = false }

--- a/engine-tests/src/test_utils/exit_precompile.rs
+++ b/engine-tests/src/test_utils/exit_precompile.rs
@@ -105,9 +105,8 @@ impl Tester {
         runner: &mut AuroraRunner,
         signer: &mut Signer,
         flag: bool,
-    ) -> Result<(), Revert> {
+    ) -> Result<SubmitResult, Revert> {
         self.call_function(runner, signer, "withdraw", &[ethabi::Token::Bool(flag)])
-            .map(|_| ())
     }
 
     pub fn withdraw_and_fail(
@@ -115,14 +114,13 @@ impl Tester {
         runner: &mut AuroraRunner,
         signer: &mut Signer,
         flag: bool,
-    ) -> Result<(), Revert> {
+    ) -> Result<SubmitResult, Revert> {
         self.call_function(
             runner,
             signer,
             "withdrawAndFail",
             &[ethabi::Token::Bool(flag)],
         )
-        .map(|_| ())
     }
 
     pub fn try_withdraw_and_avoid_fail(
@@ -130,14 +128,13 @@ impl Tester {
         runner: &mut AuroraRunner,
         signer: &mut Signer,
         flag: bool,
-    ) -> Result<(), Revert> {
+    ) -> Result<SubmitResult, Revert> {
         self.call_function(
             runner,
             signer,
             "tryWithdrawAndAvoidFail",
             &[ethabi::Token::Bool(flag)],
         )
-        .map(|_| ())
     }
 
     pub fn try_withdraw_and_avoid_fail_and_succeed(
@@ -145,14 +142,13 @@ impl Tester {
         runner: &mut AuroraRunner,
         signer: &mut Signer,
         flag: bool,
-    ) -> Result<(), Revert> {
+    ) -> Result<SubmitResult, Revert> {
         self.call_function(
             runner,
             signer,
             "tryWithdrawAndAvoidFailAndSucceed",
             &[ethabi::Token::Bool(flag)],
         )
-        .map(|_| ())
     }
 }
 

--- a/engine-tests/src/tests/contract_call.rs
+++ b/engine-tests/src/tests/contract_call.rs
@@ -1,3 +1,4 @@
+use crate::prelude::{vec, Address, H256};
 use crate::test_utils::{origin, AuroraRunner, Signer};
 
 use crate::test_utils;
@@ -49,8 +50,72 @@ fn withdraw() {
         (false, "Call contract: tt.testnet.withdraw"),
     ];
 
-    for (flag, expected) in test_data {
-        assert!(tester.withdraw(&mut runner, &mut signer, flag).is_ok());
+    for (is_to_near, expected) in test_data {
+        let withdraw_result = tester
+            .withdraw(&mut runner, &mut signer, is_to_near)
+            .unwrap();
+
+        // parse exit events
+        let schema = if is_to_near {
+            aurora_engine_precompiles::native::events::exit_to_near_schema()
+        } else {
+            aurora_engine_precompiles::native::events::exit_to_eth_schema()
+        };
+        let signature = schema.signature();
+        let exit_events: Vec<ethabi::Log> = withdraw_result
+            .logs
+            .into_iter()
+            .filter_map(|log| {
+                if log.topics.first().unwrap() != &signature.0 {
+                    return None;
+                }
+                Some(
+                    schema
+                        .parse_log(ethabi::RawLog {
+                            topics: log.topics.into_iter().map(H256).collect(),
+                            data: log.data,
+                        })
+                        .unwrap(),
+                )
+            })
+            .collect();
+
+        // One exit event
+        assert!(exit_events.len() == 1);
+
+        let dest = if is_to_near {
+            // transferred to "target.aurora" (defined in Tester.sol)
+            let dest = "target.aurora";
+            // need to hash it since it is an indexed value in the log
+            let dest = aurora_engine_sdk::keccak(&ethabi::encode(&[ethabi::Token::String(
+                dest.to_string(),
+            )]));
+            ethabi::LogParam {
+                name: "dest".to_string(),
+                value: ethabi::Token::FixedBytes(dest.as_bytes().to_vec()),
+            }
+        } else {
+            // transferred to 0xE0f5206BBD039e7b0592d8918820024e2a7437b9 (defined in Tester.sol)
+            let address = hex::decode("E0f5206BBD039e7b0592d8918820024e2a7437b9").unwrap();
+            let address = Address::from_slice(&address);
+            ethabi::LogParam {
+                name: "dest".to_string(),
+                value: ethabi::Token::Address(address),
+            }
+        };
+        let expected_event = vec![
+            ethabi::LogParam {
+                name: "is_erc20".to_string(),
+                value: ethabi::Token::Bool(true),
+            },
+            dest,
+            ethabi::LogParam {
+                name: "amount".to_string(),
+                value: ethabi::Token::Uint(1.into()),
+            },
+        ];
+        assert_eq!(&expected_event, &exit_events[0].params);
+
         // One promise is scheduled
         assert!(runner.previous_logs.contains(&expected.to_string()));
     }

--- a/engine-tests/src/tests/contract_call.rs
+++ b/engine-tests/src/tests/contract_call.rs
@@ -36,7 +36,7 @@ fn hello_world_solidity() {
     let name = "AuroraG".to_string();
     let expected = format!("Hello {}!", name);
 
-    let result = tester.hello_world(&mut runner, &mut signer, name).unwrap();
+    let result = tester.hello_world(&mut runner, &mut signer, name);
     assert_eq!(expected, result);
 }
 

--- a/engine-tests/src/tests/contract_call.rs
+++ b/engine-tests/src/tests/contract_call.rs
@@ -1,13 +1,18 @@
-use crate::prelude::{vec, Address, H256};
+use crate::prelude::{parameters::SubmitResult, vec, Address, Wei, H256, U256};
 use crate::test_utils::{origin, AuroraRunner, Signer};
 
 use crate::test_utils;
-use crate::test_utils::exit_precompile::{Tester, TesterConstructor};
+use crate::test_utils::exit_precompile::{Tester, TesterConstructor, DEST_ACCOUNT, DEST_ADDRESS};
 
 fn setup_test() -> (AuroraRunner, Signer, [u8; 20], Tester) {
     let mut runner = AuroraRunner::new();
     let token = runner.deploy_erc20_token(&"tt.testnet".to_string());
     let mut signer = test_utils::Signer::random();
+    runner.create_address(
+        test_utils::address_from_secret_key(&signer.secret_key),
+        Wei::from_eth(1.into()).unwrap(),
+        U256::zero(),
+    );
 
     let tester_ctr = TesterConstructor::load();
     let nonce = signer.use_nonce();
@@ -61,24 +66,7 @@ fn withdraw() {
         } else {
             aurora_engine_precompiles::native::events::exit_to_eth_schema()
         };
-        let signature = schema.signature();
-        let exit_events: Vec<ethabi::Log> = withdraw_result
-            .logs
-            .into_iter()
-            .filter_map(|log| {
-                if log.topics.first().unwrap() != &signature.0 {
-                    return None;
-                }
-                Some(
-                    schema
-                        .parse_log(ethabi::RawLog {
-                            topics: log.topics.into_iter().map(H256).collect(),
-                            data: log.data,
-                        })
-                        .unwrap(),
-                )
-            })
-            .collect();
+        let exit_events = parse_exit_events(withdraw_result, &schema);
 
         // One exit event
         assert!(exit_events.len() == 1);
@@ -177,4 +165,77 @@ fn try_withdraw_and_avoid_fail_and_succeed() {
         println!("{:?} {:?}", runner.previous_logs, expected.to_string());
         assert!(runner.previous_logs.contains(&expected.to_string()));
     }
+}
+
+#[test]
+fn withdraw_eth() {
+    let (mut runner, mut signer, _token, tester) = setup_test();
+    let amount = Wei::new_u64(10);
+
+    // exit to NEAR
+    let result = tester
+        .withdraw_eth(&mut runner, &mut signer, true, amount)
+        .unwrap();
+    let dest = aurora_engine_sdk::keccak(&ethabi::encode(&[ethabi::Token::String(
+        DEST_ACCOUNT.to_string(),
+    )]));
+    let schema = aurora_engine_precompiles::native::events::exit_to_near_schema();
+    let mut expected_event = vec![
+        ethabi::LogParam {
+            name: "is_erc20".to_string(),
+            value: ethabi::Token::Bool(false),
+        },
+        ethabi::LogParam {
+            name: "dest".to_string(),
+            value: ethabi::Token::FixedBytes(dest.as_bytes().to_vec()),
+        },
+        ethabi::LogParam {
+            name: "amount".to_string(),
+            value: ethabi::Token::Uint(amount.raw()),
+        },
+    ];
+    let exit_events = parse_exit_events(result, &schema);
+
+    assert!(exit_events.len() == 1);
+    assert_eq!(&expected_event, &exit_events[0].params);
+
+    // exit to ethereum
+    let amount = Wei::new_u64(42);
+    let result = tester
+        .withdraw_eth(&mut runner, &mut signer, false, amount)
+        .unwrap();
+    expected_event[1] = ethabi::LogParam {
+        name: "dest".to_string(),
+        value: ethabi::Token::Address(DEST_ADDRESS),
+    };
+    expected_event[2] = ethabi::LogParam {
+        name: "amount".to_string(),
+        value: ethabi::Token::Uint(amount.raw()),
+    };
+    let schema = aurora_engine_precompiles::native::events::exit_to_eth_schema();
+    let exit_events = parse_exit_events(result, &schema);
+
+    assert!(exit_events.len() == 1);
+    assert_eq!(&expected_event, &exit_events[0].params);
+}
+
+fn parse_exit_events(result: SubmitResult, schema: &ethabi::Event) -> Vec<ethabi::Log> {
+    let signature = schema.signature();
+    result
+        .logs
+        .into_iter()
+        .filter_map(|log| {
+            if log.topics.first().unwrap() != &signature.0 {
+                return None;
+            }
+            Some(
+                schema
+                    .parse_log(ethabi::RawLog {
+                        topics: log.topics.into_iter().map(H256).collect(),
+                        data: log.data,
+                    })
+                    .unwrap(),
+            )
+        })
+        .collect()
 }

--- a/engine-tests/src/tests/contract_call.rs
+++ b/engine-tests/src/tests/contract_call.rs
@@ -48,7 +48,7 @@ fn hello_world_solidity() {
 
 #[test]
 fn withdraw() {
-    let (mut runner, mut signer, _token, tester) = setup_test();
+    let (mut runner, mut signer, token, tester) = setup_test();
 
     let test_data = vec![
         (true, "Call contract: tt.testnet.ft_transfer"),
@@ -93,8 +93,8 @@ fn withdraw() {
         };
         let expected_event = vec![
             ethabi::LogParam {
-                name: "is_erc20".to_string(),
-                value: ethabi::Token::Bool(true),
+                name: "erc20_address".to_string(),
+                value: ethabi::Token::Address(Address(token)),
             },
             dest,
             ethabi::LogParam {
@@ -182,8 +182,8 @@ fn withdraw_eth() {
     let schema = aurora_engine_precompiles::native::events::exit_to_near_schema();
     let mut expected_event = vec![
         ethabi::LogParam {
-            name: "is_erc20".to_string(),
-            value: ethabi::Token::Bool(false),
+            name: "erc20_address".to_string(),
+            value: ethabi::Token::Address(aurora_engine_precompiles::native::events::ETH_ADDRESS),
         },
         ethabi::LogParam {
             name: "dest".to_string(),

--- a/etc/eth-contracts/contracts/test/Tester.sol
+++ b/etc/eth-contracts/contracts/test/Tester.sol
@@ -39,4 +39,25 @@ contract Tester {
         this.tryWithdrawAndAvoidFail(toNear);
         this.withdraw(toNear);
     }
+
+    function withdrawEthToNear(bytes memory recipient) external payable {
+        bytes memory input = abi.encodePacked("\x00", recipient);
+        uint input_size = 1 + recipient.length;
+        uint256 amount = msg.value;
+
+        assembly {
+            let res := call(gas(), 0xe9217bc70b7ed1f598ddd3199e80b093fa71124f, amount, add(input, 32), input_size, 0, 32)
+        }
+    }
+
+    function withdrawEthToEthereum(address recipient) external payable {
+        bytes20 recipient_b = bytes20(recipient);
+        bytes memory input = abi.encodePacked("\x00", recipient_b);
+        uint input_size = 1 + 20;
+        uint256 amount = msg.value;
+
+        assembly {
+            let res := call(gas(), 0xb0bd02f6a392af548bdf1cfaee5dfa0eefcc8eab, amount, add(input, 32), input_size, 0, 32)
+        }
+    }
 }


### PR DESCRIPTION
Closes #245 (see that ticket for details)

@paouvrard mentioned that an explicit event for ERC-20 exit, was not required, but it seemed easy to me to include it now, so I did.

This PR includes new tests showing the events are created.