### PR TITLE
Test verifying the EVM log returns the correct address

### DIFF
--- a/engine-tests/src/test_utils/solidity.rs
+++ b/engine-tests/src/test_utils/solidity.rs
@@ -74,6 +74,17 @@ impl ContractConstructor {
         }
     }
 
+    pub fn deploy_without_constructor(&self, nonce: U256) -> TransactionLegacy {
+        TransactionLegacy {
+            nonce,
+            gas_price: Default::default(),
+            gas_limit: u64::MAX.into(),
+            to: None,
+            value: Default::default(),
+            data: self.code.clone(),
+        }
+    }
+
     pub fn deploy_without_args(&self, nonce: U256) -> TransactionLegacy {
         self.deploy_with_args(nonce, &[])
     }

--- a/engine-tests/src/tests/res/caller.sol
+++ b/engine-tests/src/tests/res/caller.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract Caller {
+    function greet(address to) public {
+        to.call(abi.encodeWithSelector(Greeter(to).greet.selector));
+    }
+}
+
+
+contract Greeter { // callee contract
+    event Logger(address sender);
+
+    function greet() public {
+        emit Logger(msg.sender);
+    }
+}
+


### PR DESCRIPTION
Adds a test showing the correct address is returned by the engine.

This means the issue reported in #336 must not come from the engine, and instead must arise from elsewhere (maybe the relayer?).

Closes #336 