### PR TITLE
CI: Markup tests complexity

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -7,7 +7,7 @@ name: Builds
 jobs:
   release:
     name: Release
-    runs-on: self-hosted
+    runs-on: [self-hosted, heavy]
     steps:
       - name: Clone the repository
         uses: actions/checkout@v2
@@ -29,7 +29,7 @@ jobs:
         uses: EndBug/latest-tag@latest
   debug:
     name: Debug
-    runs-on: self-hosted
+    runs-on: [self-hosted, heavy]
     steps:
       - name: Clone the repository
         uses: actions/checkout@v2

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -11,7 +11,7 @@ name: Lints
 jobs:
   fmt:
     name: rustfmt
-    runs-on: self-hosted
+    runs-on: [self-hosted, light]
     steps:
       - name: Clone the repository
         uses: actions/checkout@v2
@@ -19,7 +19,7 @@ jobs:
         run: cargo fmt --all -- --check
   clippy:
     name: Clippy
-    runs-on: self-hosted
+    runs-on: [self-hosted, heavy]
     steps:
       - name: Clone the repository
         uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
 
   contracts:
     name: eth-contracts
-    runs-on: self-hosted
+    runs-on: [self-hosted, light]
     steps:
       - name: Clone the repository
         uses: actions/checkout@v2

--- a/.github/workflows/scheduled_lints.yml
+++ b/.github/workflows/scheduled_lints.yml
@@ -6,7 +6,7 @@ name: Scheduled_Lints
 jobs:
   clippy:
     name: Nightly_Clippy
-    runs-on: self-hosted
+    runs-on: [self-hosted, heavy]
     steps:
       - name: Clone the repository
         uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ name: Tests
 jobs:
   test:
     name: Test suite (mainnet, testnet, betanet)
-    runs-on: self-hosted
+    runs-on: [self-hosted, heavy]
     steps:
       - name: Clone the repository
         uses: actions/checkout@v2
@@ -41,7 +41,7 @@ jobs:
 
   bully-build:
     name: Bully build
-    runs-on: self-hosted
+    runs-on: [self-hosted, heavy]
     steps:
       - name: Clone the repository
         uses: actions/checkout@v2


### PR DESCRIPTION
Some of the tests are flagged as `heavy` and some of them are flagged as `light`.
This would prevent running many `heavy`  tests on CI machine at once, because the number of workers that can execute `heavy` tests is limited.