### PR TITLE
Feat(exit precompiles): Include sender field in exit precompile events

### DIFF
--- a/engine-tests/src/tests/contract_call.rs
+++ b/engine-tests/src/tests/contract_call.rs
@@ -49,6 +49,7 @@ fn hello_world_solidity() {
 #[test]
 fn withdraw() {
     let (mut runner, mut signer, token, tester) = setup_test();
+    let token = Address(token);
 
     let test_data = vec![
         (true, "Call contract: tt.testnet.ft_transfer"),
@@ -93,8 +94,12 @@ fn withdraw() {
         };
         let expected_event = vec![
             ethabi::LogParam {
+                name: "sender".to_string(),
+                value: ethabi::Token::Address(token),
+            },
+            ethabi::LogParam {
                 name: "erc20_address".to_string(),
-                value: ethabi::Token::Address(Address(token)),
+                value: ethabi::Token::Address(token),
             },
             dest,
             ethabi::LogParam {
@@ -182,6 +187,10 @@ fn withdraw_eth() {
     let schema = aurora_engine_precompiles::native::events::exit_to_near_schema();
     let mut expected_event = vec![
         ethabi::LogParam {
+            name: "sender".to_string(),
+            value: ethabi::Token::Address(tester.contract.address),
+        },
+        ethabi::LogParam {
             name: "erc20_address".to_string(),
             value: ethabi::Token::Address(aurora_engine_precompiles::native::events::ETH_ADDRESS),
         },
@@ -204,11 +213,11 @@ fn withdraw_eth() {
     let result = tester
         .withdraw_eth(&mut runner, &mut signer, false, amount)
         .unwrap();
-    expected_event[1] = ethabi::LogParam {
+    expected_event[2] = ethabi::LogParam {
         name: "dest".to_string(),
         value: ethabi::Token::Address(DEST_ADDRESS),
     };
-    expected_event[2] = ethabi::LogParam {
+    expected_event[3] = ethabi::LogParam {
         name: "amount".to_string(),
         value: ethabi::Token::Uint(amount.raw()),
     };


### PR DESCRIPTION
Follow up to #288 addressing @paouvrard's [comment](https://github.com/aurora-is-near/aurora-engine/pull/288#issuecomment-931828936) about including the sender field in the event because it is meaningful in the ETH exit case, even if it is not in the ERC-20 case.