### PR TITLE
Remove Default trait bound from engine IO

### DIFF
--- a/engine-tests/src/test_utils/mod.rs
+++ b/engine-tests/src/test_utils/mod.rs
@@ -246,7 +246,7 @@ impl AuroraRunner {
             &[crate::prelude::storage::EthConnectorStorageId::FungibleToken as u8],
         );
         let ft_value = {
-            let mut current_ft: FungibleToken<aurora_engine_sdk::near_runtime::Runtime> = trie
+            let mut current_ft: FungibleToken = trie
                 .get(&ft_key)
                 .map(|bytes| FungibleToken::try_from_slice(&bytes).unwrap())
                 .unwrap_or_default();

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -417,9 +417,7 @@ mod contract {
         };
 
         sdk::log!(crate::prelude::format!("Deployed ERC-20 in Aurora at: {:#?}", address).as_str());
-        engine
-            .register_token(address.as_bytes(), args.nep141.as_bytes())
-            .sdk_unwrap();
+        engine.register_token(address, args.nep141).sdk_unwrap();
         io.return_output(&address.as_bytes().try_to_vec().sdk_expect("ERR_SERIALIZE"));
 
         // TODO: charge for storage
@@ -742,7 +740,7 @@ mod contract {
         let args: GetErc20FromNep141CallArgs = io.read_input_borsh().sdk_unwrap();
 
         io.return_output(
-            Engine::get_erc20_from_nep141(io, args.nep141.as_bytes())
+            Engine::get_erc20_from_nep141(&io, &args.nep141)
                 .sdk_unwrap()
                 .as_slice(),
         );
@@ -751,11 +749,13 @@ mod contract {
     #[no_mangle]
     pub extern "C" fn get_nep141_from_erc20() {
         let mut io = Runtime;
+        let erc20_address: crate::engine::ERC20Address =
+            io.read_input().to_vec().try_into().sdk_unwrap();
         io.return_output(
             Engine::nep141_erc20_map(io)
-                .lookup_right(io.read_input().to_vec().as_slice())
+                .lookup_right(&erc20_address)
                 .sdk_expect("ERC20_NOT_FOUND")
-                .as_slice(),
+                .as_ref(),
         );
     }
 

--- a/engine/src/map.rs
+++ b/engine/src/map.rs
@@ -1,101 +1,57 @@
-pub use crate::prelude::{bytes_to_key, BorshDeserialize, BorshSerialize, KeyPrefixU8, Vec};
+pub use crate::prelude::{bytes_to_key, PhantomData, TryFrom, TryInto, Vec};
 use aurora_engine_sdk::io::{StorageIntermediate, IO};
-use aurora_engine_sdk::near_runtime::Runtime;
+use aurora_engine_types::storage::KeyPrefix;
 
-/// An non-iterable implementation of a map that stores its content directly on the trie.
-/// Use `key_prefix` as a unique prefix for keys.
-#[derive(BorshSerialize, BorshDeserialize)]
-pub struct LookupMap<I: IO + Default, const K: KeyPrefixU8> {
-    #[borsh_skip]
-    pub io: I,
+/// A map storing a 1:1 relation between elements of types L and R.
+/// The map is backed by storage of type I.
+pub struct BijectionMap<L, R, I> {
+    left_prefix: KeyPrefix,
+    right_prefix: KeyPrefix,
+    io: I,
+    left_phantom: PhantomData<L>,
+    right_phantom: PhantomData<R>,
 }
 
-impl<const K: KeyPrefixU8> Default for LookupMap<Runtime, K> {
-    fn default() -> Self {
-        Self { io: Runtime }
-    }
-}
-
-impl<I: IO + Default, const K: KeyPrefixU8> LookupMap<I, K> {
-    /// Create a new map.
-    pub fn new(io: I) -> Self {
-        Self { io }
-    }
-
-    /// Build key for this map scope
-    fn raw_key_to_storage_key(&self, key_raw: &[u8]) -> Vec<u8> {
-        bytes_to_key(K.into(), key_raw)
-    }
-
-    /// Returns `true` if the serialized key is present in the map.
-    #[allow(dead_code)]
-    pub fn contains_key_raw(&self, key_raw: &[u8]) -> bool {
-        let storage_key = self.raw_key_to_storage_key(key_raw);
-        self.io.storage_has_key(&storage_key)
-    }
-
-    /// Returns the serialized value corresponding to the serialized key.
-    #[allow(dead_code)]
-    pub fn get_raw(&self, key_raw: &[u8]) -> Option<Vec<u8>> {
-        let storage_key = self.raw_key_to_storage_key(key_raw);
-        self.io.read_storage(&storage_key).map(|s| s.to_vec())
-    }
-
-    /// Inserts a serialized key-value pair into the map.
-    pub fn insert_raw(&mut self, key_raw: &[u8], value_raw: &[u8]) {
-        let storage_key = self.raw_key_to_storage_key(key_raw);
-        self.io.write_storage(&storage_key, value_raw);
-    }
-
-    /// Removes a serialized key from the map, returning the serialized value at the key if the key
-    /// was previously in the map.
-    #[allow(dead_code)]
-    pub fn remove_raw(&mut self, key_raw: &[u8]) -> Option<Vec<u8>> {
-        let storage_key = self.raw_key_to_storage_key(key_raw);
-        self.io.remove_storage(&storage_key).map(|s| s.to_vec())
-    }
-}
-
-#[derive(BorshSerialize, BorshDeserialize, Default)]
-pub struct BijectionMap<I: IO + Default, const LR: KeyPrefixU8, const RL: KeyPrefixU8> {
-    #[borsh_skip]
-    pub io: I,
-}
-
-impl<I: IO + Copy + Default, const LR: KeyPrefixU8, const RL: KeyPrefixU8> BijectionMap<I, LR, RL> {
-    fn left_to_right(&self) -> LookupMap<I, LR> {
-        LookupMap { io: self.io }
-    }
-
-    fn right_to_left(&self) -> LookupMap<I, RL> {
-        LookupMap { io: self.io }
-    }
-
-    pub fn insert(&self, value_left: &[u8], value_right: &[u8]) {
-        self.left_to_right().insert_raw(value_left, value_right);
-        self.right_to_left().insert_raw(value_right, value_left);
-    }
-
-    pub fn lookup_left(&self, value_left: &[u8]) -> Option<Vec<u8>> {
-        self.left_to_right().get_raw(value_left)
-    }
-
-    #[allow(dead_code)]
-    pub fn lookup_right(&self, value_right: &[u8]) -> Option<Vec<u8>> {
-        self.right_to_left().get_raw(value_right)
-    }
-
-    #[allow(dead_code)]
-    pub fn remove_left(&self, value_left: &[u8]) {
-        if let Some(value_right) = self.left_to_right().remove_raw(value_left) {
-            self.right_to_left().remove_raw(value_right.as_slice());
+impl<L: AsRef<[u8]> + TryFrom<Vec<u8>>, R: AsRef<[u8]> + TryFrom<Vec<u8>>, I: IO>
+    BijectionMap<L, R, I>
+{
+    pub fn new(left_prefix: KeyPrefix, right_prefix: KeyPrefix, io: I) -> Self {
+        Self {
+            left_prefix,
+            right_prefix,
+            io,
+            left_phantom: PhantomData,
+            right_phantom: PhantomData,
         }
     }
 
-    #[allow(dead_code)]
-    pub fn remove_right(&self, value_right: &[u8]) {
-        if let Some(value_left) = self.right_to_left().remove_raw(value_right) {
-            self.left_to_right().remove_raw(value_left.as_slice());
-        }
+    pub fn insert(&mut self, left: &L, right: &R) {
+        let key = self.left_key(left);
+        self.io.write_storage(&key, right.as_ref());
+
+        let key = self.right_key(right);
+        self.io.write_storage(&key, left.as_ref());
+    }
+
+    pub fn lookup_left(&self, left: &L) -> Option<R> {
+        let key = self.left_key(left);
+        self.io
+            .read_storage(&key)
+            .and_then(|v| v.to_vec().try_into().ok())
+    }
+
+    pub fn lookup_right(&self, right: &R) -> Option<L> {
+        let key = self.right_key(right);
+        self.io
+            .read_storage(&key)
+            .and_then(|v| v.to_vec().try_into().ok())
+    }
+
+    fn left_key(&self, left: &L) -> Vec<u8> {
+        bytes_to_key(self.left_prefix, left.as_ref())
+    }
+
+    fn right_key(&self, right: &R) -> Vec<u8> {
+        bytes_to_key(self.right_prefix, right.as_ref())
     }
 }


### PR DESCRIPTION
The primary goal of this PR is to remove the `Default` trait bound that was required on the `IO` type after #314 . The primary reason for this trait bound was the usage of `Default` in `LookupMap` and `BijectionMap`. As a result, this PR removes `LookupMap` and refactors `BijectionMap` to no longer have a `Default` implementation, as well as to be more type-safe.

This is change does not impact the runtime behaviour of the engine in any way. It is continuing the path towards being able to run the engine without the NEAR runtime (ie as a standalone binary).