### PR TITLE
Merge all nets test-suites into single CI job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,10 +9,7 @@ on:
 name: Tests
 jobs:
   test:
-    strategy:
-      matrix:
-        net: [main, test, beta]
-    name: Test suite (${{ matrix.net }}net)
+    name: Test suite (mainnet, testnet, betanet)
     runs-on: self-hosted
     steps:
       - name: Clone the repository
@@ -20,17 +17,28 @@ jobs:
       - name: Restore cache
         run: |
           cache-util restore cargo_git cargo_registry sccache yarn_cache
-          cache-util restore aurora-engine-target@${{ matrix.net }}net@${{ hashFiles('**/Cargo.lock') }}:target
-      - run: make ${{ matrix.net }}net-test-build
+          cache-util restore aurora-engine-target@generic@${{ hashFiles('**/Cargo.lock') }}:target
+
+      - run: make mainnet-test-build
       - name: List directories
-        run: |
-          ls -la target/wasm32-unknown-unknown/release
-          ls -la
-      - run: cargo test --features ${{ matrix.net }}net-test
+        run: ls -la target/wasm32-unknown-unknown/release && ls -la
+      - run: cargo test --features mainnet-test
+
+      - run: make testnet-test-build
+      - name: List directories
+        run: ls -la target/wasm32-unknown-unknown/release && ls -la
+      - run: cargo test --features testnet-test
+
+      - run: make betanet-test-build
+      - name: List directories
+        run: ls -la target/wasm32-unknown-unknown/release && ls -la
+      - run: cargo test --features betanet-test
+ 
       - name: Save cache
         run: |
           cache-util save cargo_git cargo_registry sccache yarn_cache
-          cache-util msave aurora-engine-target@${{ matrix.net }}net@${{ hashFiles('**/Cargo.lock') }}:target
+          cache-util msave aurora-engine-target@generic@${{ hashFiles('**/Cargo.lock') }}:target
+
   bully-build:
     name: Bully build
     runs-on: self-hosted


### PR DESCRIPTION
It turns out that consecutive runs of this tests in a single environment (and therefore in a single job) takes almost the same time as if doing this in parallel (2 minutes). This is probably because of reusing build artifacts.
Meanwhile, reducing number of parallel jobs decreases CPU usage on our CI-machine