### PR TITLE
Chore: Newtypes for gas

### DIFF
--- a/engine-precompiles/src/bn128.rs
+++ b/engine-precompiles/src/bn128.rs
@@ -1,32 +1,35 @@
+use crate::prelude::types::EthGas;
 use crate::prelude::{Address, Borrowed, PhantomData, Vec};
 use crate::{Byzantium, EvmPrecompileResult, HardFork, Istanbul, Precompile, PrecompileOutput};
 use evm::{Context, ExitError};
 
 /// bn128 costs.
 mod costs {
+    use crate::prelude::types::EthGas;
+
     /// Cost of the Byzantium alt_bn128_add operation.
-    pub(super) const BYZANTIUM_ADD: u64 = 500;
+    pub(super) const BYZANTIUM_ADD: EthGas = EthGas::new(500);
 
     /// Cost of the Byzantium alt_bn128_mul operation.
-    pub(super) const BYZANTIUM_MUL: u64 = 40_000;
+    pub(super) const BYZANTIUM_MUL: EthGas = EthGas::new(40_000);
 
     /// Cost of the alt_bn128_pair per point.
-    pub(super) const BYZANTIUM_PAIR_PER_POINT: u64 = 80_000;
+    pub(super) const BYZANTIUM_PAIR_PER_POINT: EthGas = EthGas::new(80_000);
 
     /// Cost of the alt_bn128_pair operation.
-    pub(super) const BYZANTIUM_PAIR_BASE: u64 = 100_000;
+    pub(super) const BYZANTIUM_PAIR_BASE: EthGas = EthGas::new(100_000);
 
     /// Cost of the Istanbul alt_bn128_add operation.
-    pub(super) const ISTANBUL_ADD: u64 = 150;
+    pub(super) const ISTANBUL_ADD: EthGas = EthGas::new(150);
 
     /// Cost of the Istanbul alt_bn128_mul operation.
-    pub(super) const ISTANBUL_MUL: u64 = 6_000;
+    pub(super) const ISTANBUL_MUL: EthGas = EthGas::new(6_000);
 
     /// Cost of the Istanbul alt_bn128_pair per point.
-    pub(super) const ISTANBUL_PAIR_PER_POINT: u64 = 34_000;
+    pub(super) const ISTANBUL_PAIR_PER_POINT: EthGas = EthGas::new(34_000);
 
     /// Cost of the Istanbul alt_bn128_pair operation.
-    pub(super) const ISTANBUL_PAIR_BASE: u64 = 45_000;
+    pub(super) const ISTANBUL_PAIR_BASE: EthGas = EthGas::new(45_000);
 }
 
 /// bn128 constants.
