### PR TITLE
Feat(engine): Public method for computing block hash at given height

### DIFF
--- a/engine-tests/src/tests/sanity.rs
+++ b/engine-tests/src/tests/sanity.rs
@@ -496,6 +496,28 @@ fn test_block_hash() {
 }
 
 #[test]
+fn test_block_hash_api() {
+    let mut runner = test_utils::deploy_evm();
+
+    let block_height: u64 = 10;
+    let (maybe_outcome, maybe_error) = runner.call(
+        "get_block_hash",
+        "any.near",
+        block_height.try_to_vec().unwrap(),
+    );
+    if let Some(error) = maybe_error {
+        panic!("Call failed: {:?}", error);
+    }
+    let outcome = maybe_outcome.unwrap();
+    let block_hash = outcome.return_data.as_value().unwrap();
+
+    assert_eq!(
+        hex::encode(&block_hash).as_str(),
+        "c4a46f076b64877cbd8c5dbfd7bfbbea21a5653b79e3b6d06b6dfb5c88f1c384",
+    );
+}
+
+#[test]
 fn test_block_hash_contract() {
     let (mut runner, mut source_account, _) = initialize_transfer();
     let test_constructor = test_utils::solidity::ContractConstructor::compile_from_source(

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -413,6 +413,15 @@ mod contract {
     }
 
     #[no_mangle]
+    pub extern "C" fn get_block_hash() {
+        let block_height = sdk::read_input_borsh().sdk_unwrap();
+        let account_id = sdk::current_account_id();
+        let chain_id = Engine::get_state().map(|state| state.chain_id).sdk_unwrap();
+        let block_hash = Engine::compute_block_hash(chain_id, block_height, &account_id);
+        sdk::return_output(block_hash.as_bytes())
+    }
+
+    #[no_mangle]
     pub extern "C" fn get_code() {
         let address = sdk::read_input_arr20().sdk_unwrap();
         let code = Engine::get_code(&Address(address));


### PR DESCRIPTION
It is currently a bug that the `BLOCKHASH` EVM opcode implementation in the Engine returns a simulated block hash which depends on the block height, while the relayer simply uses the NEAR block hash as the Aurora hash.

This is being fixed. There is a [TS implementation](https://github.com/aurora-is-near/aurora-relayer/pull/55) of the logic which exists in the Engine, however the purpose of this PR is to allow the JS library to ask the Engine directly for the block hash. This means they will always return the same value; even if we update the logic for computing the simulated block hash in the future.