### PR TITLE
Add logging of public key of the signer

### DIFF
--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -224,6 +224,7 @@ mod contract {
             .sender()
             .sdk_expect("ERR_INVALID_ECDSA_SIGNATURE");
 
+        #[cfg(feature = "log")]
         sdk::log(crate::prelude::format!("signer_public_key 0x{}", sender).as_str());
 
         Engine::check_nonce(&sender, signed_transaction.nonce()).sdk_unwrap();

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -224,6 +224,8 @@ mod contract {
             .sender()
             .sdk_expect("ERR_INVALID_ECDSA_SIGNATURE");
 
+        sdk::log(crate::prelude::format!("signer_public_key 0x{}", sender).as_str());
+
         Engine::check_nonce(&sender, signed_transaction.nonce()).sdk_unwrap();
 
         // Check intrinsic gas is covered by transaction gas limit


### PR DESCRIPTION
It will be useful to know the public key of the signer when creating a submit. This change prevents us from having to do this process manually which can be extremely taxing and simply non-trivial.

We already require the sender's details when checking the nonce, this simply just emits a log of that retrieved sender.