@@ -97,7 +100,7 @@ impl<HF: HardFork> Bn128Add<HF> {
 }
 
 impl Precompile for Bn128Add<Byzantium> {
-    fn required_gas(_input: &[u8]) -> Result<u64, ExitError> {
+    fn required_gas(_input: &[u8]) -> Result<EthGas, ExitError> {
         Ok(costs::BYZANTIUM_ADD)
     }
 
@@ -109,7 +112,7 @@ impl Precompile for Bn128Add<Byzantium> {
     fn run(
         &self,
         input: &[u8],
-        target_gas: Option<u64>,
+        target_gas: Option<EthGas>,
         context: &Context,
         _is_static: bool,
     ) -> EvmPrecompileResult {
@@ -126,7 +129,7 @@ impl Precompile for Bn128Add<Byzantium> {
 }
 
 impl Precompile for Bn128Add<Istanbul> {
-    fn required_gas(_input: &[u8]) -> Result<u64, ExitError> {
+    fn required_gas(_input: &[u8]) -> Result<EthGas, ExitError> {
         Ok(costs::ISTANBUL_ADD)
     }
 
@@ -138,7 +141,7 @@ impl Precompile for Bn128Add<Istanbul> {
     fn run(
         &self,
         input: &[u8],
-        target_gas: Option<u64>,
+        target_gas: Option<EthGas>,
         context: &Context,
         _is_static: bool,
     ) -> EvmPrecompileResult {
@@ -189,7 +192,7 @@ impl<HF: HardFork> Bn128Mul<HF> {
 }
 
 impl Precompile for Bn128Mul<Byzantium> {
-    fn required_gas(_input: &[u8]) -> Result<u64, ExitError> {
+    fn required_gas(_input: &[u8]) -> Result<EthGas, ExitError> {
         Ok(costs::BYZANTIUM_MUL)
     }
 
@@ -200,7 +203,7 @@ impl Precompile for Bn128Mul<Byzantium> {
     fn run(
         &self,
         input: &[u8],
-        target_gas: Option<u64>,
+        target_gas: Option<EthGas>,
         context: &Context,
         _is_static: bool,
     ) -> EvmPrecompileResult {
@@ -217,7 +220,7 @@ impl Precompile for Bn128Mul<Byzantium> {
 }
 
 impl Precompile for Bn128Mul<Istanbul> {
-    fn required_gas(_input: &[u8]) -> Result<u64, ExitError> {
+    fn required_gas(_input: &[u8]) -> Result<EthGas, ExitError> {
         Ok(costs::ISTANBUL_MUL)
     }
 
@@ -228,7 +231,7 @@ impl Precompile for Bn128Mul<Istanbul> {
     fn run(
         &self,
         input: &[u8],
-        target_gas: Option<u64>,
+        target_gas: Option<EthGas>,
         context: &Context,
         _is_static: bool,
     ) -> EvmPrecompileResult {
@@ -349,9 +352,9 @@ impl<HF: HardFork> Bn128Pair<HF> {
 }
 
 impl Precompile for Bn128Pair<Byzantium> {
-    fn required_gas(input: &[u8]) -> Result<u64, ExitError> {
+    fn required_gas(input: &[u8]) -> Result<EthGas, ExitError> {
         Ok(
-            costs::BYZANTIUM_PAIR_PER_POINT * input.len() as u64 / consts::PAIR_ELEMENT_LEN as u64
+            costs::BYZANTIUM_PAIR_PER_POINT * input.len() / consts::PAIR_ELEMENT_LEN
                 + costs::BYZANTIUM_PAIR_BASE,
         )
     }
@@ -363,7 +366,7 @@ impl Precompile for Bn128Pair<Byzantium> {
     fn run(
         &self,
         input: &[u8],
-        target_gas: Option<u64>,
+        target_gas: Option<EthGas>,
         context: &Context,
         _is_static: bool,
     ) -> EvmPrecompileResult {
@@ -380,9 +383,9 @@ impl Precompile for Bn128Pair<Byzantium> {
 }
 
 impl Precompile for Bn128Pair<Istanbul> {
-    fn required_gas(input: &[u8]) -> Result<u64, ExitError> {
+    fn required_gas(input: &[u8]) -> Result<EthGas, ExitError> {
         Ok(
-            costs::ISTANBUL_PAIR_PER_POINT * input.len() as u64 / consts::PAIR_ELEMENT_LEN as u64
+            costs::ISTANBUL_PAIR_PER_POINT * input.len() / consts::PAIR_ELEMENT_LEN
                 + costs::ISTANBUL_PAIR_BASE,
         )
     }
@@ -394,7 +397,7 @@ impl Precompile for Bn128Pair<Istanbul> {
     fn run(
         &self,
         input: &[u8],
-        target_gas: Option<u64>,
+        target_gas: Option<EthGas>,
         context: &Context,
         _is_static: bool,
     ) -> EvmPrecompileResult {
@@ -434,7 +437,7 @@ mod tests {
         .unwrap();
 
         let res = Bn128Add::<Byzantium>::new()
-            .run(&input, Some(500), &new_context(), false)
+            .run(&input, Some(EthGas::new(500)), &new_context(), false)
             .unwrap()
             .output;
         assert_eq!(res, expected);
@@ -456,7 +459,7 @@ mod tests {
         .unwrap();
 
         let res = Bn128Add::<Byzantium>::new()
-            .run(&input, Some(500), &new_context(), false)
+            .run(&input, Some(EthGas::new(500)), &new_context(), false)
             .unwrap()
             .output;
         assert_eq!(res, expected);
@@ -470,7 +473,8 @@ mod tests {
             0000000000000000000000000000000000000000000000000000000000000000",
         )
         .unwrap();
-        let res = Bn128Add::<Byzantium>::new().run(&input, Some(499), &new_context(), false);
+        let res =
+            Bn128Add::<Byzantium>::new().run(&input, Some(EthGas::new(499)), &new_context(), false);
         assert!(matches!(res, Err(ExitError::OutOfGas)));
 
         // no input test
@@ -483,7 +487,7 @@ mod tests {
         .unwrap();
 
         let res = Bn128Add::<Byzantium>::new()
-            .run(&input, Some(500), &new_context(), false)
+            .run(&input, Some(EthGas::new(500)), &new_context(), false)
             .unwrap()
             .output;
         assert_eq!(res, expected);
@@ -498,7 +502,8 @@ mod tests {
         )
         .unwrap();
 
-        let res = Bn128Add::<Byzantium>::new().run(&input, Some(500), &new_context(), false);
+        let res =
+            Bn128Add::<Byzantium>::new().run(&input, Some(EthGas::new(500)), &new_context(), false);
         assert!(matches!(
             res,
             Err(ExitError::Other(Borrowed("ERR_BN128_INVALID_POINT")))
@@ -522,7 +527,7 @@ mod tests {
         .unwrap();
 
         let res = Bn128Mul::<Byzantium>::new()
-            .run(&input, Some(40_000), &new_context(), false)
+            .run(&input, Some(EthGas::new(40_000)), &new_context(), false)
             .unwrap()
             .output;
         assert_eq!(res, expected);
@@ -535,7 +540,12 @@ mod tests {
             0200000000000000000000000000000000000000000000000000000000000000",
         )
         .unwrap();
-        let res = Bn128Mul::<Byzantium>::new().run(&input, Some(39_999), &new_context(), false);
+        let res = Bn128Mul::<Byzantium>::new().run(
+            &input,
+            Some(EthGas::new(39_999)),
+            &new_context(),
+            false,
+        );
         assert!(matches!(res, Err(ExitError::OutOfGas)));
 
         // zero multiplication test
@@ -554,7 +564,7 @@ mod tests {
         .unwrap();
 
         let res = Bn128Mul::<Byzantium>::new()
-            .run(&input, Some(40_000), &new_context(), false)
+            .run(&input, Some(EthGas::new(40_000)), &new_context(), false)
             .unwrap()
             .output;
         assert_eq!(res, expected);
@@ -569,7 +579,7 @@ mod tests {
         .unwrap();
 
         let res = Bn128Mul::<Byzantium>::new()
-            .run(&input, Some(40_000), &new_context(), false)
+            .run(&input, Some(EthGas::new(40_000)), &new_context(), false)
             .unwrap()
             .output;
         assert_eq!(res, expected);
@@ -583,7 +593,12 @@ mod tests {
         )
         .unwrap();
 
-        let res = Bn128Mul::<Byzantium>::new().run(&input, Some(40_000), &new_context(), false);
+        let res = Bn128Mul::<Byzantium>::new().run(
+            &input,
+            Some(EthGas::new(40_000)),
+            &new_context(),
+            false,
+        );
         assert!(matches!(
             res,
             Err(ExitError::Other(Borrowed("ERR_BN128_INVALID_POINT")))
@@ -613,7 +628,7 @@ mod tests {
                 .unwrap();
 
         let res = Bn128Pair::<Byzantium>::new()
-            .run(&input, Some(260_000), &new_context(), false)
+            .run(&input, Some(EthGas::new(260_000)), &new_context(), false)
             .unwrap()
             .output;
         assert_eq!(res, expected);
@@ -635,7 +650,12 @@ mod tests {
             12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa",
         )
         .unwrap();
-        let res = Bn128Pair::<Byzantium>::new().run(&input, Some(259_999), &new_context(), false);
+        let res = Bn128Pair::<Byzantium>::new().run(
+            &input,
+            Some(EthGas::new(259_999)),
+            &new_context(),
+            false,
+        );
         assert!(matches!(res, Err(ExitError::OutOfGas)));
 
         // no input test
@@ -645,7 +665,7 @@ mod tests {
                 .unwrap();
 
         let res = Bn128Pair::<Byzantium>::new()
-            .run(&input, Some(260_000), &new_context(), false)
+            .run(&input, Some(EthGas::new(260_000)), &new_context(), false)
             .unwrap()
             .output;
         assert_eq!(res, expected);
@@ -662,7 +682,12 @@ mod tests {
         )
         .unwrap();
 
-        let res = Bn128Pair::<Byzantium>::new().run(&input, Some(260_000), &new_context(), false);
+        let res = Bn128Pair::<Byzantium>::new().run(
+            &input,
+            Some(EthGas::new(260_000)),
+            &new_context(),
+            false,
+        );
         assert!(matches!(
             res,
             Err(ExitError::Other(Borrowed("ERR_BN128_INVALID_A")))
@@ -678,7 +703,12 @@ mod tests {
         )
         .unwrap();
 
-        let res = Bn128Pair::<Byzantium>::new().run(&input, Some(260_000), &new_context(), false);
+        let res = Bn128Pair::<Byzantium>::new().run(
+            &input,
+            Some(EthGas::new(260_000)),
+            &new_context(),
+            false,
+        );
         assert!(matches!(
             res,
             Err(ExitError::Other(Borrowed("ERR_BN128_INVALID_LEN",)))

--- a/engine-precompiles/src/hash.rs
+++ b/engine-precompiles/src/hash.rs
@@ -1,17 +1,20 @@
 #[cfg(feature = "contract")]
 use crate::prelude::sdk;
+use crate::prelude::types::EthGas;
 use crate::prelude::{vec, Address};
 use crate::{EvmPrecompileResult, Precompile, PrecompileOutput};
 use evm::{Context, ExitError};
 
 mod costs {
-    pub(super) const SHA256_BASE: u64 = 60;
+    use crate::prelude::types::EthGas;
 
-    pub(super) const SHA256_PER_WORD: u64 = 12;
+    pub(super) const SHA256_BASE: EthGas = EthGas::new(60);
 
-    pub(super) const RIPEMD160_BASE: u64 = 600;
+    pub(super) const SHA256_PER_WORD: EthGas = EthGas::new(12);
 
-    pub(super) const RIPEMD160_PER_WORD: u64 = 120;
+    pub(super) const RIPEMD160_BASE: EthGas = EthGas::new(600);
+
+    pub(super) const RIPEMD160_PER_WORD: EthGas = EthGas::new(120);
 }
 
 mod consts {
@@ -28,7 +31,7 @@ impl SHA256 {
 }
 
 impl Precompile for SHA256 {
-    fn required_gas(input: &[u8]) -> Result<u64, ExitError> {
+    fn required_gas(input: &[u8]) -> Result<EthGas, ExitError> {
         Ok(
             (input.len() as u64 + consts::SHA256_WORD_LEN - 1) / consts::SHA256_WORD_LEN
                 * costs::SHA256_PER_WORD
@@ -43,7 +46,7 @@ impl Precompile for SHA256 {
     fn run(
         &self,
         input: &[u8],
-        target_gas: Option<u64>,
+        target_gas: Option<EthGas>,
         _context: &Context,
         _is_static: bool,
     ) -> EvmPrecompileResult {
@@ -67,7 +70,7 @@ impl Precompile for SHA256 {
     fn run(
         &self,
         input: &[u8],
-        target_gas: Option<u64>,
+        target_gas: Option<EthGas>,
         _context: &Context,
         _is_static: bool,
     ) -> EvmPrecompileResult {
@@ -100,7 +103,7 @@ impl RIPEMD160 {
 }
 
 impl Precompile for RIPEMD160 {
-    fn required_gas(input: &[u8]) -> Result<u64, ExitError> {
+    fn required_gas(input: &[u8]) -> Result<EthGas, ExitError> {
         Ok(
             (input.len() as u64 + consts::RIPEMD_WORD_LEN - 1) / consts::RIPEMD_WORD_LEN
                 * costs::RIPEMD160_PER_WORD
@@ -114,7 +117,7 @@ impl Precompile for RIPEMD160 {
     fn run(
         &self,
         input: &[u8],
-        target_gas: Option<u64>,
+        target_gas: Option<EthGas>,
         _context: &Context,
         _is_static: bool,
     ) -> EvmPrecompileResult {
@@ -151,7 +154,7 @@ mod tests {
                 .unwrap();
 
         let res = SHA256
-            .run(input, Some(60), &new_context(), false)
+            .run(input, Some(EthGas::new(60)), &new_context(), false)
             .unwrap()
             .output;
         assert_eq!(res, expected);
@@ -165,7 +168,7 @@ mod tests {
                 .unwrap();
 
         let res = RIPEMD160
-            .run(input, Some(600), &new_context(), false)
+            .run(input, Some(EthGas::new(600)), &new_context(), false)
             .unwrap()
             .output;
         assert_eq!(res, expected);

--- a/engine-precompiles/src/identity.rs
+++ b/engine-precompiles/src/identity.rs
@@ -1,14 +1,17 @@
+use crate::prelude::types::EthGas;
 use crate::prelude::Address;
 use crate::{EvmPrecompileResult, Precompile, PrecompileOutput};
 use evm::{Context, ExitError};
 
 /// Identity precompile costs.
 mod costs {
+    use crate::prelude::types::EthGas;
+
     /// The base cost of the operation.
-    pub(super) const IDENTITY_BASE: u64 = 15;
+    pub(super) const IDENTITY_BASE: EthGas = EthGas::new(15);
 
     /// The cost per word.
-    pub(super) const IDENTITY_PER_WORD: u64 = 3;
+    pub(super) const IDENTITY_PER_WORD: EthGas = EthGas::new(3);
 }
 
 mod consts {
@@ -23,7 +26,7 @@ impl Identity {
 }
 
 impl Precompile for Identity {
-    fn required_gas(input: &[u8]) -> Result<u64, ExitError> {
+    fn required_gas(input: &[u8]) -> Result<EthGas, ExitError> {
         Ok(
             (input.len() as u64 + consts::IDENTITY_WORD_LEN - 1) / consts::IDENTITY_WORD_LEN
                 * costs::IDENTITY_PER_WORD
@@ -38,7 +41,7 @@ impl Precompile for Identity {
     fn run(
         &self,
         input: &[u8],
-        target_gas: Option<u64>,
+        target_gas: Option<EthGas>,
         _context: &Context,
         _is_static: bool,
     ) -> EvmPrecompileResult {
@@ -67,20 +70,20 @@ mod tests {
 
         let expected = input[0..2].to_vec();
         let res = Identity
-            .run(&input[0..2], Some(18), &new_context(), false)
+            .run(&input[0..2], Some(EthGas::new(18)), &new_context(), false)
             .unwrap()
             .output;
         assert_eq!(res, expected);
 
         let expected = input.to_vec();
         let res = Identity
-            .run(&input, Some(18), &new_context(), false)
+            .run(&input, Some(EthGas::new(18)), &new_context(), false)
             .unwrap()
             .output;
         assert_eq!(res, expected);
 
         // gas fail
-        let res = Identity.run(&input[0..2], Some(17), &new_context(), false);
+        let res = Identity.run(&input[0..2], Some(EthGas::new(17)), &new_context(), false);
 
         assert!(matches!(res, Err(ExitError::OutOfGas)));
 
@@ -90,7 +93,7 @@ mod tests {
             24, 25, 26, 27, 28, 29, 30, 31, 32,
         ];
         let res = Identity
-            .run(&input, Some(21), &new_context(), false)
+            .run(&input, Some(EthGas::new(21)), &new_context(), false)
             .unwrap()
             .output;
         assert_eq!(res, input.to_vec());

--- a/engine-precompiles/src/modexp.rs
+++ b/engine-precompiles/src/modexp.rs
@@ -1,6 +1,7 @@
 use crate::prelude::{Address, PhantomData, Vec, U256};
 use crate::{Berlin, Byzantium, EvmPrecompileResult, HardFork, Precompile, PrecompileOutput};
 
+use crate::prelude::types::EthGas;
 use evm::{Context, ExitError};
 use num::{BigUint, Integer};
 
@@ -94,7 +95,7 @@ impl ModExp<Byzantium> {
 }
 
 impl Precompile for ModExp<Byzantium> {
-    fn required_gas(input: &[u8]) -> Result<u64, ExitError> {
+    fn required_gas(input: &[u8]) -> Result<EthGas, ExitError> {
         let (base_len, exp_len, mod_len) = parse_lengths(input);
 
         let mul = Self::mul_complexity(core::cmp::max(mod_len, base_len));
@@ -102,7 +103,7 @@ impl Precompile for ModExp<Byzantium> {
         // mul * iter_count bounded by 2^195 < 2^256 (no overflow)
         let gas = mul * core::cmp::max(iter_count, U256::one()) / U256::from(20);
 
-        Ok(saturating_round(gas))
+        Ok(EthGas::new(saturating_round(gas)))
     }
 
     /// See: https://eips.ethereum.org/EIPS/eip-198
@@ -110,7 +111,7 @@ impl Precompile for ModExp<Byzantium> {
     fn run(
         &self,
         input: &[u8],
-        target_gas: Option<u64>,
+        target_gas: Option<EthGas>,
         _context: &Context,
         _is_static: bool,
     ) -> EvmPrecompileResult {
@@ -136,7 +137,7 @@ impl ModExp<Berlin> {
 }
 
 impl Precompile for ModExp<Berlin> {
-    fn required_gas(input: &[u8]) -> Result<u64, ExitError> {
+    fn required_gas(input: &[u8]) -> Result<EthGas, ExitError> {
         let (base_len, exp_len, mod_len) = parse_lengths(input);
 
         let mul = Self::mul_complexity(base_len, mod_len);
@@ -144,13 +145,13 @@ impl Precompile for ModExp<Berlin> {
         // mul * iter_count bounded by 2^189 (so no overflow)
         let gas = mul * iter_count / U256::from(3);
 
-        Ok(core::cmp::max(200, saturating_round(gas)))
+        Ok(EthGas::new(core::cmp::max(200, saturating_round(gas))))
     }
 
     fn run(
         &self,
         input: &[u8],
-        target_gas: Option<u64>,
+        target_gas: Option<EthGas>,
         _context: &Context,
         _is_static: bool,
     ) -> EvmPrecompileResult {
@@ -369,14 +370,46 @@ mod tests {
         }
     ];
 
-    const BYZANTIUM_GAS: [u64; 18] = [
-        13_056, 13_056, 13_056, 204, 204, 3_276, 665, 665, 10_649, 1_894, 1_894, 30_310, 5_580,
-        5_580, 89_292, 17_868, 17_868, 285_900,
+    const BYZANTIUM_GAS: [EthGas; 18] = [
+        EthGas::new(13_056),
+        EthGas::new(13_056),
+        EthGas::new(13_056),
+        EthGas::new(204),
+        EthGas::new(204),
+        EthGas::new(3_276),
+        EthGas::new(665),
+        EthGas::new(665),
+        EthGas::new(10_649),
+        EthGas::new(1_894),
+        EthGas::new(1_894),
+        EthGas::new(30_310),
+        EthGas::new(5_580),
+        EthGas::new(5_580),
+        EthGas::new(89_292),
+        EthGas::new(17_868),
+        EthGas::new(17_868),
+        EthGas::new(285_900),
     ];
 
-    const BERLIN_GAS: [u64; 18] = [
-        1_360, 1_360, 1_360, 200, 200, 341, 200, 200, 1_365, 341, 341, 5_461, 1_365, 1_365, 21_845,
-        5_461, 5_461, 87_381,
+    const BERLIN_GAS: [EthGas; 18] = [
+        EthGas::new(1_360),
+        EthGas::new(1_360),
+        EthGas::new(1_360),
+        EthGas::new(200),
+        EthGas::new(200),
+        EthGas::new(341),
+        EthGas::new(200),
+        EthGas::new(200),
+        EthGas::new(1_365),
+        EthGas::new(341),
+        EthGas::new(341),
+        EthGas::new(5_461),
+        EthGas::new(1_365),
+        EthGas::new(1_365),
+        EthGas::new(21_845),
+        EthGas::new(5_461),
+        EthGas::new(5_461),
+        EthGas::new(87_381),
     ];
 
     #[test]
@@ -454,7 +487,7 @@ mod tests {
     #[test]
     fn test_berlin_modexp_empty_input() {
         let res = ModExp::<Berlin>::new()
-            .run(&[], Some(100_000), &new_context(), false)
+            .run(&[], Some(EthGas::new(100_000)), &new_context(), false)
             .unwrap();
         let expected: Vec<u8> = Vec::new();
         assert_eq!(res.output, expected)

--- a/engine-precompiles/src/secp256k1.rs
+++ b/engine-precompiles/src/secp256k1.rs
@@ -1,10 +1,13 @@
+use crate::prelude::types::EthGas;
 use crate::prelude::{sdk, vec, Borrowed, H256};
 use crate::{EvmPrecompileResult, Precompile, PrecompileOutput};
 use ethabi::Address;
 use evm::{Context, ExitError};
 
 mod costs {
-    pub(super) const ECRECOVER_BASE: u64 = 3_000;
+    use crate::prelude::types::EthGas;
+
+    pub(super) const ECRECOVER_BASE: EthGas = EthGas::new(3_000);
 }
 
 mod consts {
@@ -56,14 +59,14 @@ impl ECRecover {
 }
 
 impl Precompile for ECRecover {
-    fn required_gas(_input: &[u8]) -> Result<u64, ExitError> {
+    fn required_gas(_input: &[u8]) -> Result<EthGas, ExitError> {
         Ok(costs::ECRECOVER_BASE)
     }
 
     fn run(
         &self,
         input: &[u8],
-        target_gas: Option<u64>,
+        target_gas: Option<EthGas>,
         _context: &Context,
         _is_static: bool,
     ) -> EvmPrecompileResult {
@@ -142,7 +145,7 @@ mod tests {
                 .unwrap();
 
         let res = ECRecover
-            .run(&input, Some(3_000), &new_context(), false)
+            .run(&input, Some(EthGas::new(3_000)), &new_context(), false)
             .unwrap()
             .output;
         assert_eq!(res, expected);
@@ -150,7 +153,7 @@ mod tests {
         // out of gas
         let input = hex::decode("47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad000000000000000000000000000000000000000000000000000000000000001b650acf9d3f5f0a2c799776a1254355d5f4061762a237396a99a0e0e3fc2bcd6729514a0dacb2e623ac4abd157cb18163ff942280db4d5caad66ddf941ba12e03").unwrap();
 
-        let res = ECRecover.run(&input, Some(2_999), &new_context(), false);
+        let res = ECRecover.run(&input, Some(EthGas::new(2_999)), &new_context(), false);
         assert!(matches!(res, Err(ExitError::OutOfGas)));
 
         // bad inputs
@@ -160,7 +163,7 @@ mod tests {
                 .unwrap();
 
         let res = ECRecover
-            .run(&input, Some(3_000), &new_context(), false)
+            .run(&input, Some(EthGas::new(3_000)), &new_context(), false)
             .unwrap()
             .output;
         assert_eq!(res, expected);
@@ -171,7 +174,7 @@ mod tests {
                 .unwrap();
 
         let res = ECRecover
-            .run(&input, Some(3_000), &new_context(), false)
+            .run(&input, Some(EthGas::new(3_000)), &new_context(), false)
             .unwrap()
             .output;
         assert_eq!(res, expected);
@@ -182,7 +185,7 @@ mod tests {
                 .unwrap();
 
         let res = ECRecover
-            .run(&input, Some(3_000), &new_context(), false)
+            .run(&input, Some(EthGas::new(3_000)), &new_context(), false)
             .unwrap()
             .output;
         assert_eq!(res, expected);
@@ -193,7 +196,7 @@ mod tests {
                 .unwrap();
 
         let res = ECRecover
-            .run(&input, Some(3_000), &new_context(), false)
+            .run(&input, Some(EthGas::new(3_000)), &new_context(), false)
             .unwrap()
             .output;
         assert_eq!(res, expected);

--- a/engine-sdk/src/near_runtime.rs
+++ b/engine-sdk/src/near_runtime.rs
@@ -1,4 +1,5 @@
 use crate::io::StorageIntermediate;
+use crate::prelude::NearGas;
 use crate::promise::PromiseId;
 use aurora_engine_types::account_id::AccountId;
 use aurora_engine_types::parameters::{PromiseAction, PromiseBatchAction, PromiseCreateArgs};
@@ -21,7 +22,7 @@ impl Runtime {
     const ENV_REGISTER_ID: RegisterIndex = RegisterIndex(4);
     const PROMISE_REGISTER_ID: RegisterIndex = RegisterIndex(5);
 
-    const GAS_FOR_STATE_MIGRATION: u64 = 100_000_000_000_000;
+    const GAS_FOR_STATE_MIGRATION: NearGas = NearGas::new(100_000_000_000_000);
 
     /// Deploy code from given key in place of the current contract.
     /// Not implemented in terms of higher level traits (eg IO) for efficiency reasons.
@@ -39,7 +40,7 @@ impl Runtime {
                 b"state_migration",
                 &[],
                 0,
-                Self::GAS_FOR_STATE_MIGRATION,
+                Self::GAS_FOR_STATE_MIGRATION.into_u64(),
             )
         }
     }

--- a/engine-sdk/src/prelude.rs
+++ b/engine-sdk/src/prelude.rs
@@ -1,3 +1,3 @@
-pub use aurora_engine_types::types::{PromiseResult, STORAGE_PRICE_PER_BYTE};
+pub use aurora_engine_types::types::{NearGas, PromiseResult, STORAGE_PRICE_PER_BYTE};
 pub use aurora_engine_types::{vec, Address, Vec, H256};
 pub use borsh::{BorshDeserialize, BorshSerialize};

--- a/engine-types/src/lib.rs
+++ b/engine-types/src/lib.rs
@@ -29,35 +29,16 @@ mod v0 {
     };
     #[cfg(not(feature = "std"))]
     pub use core::{
-        cmp::Ordering,
-        convert::TryFrom,
-        convert::TryInto,
-        marker::PhantomData,
-        mem,
-        ops::{Add, Sub},
+        cmp::Ordering, convert::TryFrom, convert::TryInto, fmt::Display, marker::PhantomData, mem,
+        ops::Add, ops::Div, ops::Mul, ops::Sub,
     };
     pub use primitive_types::{H160, H256, U256};
     #[cfg(feature = "std")]
     pub use std::{
-        borrow::Cow,
-        borrow::Cow::Borrowed,
-        borrow::ToOwned,
-        boxed::Box,
-        cmp::Ordering,
-        collections::BTreeMap,
-        collections::HashMap,
-        convert::TryFrom,
-        convert::TryInto,
-        error::Error,
-        fmt, format,
-        marker::PhantomData,
-        mem,
-        ops::{Add, Sub},
-        str,
-        string::String,
-        string::ToString,
-        vec,
-        vec::Vec,
+        borrow::Cow, borrow::Cow::Borrowed, borrow::ToOwned, boxed::Box, cmp::Ordering,
+        collections::BTreeMap, collections::HashMap, convert::TryFrom, convert::TryInto,
+        error::Error, fmt, fmt::Display, format, marker::PhantomData, mem, ops::Add, ops::Div,
+        ops::Mul, ops::Sub, str, string::String, string::ToString, vec, vec::Vec,
     };
 }
 

--- a/engine/src/connector.rs
+++ b/engine/src/connector.rs
@@ -10,7 +10,7 @@ use crate::parameters::{
 };
 use crate::prelude::{
     format, sdk, str, validate_eth_address, AccountId, Address, Balance, BorshDeserialize,
-    BorshSerialize, EthAddress, EthConnectorStorageId, Gas, KeyPrefix, PromiseResult, String,
+    BorshSerialize, EthAddress, EthConnectorStorageId, KeyPrefix, NearGas, PromiseResult, String,
     ToString, TryFrom, Vec, WithdrawCallArgs, ERR_FAILED_PARSE, H160, U256,
 };
 use crate::proof::Proof;
@@ -23,9 +23,9 @@ use aurora_engine_types::types::AddressValidationError;
 
 pub const ERR_NOT_ENOUGH_BALANCE_FOR_FEE: &str = "ERR_NOT_ENOUGH_BALANCE_FOR_FEE";
 pub const NO_DEPOSIT: Balance = 0;
-const GAS_FOR_FINISH_DEPOSIT: Gas = 50_000_000_000_000;
+const GAS_FOR_FINISH_DEPOSIT: NearGas = NearGas::new(50_000_000_000_000);
 // Note: Is 40Tgas always enough?
-const GAS_FOR_VERIFY_LOG_ENTRY: Gas = 40_000_000_000_000;
+const GAS_FOR_VERIFY_LOG_ENTRY: NearGas = NearGas::new(40_000_000_000_000);
 
 pub const UNPAUSE_ALL: PausedMask = 0;
 pub const PAUSE_DEPOSIT: PausedMask = 1 << 0;
@@ -252,7 +252,7 @@ impl<I: IO + Copy> EthConnectorContract<I> {
             method: "verify_log_entry".to_string(),
             args: proof_to_verify,
             attached_balance: NO_DEPOSIT,
-            attached_gas: GAS_FOR_VERIFY_LOG_ENTRY,
+            attached_gas: GAS_FOR_VERIFY_LOG_ENTRY.into_u64(),
         };
 
         // Finalize deposit
@@ -310,7 +310,7 @@ impl<I: IO + Copy> EthConnectorContract<I> {
             method: "finish_deposit".to_string(),
             args: data,
             attached_balance: NO_DEPOSIT,
-            attached_gas: GAS_FOR_FINISH_DEPOSIT,
+            attached_gas: GAS_FOR_FINISH_DEPOSIT.into_u64(),
         };
         Ok(PromiseWithCallbackArgs {
             base: verify_call,

--- a/engine/src/fungible_token.rs
+++ b/engine/src/fungible_token.rs
@@ -5,16 +5,16 @@ use crate::parameters::{NEP141FtOnTransferArgs, ResolveTransferCallArgs, Storage
 use crate::prelude::account_id::AccountId;
 use crate::prelude::{
     sdk, storage, vec, Address, BTreeMap, Balance, BorshDeserialize, BorshSerialize, EthAddress,
-    Gas, PromiseResult, StorageBalanceBounds, StorageUsage, String, ToString, TryInto, Vec, Wei,
-    U256,
+    NearGas, PromiseResult, StorageBalanceBounds, StorageUsage, String, ToString, TryInto, Vec,
+    Wei, U256,
 };
 use aurora_engine_sdk::io::{StorageIntermediate, IO};
 use aurora_engine_types::parameters::{
     PromiseAction, PromiseBatchAction, PromiseCreateArgs, PromiseWithCallbackArgs,
 };
 
-const GAS_FOR_RESOLVE_TRANSFER: Gas = 5_000_000_000_000;
-const GAS_FOR_FT_ON_TRANSFER: Gas = 10_000_000_000_000;
+const GAS_FOR_RESOLVE_TRANSFER: NearGas = NearGas::new(5_000_000_000_000);
+const GAS_FOR_FT_ON_TRANSFER: NearGas = NearGas::new(10_000_000_000_000);
 
 #[derive(Debug, Default, BorshDeserialize, BorshSerialize)]
 pub struct FungibleToken {
@@ -296,14 +296,14 @@ impl<I: IO + Copy> FungibleTokenOps<I> {
             method: "ft_on_transfer".to_string(),
             args: data1.into_bytes(),
             attached_balance: NO_DEPOSIT,
-            attached_gas: GAS_FOR_FT_ON_TRANSFER,
+            attached_gas: GAS_FOR_FT_ON_TRANSFER.into_u64(),
         };
         let ft_resolve_transfer_call = PromiseCreateArgs {
             target_account_id: current_account_id,
             method: "ft_resolve_transfer".to_string(),
             args: data2,
             attached_balance: NO_DEPOSIT,
-            attached_gas: GAS_FOR_RESOLVE_TRANSFER,
+            attached_gas: GAS_FOR_RESOLVE_TRANSFER.into_u64(),
         };
         Ok(PromiseWithCallbackArgs {
             base: ft_on_transfer_call,

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -97,6 +97,9 @@ mod contract {
     };
     use crate::transaction::{EthTransactionKind, NormalizedEthTransaction};
 
+    #[cfg(feature = "integration-test")]
+    use crate::prelude::NearGas;
+
     const CODE_KEY: &[u8; 4] = b"CODE";
     const CODE_STAGE_KEY: &[u8; 10] = b"CODE_STAGE";
     const GAS_OVERFLOW: &str = "ERR_GAS_OVERFLOW";
@@ -948,8 +951,8 @@ mod contract {
     #[no_mangle]
     pub extern "C" fn mint_account() {
         use evm::backend::ApplyBackend;
-        const GAS_FOR_VERIFY: u64 = 20_000_000_000_000;
-        const GAS_FOR_FINISH: u64 = 50_000_000_000_000;
+        const GAS_FOR_VERIFY: NearGas = NearGas::new(20_000_000_000_000);
+        const GAS_FOR_FINISH: NearGas = NearGas::new(50_000_000_000_000);
 
         let mut io = Runtime;
         let args: ([u8; 20], u64, u64) = io.read_input_borsh().sdk_expect("ERR_ARGS");
@@ -983,14 +986,14 @@ mod contract {
             method: "verify_log_entry".to_string(),
             args: Vec::new(),
             attached_balance: 0,
-            attached_gas: GAS_FOR_VERIFY,
+            attached_gas: GAS_FOR_VERIFY.into_u64(),
         };
         let finish_call = aurora_engine_types::parameters::PromiseCreateArgs {
             target_account_id: aurora_account_id,
             method: "finish_deposit".to_string(),
             args: args.try_to_vec().unwrap(),
             attached_balance: 0,
-            attached_gas: GAS_FOR_FINISH,
+            attached_gas: GAS_FOR_FINISH.into_u64(),
         };
         io.promise_crate_with_callback(&aurora_engine_types::parameters::PromiseWithCallbackArgs {
             base: verify_call,


### PR DESCRIPTION
While working on the `engine-standalone`, I have come to realise that the gas usages, since they are costs, should be using newtypes and not a normal type. This prevents dev error in the case of trying to use the wrong values, in the wrong areas which can lead to unintentional bugs.

Newtypes are 0 cost, therefore this is a wise decision to add this bit of work in. There will be more work around these areas if the need arises as I continue work through out the library and notice improvements that should be done. This is one of them that I had noticed.

This is a semantic change and intended for dev experience and will help the code be at a higher level of quality. From this point forward, the types will be made aware to the developer when working on the library and forces them to be consciously aware of which types they are dealing with, and not just general values.

Notably, we now have:

```rust
pub struct EthGas(u64);

pub struct NearGas(u64);
```

... as well as boiler plate implementations which make working with the newtypes generally easier.