### PR TITLE
Fix ripemd160 word cost

### DIFF
--- a/engine-precompiles/src/hash.rs
+++ b/engine-precompiles/src/hash.rs
@@ -11,7 +11,7 @@ mod costs {
 
     pub(super) const RIPEMD160_BASE: u64 = 600;
 
-    pub(super) const RIPEMD160_PER_WORD: u64 = 12;
+    pub(super) const RIPEMD160_PER_WORD: u64 = 120;
 }
 
 mod consts {


### PR DESCRIPTION
This fixes the ripemd160 gas cost which incorrectly is charging 10x less than it should be right now.

Do note that @mrLSD is working on tests for precompiles using ETH tests.

Closes #302.