### PR TITLE
Fix(engine): Remove unnecessary eth-connector logic

### DIFF
--- a/engine/src/connector.rs
+++ b/engine/src/connector.rs
@@ -338,16 +338,6 @@ impl EthConnectorContract {
         }
     }
 
-    /// Internal logic for explicitly setting an eth balance (needed by ApplyBackend for Engine)
-    pub(crate) fn internal_set_eth_balance(&mut self, address: &Address, amount: &U256) {
-        // Call to `as_u128` here should be fine because u128::MAX is a value greater than
-        // all the Wei in existence, so a u128 should always be able to represent
-        // the balance of a single account.
-        self.ft
-            .internal_set_eth_balance(address.0, amount.as_u128());
-        self.save_ft_contract();
-    }
-
     /// Internal ETH withdraw ETH logic
     pub(crate) fn internal_remove_eth(&mut self, address: &Address, amount: &U256) {
         self.burn_eth_on_aurora(address.0, amount.as_u128());

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -1028,10 +1028,6 @@ impl ApplyBackend for Engine {
                 } => {
                     let generation = Self::get_generation(&address);
                     Engine::set_nonce(&address, &basic.nonce);
-
-                    // Apply changes for eth-connector
-                    EthConnectorContract::get_instance()
-                        .internal_set_eth_balance(&address, &basic.balance);
                     Engine::set_balance(&address, &Wei::new(basic.balance));
 
                     if let Some(code) = code {

--- a/engine/src/fungible_token.rs
+++ b/engine/src/fungible_token.rs
@@ -4,8 +4,8 @@ use crate::json::{parse_json, JsonValue};
 use crate::parameters::{FtResolveTransfer, NEP141FtOnTransferArgs, StorageBalance};
 use crate::prelude::{
     sdk, storage, str_from_slice, AccountId, Address, BTreeMap, Balance, BorshDeserialize,
-    BorshSerialize, EthAddress, Gas, Ordering, PromiseResult, StorageBalanceBounds, StorageUsage,
-    String, ToString, TryInto, Vec, Wei, U256,
+    BorshSerialize, EthAddress, Gas, PromiseResult, StorageBalanceBounds, StorageUsage, String,
+    ToString, TryInto, Vec, Wei, U256,
 };
 
 const GAS_FOR_RESOLVE_TRANSFER: Gas = 5_000_000_000_000;
@@ -127,25 +127,6 @@ impl FungibleToken {
                 .expect("ERR_TOTAL_SUPPLY_OVERFLOW");
         } else {
             sdk::panic_utf8(b"ERR_BALANCE_OVERFLOW");
-        }
-    }
-
-    /// Needed by engine to update balances after a transaction (see ApplyBackend for Engine)
-    pub(crate) fn internal_set_eth_balance(&mut self, address: EthAddress, new_balance: Balance) {
-        let current_balance = self.internal_unwrap_balance_of_eth_on_aurora(address);
-        match current_balance.cmp(&new_balance) {
-            Ordering::Less => {
-                // current_balance is smaller, so we need to deposit
-                let diff = new_balance - current_balance;
-                self.internal_deposit_eth_to_aurora(address, diff);
-            }
-            Ordering::Greater => {
-                // current_balance is larger, so we need to withdraw
-                let diff = current_balance - new_balance;
-                self.internal_withdraw_eth_from_aurora(address, diff);
-            }
-            // if the balances are equal then we do not need to do anything
-            Ordering::Equal => (),
         }
     }
 


### PR DESCRIPTION
The `FungibleToken` data structure which is part of the eth-connector only tracks the total amount of ETH on NEAR (total balances of the nETH NEP-141 token held by NEAR accounts) and on Aurora (total balances of ETH held by addresses in the EVM). Any EVM actions which only result in `Apply::Modify` actions on the state must preserve the total amount of ETH(*) on both NEAR and Aurora because ETH can only be moved around by transfers(**). 

All this is to justify removing the call to `internal_set_eth_balance` call in the `apply` function on the Engine. By the above argument, removing this call maintains the correctness of the code while giving us other benefits. These benefits include: slightly lower gas costs by removing useless computation(***) and **unblocking the bully on Rinkeby** (cc @strokovok) where there is an account with a Wei balance greater than `u128::MAX` (this was a problem because the eth-connector deals with `u128` numbers as this is the standard on NEAR).

(*) Note: `Apply::Delete` can change the total amount of ETH on Aurora, and this still makes a call into the eth-connector to update accordingly; in this PR we only change the `Apply::Modify` flow.

(**) Note: the exit precompiles are transfers to special addresses (preserving the total amount of ETH on Aurora) which trigger callbacks that may change the amount of ETH on NEAR (in the exit to Ethereum case).

(***) Note: the reason this unnecessary call ended up in the code in the first place was something of an accident. The eth-connector work had [replaced the `Engine::set_balance` call with a `internal_deposit_eth` call](https://github.com/aurora-is-near/aurora-engine/pull/24/files#diff-ff278ec599adfd033d35a083ebe8948db8bf177c9817dee8ddc4f3a9e3f5728eL316), causing tests to fail. These tests were [fixed by replacing the `internal_deposit_eth` call with the `internal_set_eth_balance`](https://github.com/aurora-is-near/aurora-engine/pull/71/files#diff-ff278ec599adfd033d35a083ebe8948db8bf177c9817dee8ddc4f3a9e3f5728eL513) call in the connector, but we failed to notice that involving the connector at all was unnecessary in the first place. Later the call to `Engine::set_balance` was [re-introduced when merging the eth-connector work with `master`](https://github.com/aurora-is-near/aurora-engine/pull/109/files#diff-ff278ec599adfd033d35a083ebe8948db8bf177c9817dee8ddc4f3a9e3f5728eR549) (eth-connector was on a feature branch for a long time), and this accident meant both calls were present in the final merge to master. Ultimately this was a good thing because it tipped me off to the fact we don't actually need `internal_set_eth_balance` when investigating the bully failures.