### PR TITLE
Fix 0x prefix on address, if there

### DIFF
--- a/engine-tests/src/tests/sanity.rs
+++ b/engine-tests/src/tests/sanity.rs
@@ -23,8 +23,8 @@ fn test_state_format() {
     // break the contract unless we do a state migration.
     let args = aurora_engine::parameters::NewCallArgs {
         chain_id: aurora_engine_types::types::u256_to_arr(&666.into()),
-        owner_id: "boss".into(),
-        bridge_prover_id: "prover_mcprovy_face".into(),
+        owner_id: "boss".parse().unwrap(),
+        bridge_prover_id: "prover_mcprovy_face".parse().unwrap(),
         upgrade_delay_blocks: 3,
     };
     let state: aurora_engine::engine::EngineState = args.into();

--- a/engine-types/src/types.rs
+++ b/engine-types/src/types.rs
@@ -109,6 +109,7 @@ pub struct U128(pub u128);
 
 pub const STORAGE_PRICE_PER_BYTE: u128 = 10_000_000_000_000_000_000; // 1e19yN, 0.00001N
 pub const ERR_FAILED_PARSE: &str = "ERR_FAILED_PARSE";
+pub const ERR_INVALID_ETH_ADDRESS: &str = "ERR_INVALID_ETH_ADDRESS";
 
 /// Internal args format for meta call.
 #[derive(Debug)]

--- a/engine/src/deposit_event.rs
+++ b/engine/src/deposit_event.rs
@@ -2,7 +2,7 @@ use crate::log_entry::LogEntry;
 use crate::prelude::{vec, EthAddress, String, ToString, Vec, U256};
 use ethabi::{Event, EventParam, Hash, Log, ParamType, RawLog};
 
-const DEPOSITED_EVENT: &str = "Deposited";
+pub const DEPOSITED_EVENT: &str = "Deposited";
 
 pub type EventParams = Vec<EventParam>;
 
@@ -50,7 +50,7 @@ pub struct DepositedEvent {
 
 impl DepositedEvent {
     #[allow(dead_code)]
-    fn event_params() -> EventParams {
+    pub fn event_params() -> EventParams {
         vec![
             EventParam {
                 name: "sender".to_string(),
@@ -78,11 +78,23 @@ impl DepositedEvent {
     /// Parses raw Ethereum logs proof's entry data
     pub fn from_log_entry_data(data: &[u8]) -> Self {
         let event = EthEvent::fetch_log_entry_data(DEPOSITED_EVENT, Self::event_params(), data);
-        let sender = event.log.params[0].value.clone().into_address().unwrap().0;
-
-        let recipient = event.log.params[1].value.clone().to_string();
-        let amount = event.log.params[2].value.clone().into_uint().unwrap();
-        let fee = event.log.params[3].value.clone().into_uint().unwrap();
+        let sender = event.log.params[0]
+            .value
+            .clone()
+            .into_address()
+            .expect("INVALID_SENDER")
+            .0;
+        let recipient: String = event.log.params[1].value.clone().to_string();
+        let amount = event.log.params[2]
+            .value
+            .clone()
+            .into_uint()
+            .expect("INVALID_AMOUNT");
+        let fee = event.log.params[3]
+            .value
+            .clone()
+            .into_uint()
+            .expect("INVALID_FEE");
         Self {
             eth_custodian_address: event.eth_custodian_address,
             sender,

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -20,11 +20,11 @@ pub mod transaction;
 pub mod admin_controlled;
 #[cfg_attr(feature = "contract", allow(dead_code))]
 pub mod connector;
-mod deposit_event;
+pub mod deposit_event;
 pub mod engine;
 pub mod fungible_token;
 pub mod json;
-mod log_entry;
+pub mod log_entry;
 mod prelude;
 
 #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
There was an incident detailed in #335. This fixes that incident.

In the future, it would be a good idea to make the test framework more general which would allow for different sizes of inputs to the Engine.

This is labelled as critical as we have to rescue two users funds in a timely manner.

This closes #335.