### PR TITLE
Feat(standalone): Standalone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,6 +1186,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "engine-standalone"
+version = "0.1.0"
+dependencies = [
+ "aurora-engine",
+ "aurora-engine-sdk",
+ "aurora-engine-types",
+ "evm-core",
+ "hex",
+ "libc",
+]
+
+[[package]]
 name = "enumset"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,11 @@ opt-level = 3
 [workspace]
 members = [
     "engine",
-    "engine-types",
-    "engine-sdk",
     "engine-precompiles",
-    "engine-tests"
+    "engine-sdk",
+    "engine-standalone",
+    "engine-tests",
+    "engine-types",
 ]
 exclude = [
     "etc/state-migration-test",

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ target/wasm32-unknown-unknown/release/aurora_engine.wasm: Cargo.toml Cargo.lock 
 		--target wasm32-unknown-unknown \
 		--release \
 		--verbose \
+		-p aurora-engine \
 		--no-default-features \
 		--features=$(FEATURES)$(ADDITIONAL_FEATURES) \
 		-Z avoid-dev-deps
@@ -90,6 +91,7 @@ target/wasm32-unknown-unknown/release/aurora_engine.wasm: Cargo.toml Cargo.lock 
 target/wasm32-unknown-unknown/debug/aurora_engine.wasm: Cargo.toml Cargo.lock $(wildcard src/*.rs) etc/eth-contracts/res/EvmErc20.bin
 	$(CARGO) build \
 		--target wasm32-unknown-unknown \
+		-p aurora-engine \
 		--no-default-features \
 		--features=$(FEATURES)$(ADDITIONAL_FEATURES) \
 		-Z avoid-dev-deps

--- a/engine-precompiles/src/lib.rs
+++ b/engine-precompiles/src/lib.rs
@@ -50,7 +50,6 @@ impl From<PrecompileOutput> for evm::executor::PrecompileOutput {
     fn from(output: PrecompileOutput) -> Self {
         evm::executor::PrecompileOutput {
             exit_status: ExitSucceed::Returned,
-            // This shouldn't fail, and is expected.
             cost: output.cost.into_u64(),
             output: output.output,
             logs: output.logs,

--- a/engine-sdk/Cargo.toml
+++ b/engine-sdk/Cargo.toml
@@ -19,5 +19,6 @@ sha3 = { version = "0.9.1", default-features = false }
 sha2 = { version = "0.9.3", default-features = false }
 
 [features]
+std = ["aurora-engine-types/std"]
 contract = []
 log = []

--- a/engine-sdk/src/env.rs
+++ b/engine-sdk/src/env.rs
@@ -2,6 +2,7 @@ use crate::error::{OneYoctoAttachError, PrivateCallError};
 use aurora_engine_types::account_id::AccountId;
 
 /// Timestamp represented by the number of nanoseconds since the Unix Epoch.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Timestamp(u64);
 
 impl Timestamp {
@@ -54,5 +55,42 @@ pub trait Env {
         } else {
             Err(OneYoctoAttachError)
         }
+    }
+}
+
+/// Fully in-memory implementation of the blockchain environment with
+/// fixed values for all the fields.
+pub struct Fixed {
+    pub signer_account_id: AccountId,
+    pub current_account_id: AccountId,
+    pub predecessor_account_id: AccountId,
+    pub block_height: u64,
+    pub block_timestamp: Timestamp,
+    pub attached_deposit: u128,
+}
+
+impl Env for Fixed {
+    fn signer_account_id(&self) -> AccountId {
+        self.signer_account_id.clone()
+    }
+
+    fn current_account_id(&self) -> AccountId {
+        self.current_account_id.clone()
+    }
+
+    fn predecessor_account_id(&self) -> AccountId {
+        self.predecessor_account_id.clone()
+    }
+
+    fn block_height(&self) -> u64 {
+        self.block_height
+    }
+
+    fn block_timestamp(&self) -> Timestamp {
+        self.block_timestamp
+    }
+
+    fn attached_deposit(&self) -> u128 {
+        self.attached_deposit
     }
 }

--- a/engine-sdk/src/promise.rs
+++ b/engine-sdk/src/promise.rs
@@ -7,14 +7,11 @@ use aurora_engine_types::types::PromiseResult;
 pub struct PromiseId(u64);
 
 impl PromiseId {
-    // TODO: can remove this annotation when there is a standalone implementation that uses PromiseId.
-    #[allow(dead_code)]
-    pub(crate) fn new(id: u64) -> Self {
+    pub fn new(id: u64) -> Self {
         Self(id)
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn raw(self) -> u64 {
+    pub fn raw(self) -> u64 {
         self.0
     }
 }

--- a/engine-standalone/Cargo.toml
+++ b/engine-standalone/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "engine-standalone"
+version = "0.1.0"
+edition = "2018"
+authors = ["Aurora <hello@aurora.dev>"]
+description = "Aurora engine standalone library. Provides debugging capabilities."
+homepage = "https://github.com/aurora-is-near/aurora-engine"
+repository = "https://github.com/aurora-is-near/aurora-engine"
+license = "CC0-1.0"
+publish = false
+autobenches = false
+
+[dependencies]
+aurora-engine = { path = "../engine", default-features = false, features = ["std"] }
+aurora-engine-types = { path = "../engine-types", default-features = false, features = ["std"] }
+aurora-engine-sdk = { path = "../engine-sdk", default-features = false, features = ["std"] }
+evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", default-features = false }
+libc = "0.2"
+
+[dev-dependencies]
+hex = { version = "0.4.3", default-features = false }
+
+[features]
+default = []
+mainnet = []
+testnet = []
+betanet = []

--- a/engine-standalone/LICENSE
+++ b/engine-standalone/LICENSE
@@ -1,0 +1,116 @@
+CC0 1.0 Universal
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator and
+subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for the
+purpose of contributing to a commons of creative, cultural and scientific
+works ("Commons") that the public can reliably and without fear of later
+claims of infringement build upon, modify, incorporate in other works, reuse
+and redistribute as freely as possible in any form whatsoever and for any
+purposes, including without limitation commercial purposes. These owners may
+contribute to the Commons to promote the ideal of a free culture and the
+further production of creative, cultural and scientific works, or to gain
+reputation or greater distribution for their Work in part through the use and
+efforts of others.
+
+For these and/or other purposes and motivations, and without any expectation
+of additional consideration or compensation, the person associating CC0 with a
+Work (the "Affirmer"), to the extent that he or she is an owner of Copyright
+and Related Rights in the Work, voluntarily elects to apply CC0 to the Work
+and publicly distribute the Work under its terms, with knowledge of his or her
+Copyright and Related Rights in the Work and the meaning and intended legal
+effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not limited
+to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display, communicate,
+  and translate a Work;
+
+  ii. moral rights retained by the original author(s) and/or performer(s);
+
+  iii. publicity and privacy rights pertaining to a person's image or likeness
+  depicted in a Work;
+
+  iv. rights protecting against unfair competition in regards to a Work,
+  subject to the limitations in paragraph 4(a), below;
+
+  v. rights protecting the extraction, dissemination, use and reuse of data in
+  a Work;
+
+  vi. database rights (such as those arising under Directive 96/9/EC of the
+  European Parliament and of the Council of 11 March 1996 on the legal
+  protection of databases, and under any national implementation thereof,
+  including any amended or successor version of such directive); and
+
+  vii. other similar, equivalent or corresponding rights throughout the world
+  based on applicable law or treaty, and any national implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention of,
+applicable law, Affirmer hereby overtly, fully, permanently, irrevocably and
+unconditionally waives, abandons, and surrenders all of Affirmer's Copyright
+and Related Rights and associated claims and causes of action, whether now
+known or unknown (including existing as well as future claims and causes of
+action), in the Work (i) in all territories worldwide, (ii) for the maximum
+duration provided by applicable law or treaty (including future time
+extensions), (iii) in any current or future medium and for any number of
+copies, and (iv) for any purpose whatsoever, including without limitation
+commercial, advertising or promotional purposes (the "Waiver"). Affirmer makes
+the Waiver for the benefit of each member of the public at large and to the
+detriment of Affirmer's heirs and successors, fully intending that such Waiver
+shall not be subject to revocation, rescission, cancellation, termination, or
+any other legal or equitable action to disrupt the quiet enjoyment of the Work
+by the public as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason be
+judged legally invalid or ineffective under applicable law, then the Waiver
+shall be preserved to the maximum extent permitted taking into account
+Affirmer's express Statement of Purpose. In addition, to the extent the Waiver
+is so judged Affirmer hereby grants to each affected person a royalty-free,
+non transferable, non sublicensable, non exclusive, irrevocable and
+unconditional license to exercise Affirmer's Copyright and Related Rights in
+the Work (i) in all territories worldwide, (ii) for the maximum duration
+provided by applicable law or treaty (including future time extensions), (iii)
+in any current or future medium and for any number of copies, and (iv) for any
+purpose whatsoever, including without limitation commercial, advertising or
+promotional purposes (the "License"). The License shall be deemed effective as
+of the date CC0 was applied by Affirmer to the Work. Should any part of the
+License for any reason be judged legally invalid or ineffective under
+applicable law, such partial invalidity or ineffectiveness shall not
+invalidate the remainder of the License, and in such case Affirmer hereby
+affirms that he or she will not (i) exercise any of his or her remaining
+Copyright and Related Rights in the Work or (ii) assert any associated claims
+and causes of action with respect to the Work, in either case contrary to
+Affirmer's express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+  a. No trademark or patent rights held by Affirmer are waived, abandoned,
+  surrendered, licensed or otherwise affected by this document.
+
+  b. Affirmer offers the Work as-is and makes no representations or warranties
+  of any kind concerning the Work, express, implied, statutory or otherwise,
+  including without limitation warranties of title, merchantability, fitness
+  for a particular purpose, non infringement, or the absence of latent or
+  other defects, accuracy, or the present or absence of errors, whether or not
+  discoverable, all to the greatest extent permissible under applicable law.
+
+  c. Affirmer disclaims responsibility for clearing rights of other persons
+  that may apply to the Work or any use thereof, including without limitation
+  any person's Copyright and Related Rights in the Work. Further, Affirmer
+  disclaims responsibility for obtaining any necessary consents, permissions
+  or other rights required for any use of the Work.
+
+  d. Affirmer understands and acknowledges that Creative Commons is not a
+  party to this document and has no duty or obligation with respect to this
+  CC0 or use of the Work.
+
+For more information, please see
+<http://creativecommons.org/publicdomain/zero/1.0/>

--- a/engine-standalone/src/ffi.rs
+++ b/engine-standalone/src/ffi.rs
@@ -1,0 +1,209 @@
+use crate::trace::{TraceLog, TransactionTrace};
+use libc::{c_uchar, c_uint, c_ushort, size_t, uintmax_t};
+use std::ffi::CString;
+
+/// Translates a struct into a C struct.
+pub trait IntoC<T> {
+    /// A method used to consume a struct and convert it into a C-compatible
+    /// struct.
+    fn into_c(self) -> T;
+}
+
+#[repr(C)]
+/// The C trace log of an execution on the EVM.
+pub struct CTraceLog {
+    /// The depth of the log.
+    depth: c_uint,
+    /// Any errors that may have occurred during execution.
+    ///
+    /// Empty if none.
+    error: CString,
+    /// Gas used to execute the transaction.
+    gas: uintmax_t,
+    /// Gas cost for the transaction.
+    gas_cost: uintmax_t,
+    /// The bounded memory.
+    memory_ptr: *const [c_uchar; 32],
+    /// The length of the memory vector.
+    memory_len: size_t,
+    /// The opcode as a byte.
+    opcode: c_uchar, // opcode as byte
+    /// The current program counter of the transaction.
+    program_counter: c_uint,
+    /// The local stack.
+    stack_ptr: *const [c_uchar; 32],
+    /// The length of the stack vector.
+    stack_len: size_t,
+    /// The storage of the logs as a set of tuples.
+    storage_ptr: *const ([c_uchar; 32], [c_uchar; 32]),
+    /// The length of the storage.
+    storage_len: size_t,
+}
+
+impl From<TraceLog> for CTraceLog {
+    fn from(log: TraceLog) -> Self {
+        let error = match log.error() {
+            Some(err) => CString::new(err.to_string()),
+            None => CString::new(""),
+        }
+        .expect("CString::new failed");
+        let (memory_ptr, memory_len) = {
+            let len = log.memory().len();
+            let memory = log.memory().clone();
+
+            (memory.into_raw().as_ptr(), len)
+        };
+        let (stack_ptr, stack_len) = {
+            let len = log.stack().len();
+            let stack = log.stack().clone();
+
+            (stack.into_raw().as_ptr(), len)
+        };
+        let (storage_ptr, storage_len) = {
+            let storage_map = log.storage().clone();
+            let storage: Vec<([u8; 32], [u8; 32])> = storage_map
+                .into_iter()
+                .map(|(key, value)| (key.into_raw(), value.into_raw()))
+                .collect();
+
+            (storage.as_ptr(), storage.len())
+        };
+
+        Self {
+            depth: log.depth().into_u32(),
+            error,
+            gas: log.gas().into_u64(),
+            gas_cost: log.gas_cost().into_u64(),
+            memory_ptr,
+            memory_len,
+            opcode: log.opcode().as_u8(),
+            program_counter: log.program_counter().into_u32(),
+            stack_ptr,
+            stack_len,
+            storage_ptr,
+            storage_len,
+        }
+    }
+}
+
+#[repr(C)]
+pub struct CTransactionTrace {
+    /// The total gas cost of the transaction.
+    gas: uintmax_t,
+    /// The return of the operation.
+    result: CString,
+    /// The collection of traces.
+    logs_ptr: *const CTraceLog,
+    /// The length of the logs vector.
+    logs_len: size_t,
+}
+
+impl From<TransactionTrace> for CTransactionTrace {
+    fn from(trace: TransactionTrace) -> Self {
+        let logs = trace.logs().clone();
+        let c_logs: Vec<CTraceLog> = logs.into_iter().map(CTraceLog::from).collect();
+        let (logs_ptr, logs_len) = {
+            let len = c_logs.len();
+            (c_logs.as_ptr(), len)
+        };
+
+        Self {
+            gas: trace.gas().into_u64(),
+            result: CString::new(trace.result()).expect("CString::new failed"),
+            logs_ptr,
+            logs_len,
+        }
+    }
+}
+
+// Debug methods
+
+/// Takes in a transaction hash and returns a `TransactionTrace`.
+#[no_mangle]
+pub extern "C" fn trace_transaction(_tx_hash: *const [c_uchar; 32]) -> *const CTransactionTrace {
+    todo!()
+}
+
+// Storage getters
+
+/// Gets the nonce of an Ethereum address at a given block.
+/// Returns 0 on success, 1 on failure (block hash not found); the nonce variable is overwritten
+/// with the requested nonce iff 0 is returned.
+#[no_mangle]
+pub extern "C" fn get_nonce(
+    _block_hash: *const [c_uchar; 32],
+    _address: *const [c_uchar; 20],
+    _nonce_out: *mut uintmax_t,
+) -> c_uchar {
+    todo!()
+}
+
+/// Gets the balance of an Ethereum address at a given block.
+///
+/// Returns 0 on success, 1 on failure (block hash not found); the balance variable is overwritten
+/// with the requested balance (big endian encoded) iff 0 is returned.
+#[no_mangle]
+pub extern "C" fn get_balance(
+    _block_hash: *const [c_uchar; 32],
+    _address: *const [c_uchar; 20],
+    _balance_out: *mut [c_uchar; 32],
+) -> c_uchar {
+    todo!()
+}
+
+/// Returns the size of the EVM bytecode (in bytes) for the specified account at a given block.
+///
+/// Returns 0 on success, 1 on failure (block hash not found); the size variable is overwritten
+/// with the requested balance (big endian encoded) iff 0 is returned.
+#[no_mangle]
+pub extern "C" fn get_code_size(
+    _block_hash: *const [c_uchar; 32],
+    _address: *const [c_uchar; 20],
+    _size_out: *const c_uint,
+) -> c_uchar {
+    todo!()
+}
+
+/// Returns the byte slice with the code for the specified account at a given block.
+///
+/// Returns 0 on success, 1 on failure (block hash not found); the code variable is overwritten
+/// with the requested balance (big endian encoded) iff 0 is returned. The size of the output slice
+/// needed should be determined from `get_code_size`.
+#[no_mangle]
+pub extern "C" fn get_code(
+    _block_hash: *const [c_uchar; 32],
+    _address: *const [c_uchar; 20],
+    _code_out: *mut c_uchar,
+    _code_out_len: *mut c_uint,
+) -> c_uchar {
+    todo!()
+}
+
+/// Gets the state value for the provided address and key values at a given block.
+/// Returns 0 on success, 1 on failure (block hash not found); the value variable is overwritten
+/// with the requested balance (big endian encoded) iff 0 is returned.
+#[no_mangle]
+pub extern "C" fn get_state(
+    _block_hash: *const [c_uchar; 32],
+    _address: *const [c_uchar; 20],
+    _key: *const [c_uchar; 32],
+    _value_out: *mut [c_uchar; 32],
+) -> c_uchar {
+    todo!()
+}
+
+// Storage setters
+
+/// Submit a transaction which was included in the given block. The transaction is RPL encoded.
+/// This will update the storage to include the transaction, the diff it generated, and other state metadata (see storage details).
+/// The return value is 0 on success. Non-zero return values will correspond to different errors that may occur (exact errors TBD).
+#[no_mangle]
+pub extern "C" fn submit_transaction(
+    _block_hash: *const [c_uchar; 32],
+    _block_height: *const uintmax_t,
+    _transaction: *const c_uchar,
+    _transaction_len: *const c_uint,
+    _tx_position: *const c_ushort,
+) -> c_uchar {
+    todo!()
+}

--- a/engine-standalone/src/main.rs
+++ b/engine-standalone/src/main.rs
@@ -1,0 +1,9 @@
+mod ffi;
+mod trace;
+
+#[cfg(test)]
+mod tests;
+
+fn main() {
+    println!("Hello, World!");
+}

--- a/engine-standalone/src/tests/mocks/mod.rs
+++ b/engine-standalone/src/tests/mocks/mod.rs
@@ -1,0 +1,2 @@
+pub mod promise;
+pub mod storage;

--- a/engine-standalone/src/tests/mocks/promise.rs
+++ b/engine-standalone/src/tests/mocks/promise.rs
@@ -1,0 +1,76 @@
+use aurora_engine_sdk::promise::PromiseHandler;
+use aurora_engine_sdk::promise::PromiseId;
+use aurora_engine_types::parameters::{PromiseBatchAction, PromiseCreateArgs};
+use aurora_engine_types::types::PromiseResult;
+use std::collections::HashMap;
+
+pub enum PromiseArgs {
+    Create(PromiseCreateArgs),
+    #[allow(dead_code)]
+    Callback {
+        base: PromiseId,
+        callback: PromiseCreateArgs,
+    },
+    Batch(PromiseBatchAction),
+}
+
+/// Doesn't actually schedule any promises, only tracks what promises should be scheduled
+#[derive(Default)]
+pub struct PromiseTracker {
+    internal_index: u64,
+    pub promise_results: Vec<PromiseResult>,
+    pub scheduled_promises: HashMap<u64, PromiseArgs>,
+    pub returned_promise: Option<PromiseId>,
+}
+
+impl PromiseTracker {
+    fn take_id(&mut self) -> u64 {
+        let id = self.internal_index;
+        self.internal_index += 1;
+        id
+    }
+}
+
+impl PromiseHandler for PromiseTracker {
+    fn promise_results_count(&self) -> u64 {
+        self.promise_results.len() as u64
+    }
+
+    fn promise_result(&self, index: u64) -> Option<PromiseResult> {
+        self.promise_results.get(index as usize).cloned()
+    }
+
+    fn promise_create_call(&mut self, args: &PromiseCreateArgs) -> PromiseId {
+        let id = self.take_id();
+        self.scheduled_promises
+            .insert(id, PromiseArgs::Create(args.clone()));
+        PromiseId::new(id)
+    }
+
+    fn promise_attach_callback(
+        &mut self,
+        base: PromiseId,
+        callback: &aurora_engine_types::parameters::PromiseCreateArgs,
+    ) -> aurora_engine_sdk::promise::PromiseId {
+        let id = self.take_id();
+        self.scheduled_promises.insert(
+            id,
+            PromiseArgs::Callback {
+                base,
+                callback: callback.clone(),
+            },
+        );
+        PromiseId::new(id)
+    }
+
+    fn promise_create_batch(&mut self, args: &PromiseBatchAction) -> PromiseId {
+        let id = self.take_id();
+        self.scheduled_promises
+            .insert(id, PromiseArgs::Batch(args.clone()));
+        PromiseId::new(id)
+    }
+
+    fn promise_return(&mut self, promise: PromiseId) {
+        self.returned_promise = Some(promise);
+    }
+}

--- a/engine-standalone/src/tests/mocks/storage.rs
+++ b/engine-standalone/src/tests/mocks/storage.rs
@@ -1,0 +1,78 @@
+use aurora_engine_sdk::io::{StorageIntermediate, IO};
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+pub struct Value(Vec<u8>);
+
+impl StorageIntermediate for Value {
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    fn copy_to_slice(&self, buffer: &mut [u8]) {
+        buffer.copy_from_slice(&self.0)
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct Storage {
+    input: Vec<u8>,
+    output: Vec<u8>,
+    // TODO: write a real storage backend
+    kv_store: HashMap<Vec<u8>, Vec<u8>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct StoragePointer<'a>(pub &'a RwLock<Storage>);
+
+impl<'a> IO for StoragePointer<'a> {
+    type StorageValue = Value;
+
+    fn read_input(&self) -> Self::StorageValue {
+        Value(self.0.read().unwrap().input.clone())
+    }
+
+    fn return_output(&mut self, value: &[u8]) {
+        let mut storage = self.0.write().unwrap();
+        storage.output = value.to_vec();
+    }
+
+    fn read_storage(&self, key: &[u8]) -> Option<Self::StorageValue> {
+        self.0
+            .read()
+            .unwrap()
+            .kv_store
+            .get(key)
+            .map(|v| Value(v.clone()))
+    }
+
+    fn storage_has_key(&self, key: &[u8]) -> bool {
+        self.0.read().unwrap().kv_store.contains_key(key)
+    }
+
+    fn write_storage(&mut self, key: &[u8], value: &[u8]) -> Option<Self::StorageValue> {
+        let key = key.to_vec();
+        let value = value.to_vec();
+        let mut storage = self.0.write().unwrap();
+        storage.kv_store.insert(key, value).map(Value)
+    }
+
+    fn write_storage_direct(
+        &mut self,
+        key: &[u8],
+        value: Self::StorageValue,
+    ) -> Option<Self::StorageValue> {
+        let key = key.to_vec();
+        let mut storage = self.0.write().unwrap();
+        storage.kv_store.insert(key, value.0).map(Value)
+    }
+
+    fn remove_storage(&mut self, key: &[u8]) -> Option<Self::StorageValue> {
+        let mut storage = self.0.write().unwrap();
+        storage.kv_store.remove(key).map(Value)
+    }
+}

--- a/engine-standalone/src/tests/mod.rs
+++ b/engine-standalone/src/tests/mod.rs
@@ -1,0 +1,2 @@
+pub mod mocks;
+pub mod sanity;

--- a/engine-standalone/src/tests/sanity.rs
+++ b/engine-standalone/src/tests/sanity.rs
@@ -1,0 +1,82 @@
+use crate::tests::mocks::{promise, storage};
+use aurora_engine::engine;
+use aurora_engine_types::types::Wei;
+use aurora_engine_types::{account_id::AccountId, Address, U256};
+use std::sync::RwLock;
+
+#[test]
+fn test_deploy_code() {
+    let chain_id: [u8; 32] = {
+        let value = U256::from(1313161554);
+        let mut buf = [0u8; 32];
+        value.to_big_endian(&mut buf);
+        buf
+    };
+    let owner_id: AccountId = "aurora".parse().unwrap();
+    let state = engine::EngineState {
+        chain_id,
+        owner_id: owner_id.clone(),
+        bridge_prover_id: "mr_the_prover".parse().unwrap(),
+        upgrade_delay_blocks: 0,
+    };
+    let origin = Address([0u8; 20]);
+    let storage = RwLock::new(storage::Storage::default());
+    let io = storage::StoragePointer(&storage);
+    let env = aurora_engine_sdk::env::Fixed {
+        signer_account_id: owner_id.clone(),
+        current_account_id: owner_id.clone(),
+        predecessor_account_id: owner_id.clone(),
+        block_height: 0,
+        block_timestamp: aurora_engine_sdk::env::Timestamp::new(0),
+        attached_deposit: 0,
+    };
+    let mut handler = promise::PromiseTracker::default();
+    let mut engine = engine::Engine::new_with_state(state, origin, owner_id, io, &env);
+    let code_to_deploy = vec![1, 2, 3, 4, 5, 6];
+    let result = engine.deploy_code(
+        origin,
+        Wei::zero(),
+        evm_deploy(&code_to_deploy),
+        u64::MAX,
+        Vec::new(),
+        &mut handler,
+    );
+
+    // no promises are scheduled
+    assert!(handler.scheduled_promises.is_empty());
+
+    // execution was successful
+    let contract_address = match result.unwrap().status {
+        aurora_engine::parameters::TransactionStatus::Succeed(bytes) => Address::from_slice(&bytes),
+        other => panic!("Unexpected status: {:?}", other),
+    };
+
+    // state is updated
+    assert_eq!(engine::get_balance(&io, &origin), Wei::zero());
+    assert_eq!(engine::get_balance(&io, &contract_address), Wei::zero());
+    assert_eq!(engine::get_nonce(&io, &origin), U256::one());
+    assert_eq!(engine::get_nonce(&io, &contract_address), U256::one());
+    assert_eq!(engine::get_generation(&io, &contract_address), 1);
+    assert_eq!(engine::get_code(&io, &contract_address), code_to_deploy);
+}
+
+fn evm_deploy(code: &[u8]) -> Vec<u8> {
+    let len = code.len();
+    if len > u16::MAX as usize {
+        panic!("Cannot deploy a contract with that many bytes!");
+    }
+    let len = len as u16;
+    // This bit of EVM byte code essentially says:
+    // "If msg.value > 0 revert; otherwise return `len` amount of bytes that come after me
+    // in the code." By prepending this to `code` we create a valid EVM program which
+    // returns `code`, which is exactly what we want.
+    let init_code = format!(
+        "608060405234801561001057600080fd5b5061{}806100206000396000f300",
+        hex::encode(len.to_be_bytes())
+    );
+    hex::decode(init_code)
+        .unwrap()
+        .into_iter()
+        .chain(code.iter().copied())
+        .collect()
+}

--- a/engine-standalone/src/trace.rs
+++ b/engine-standalone/src/trace.rs
@@ -1,0 +1,278 @@
+use aurora_engine_types::types::EthGas;
+use aurora_engine_types::BTreeMap;
+use evm_core::Opcode;
+use std::ops::Index;
+
+/// Depth of a log.
+#[derive(Debug, Clone, Copy)]
+pub struct Depth(u32);
+
+impl Depth {
+    /// Performs the conversion into a u32.
+    pub fn into_u32(self) -> u32 {
+        self.0
+    }
+}
+
+/// A trace log memory.
+#[derive(Debug, Clone)]
+pub struct LogMemory(Vec<[u8; 32]>);
+
+impl LogMemory {
+    /// Returns the number of elements in the memory buffer.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns true if there are no elements in the memory buffer.
+    #[allow(dead_code)]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Performs the conversion into a raw buffer.
+    pub fn into_raw(self) -> Vec<[u8; 32]> {
+        self.0
+    }
+}
+
+/// The stack of the log.
+#[derive(Debug, Clone)]
+pub struct LogStack(Vec<[u8; 32]>);
+
+impl LogStack {
+    /// Returns the number of elements in the stack buffer.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns true if there are no elements in the stack buffer.
+    #[allow(dead_code)]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Performs the conversion into a vector.
+    pub fn into_raw(self) -> Vec<[u8; 32]> {
+        self.0
+    }
+}
+
+/// A trace log program counter.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+pub struct ProgramCounter(pub u32);
+
+impl ProgramCounter {
+    /// Performs the conversion into a u32.
+    pub fn into_u32(self) -> u32 {
+        self.0
+    }
+}
+
+/// A storage key for the `LogStorage`.
+#[derive(Debug, Clone)]
+pub struct LogStorageKey([u8; 32]);
+
+impl LogStorageKey {
+    /// Performs the conversion into a 32 byte word.
+    pub fn into_raw(self) -> [u8; 32] {
+        self.0
+    }
+}
+
+/// A storage value for the `LogStorage`.
+#[derive(Debug, Clone)]
+pub struct LogStorageValue([u8; 32]);
+
+impl LogStorageValue {
+    /// Performs the conversion into a 32 byte word.
+    pub fn into_raw(self) -> [u8; 32] {
+        self.0
+    }
+}
+
+/// A map for `LogStorageKeys` to `LogStorageValue`s.
+#[derive(Debug, Clone)]
+pub struct LogStorage(BTreeMap<LogStorageKey, LogStorageValue>);
+
+impl IntoIterator for LogStorage {
+    type Item = (LogStorageKey, LogStorageValue);
+    type IntoIter = std::collections::btree_map::IntoIter<LogStorageKey, LogStorageValue>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+/// The trace log of an execution on the EVM.
+#[derive(Debug, Clone)]
+pub struct TraceLog {
+    /// The depth of the log.
+    depth: Depth,
+    /// Any errors that may have occurred during execution.
+    error: Option<String>,
+    /// Gas used to execute the transaction.
+    gas: EthGas,
+    /// Gas cost for the transaction.
+    gas_cost: EthGas,
+    /// The bounded memory.
+    memory: LogMemory,
+    /// The opcode as a byte.
+    opcode: Opcode,
+    /// The current program counter of the transaction.
+    program_counter: ProgramCounter,
+    /// The local stack.
+    stack: LogStack,
+    /// The storage of the execution.
+    storage: LogStorage,
+}
+
+impl TraceLog {
+    /// Returns the depth of the log.
+    pub fn depth(&self) -> Depth {
+        self.depth
+    }
+
+    /// Returns a potential error, if any in the execution.
+    pub fn error(&self) -> Option<&String> {
+        self.error.as_ref()
+    }
+
+    /// Returns the gas consumed.
+    pub fn gas(&self) -> EthGas {
+        self.gas
+    }
+
+    /// Returns the gas cost of the execution.
+    pub fn gas_cost(&self) -> EthGas {
+        self.gas_cost
+    }
+
+    /// Returns the memory of the log.
+    pub fn memory(&self) -> &LogMemory {
+        &self.memory
+    }
+
+    /// Returns the opcode for the execution of the log.
+    pub fn opcode(&self) -> Opcode {
+        self.opcode
+    }
+
+    /// Returns the program counter for the log.
+    pub fn program_counter(&self) -> ProgramCounter {
+        self.program_counter
+    }
+
+    /// Returns the stack of the log.
+    pub fn stack(&self) -> &LogStack {
+        &self.stack
+    }
+
+    /// Returns the storage of the log.
+    pub fn storage(&self) -> &LogStorage {
+        &self.storage
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Logs(Vec<TraceLog>);
+
+impl Logs {
+    /// Returns the number of logs.
+    #[allow(dead_code)]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns true if there are no logs.
+    #[allow(dead_code)]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl Index<usize> for Logs {
+    type Output = TraceLog;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl IntoIterator for Logs {
+    type Item = TraceLog;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+#[derive(Debug)]
+pub struct TransactionTrace {
+    /// The total gas cost of the transaction.
+    gas: EthGas,
+    /// The result of the operation.
+    result: String,
+    /// The collection of traces.
+    logs: Logs,
+}
+
+impl TransactionTrace {
+    /// Constructs a new TransactionTrace with a given gas, return, and logs.
+    #[allow(dead_code)]
+    pub fn new(gas: EthGas, result: String, logs: Logs) -> TransactionTrace {
+        Self { gas, result, logs }
+    }
+
+    /// Returns the EthGas associated with this transaction as a reference.
+    pub fn gas(&self) -> EthGas {
+        self.gas
+    }
+
+    /// Returns the return as a str reference.
+    pub fn result(&self) -> &str {
+        self.result.as_str()
+    }
+
+    /// Returns a reference to the logs.
+    pub fn logs(&self) -> &Logs {
+        &self.logs
+    }
+}
+
+/// Consumes a `TransactionTrace` and provides the ability to step through each
+/// execution of the transaction.
+#[derive(Debug)]
+pub struct StepTransactionTrace {
+    /// The under-laying transaction trace.
+    inner: TransactionTrace,
+    /// The current step.
+    step: usize,
+}
+
+impl StepTransactionTrace {
+    /// Constructs a new `TraceStepper` with a given `TransactionTrace`.
+    #[allow(dead_code)]
+    pub fn new(transaction_trace: TransactionTrace) -> Self {
+        Self {
+            inner: transaction_trace,
+            step: 0,
+        }
+    }
+
+    /// Steps through the logs, one at a time until it reaches the end of the
+    /// execution.
+    ///
+    /// Returns a reference to a `TraceLog` if there is log, else it will return
+    /// `None`.
+    #[allow(dead_code)]
+    pub fn step(&mut self) -> Option<&TraceLog> {
+        if self.step > self.inner.logs.len() {
+            None
+        } else {
+            self.step += 1;
+            Some(&self.inner.logs[self.step])
+        }
+    }
+}

--- a/engine-types/src/parameters.rs
+++ b/engine-types/src/parameters.rs
@@ -11,7 +11,7 @@ pub enum PromiseArgs {
 }
 
 #[must_use]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, BorshSerialize, BorshDeserialize, Clone)]
 pub struct PromiseCreateArgs {
     pub target_account_id: AccountId,
     pub method: String,
@@ -27,7 +27,7 @@ pub struct PromiseWithCallbackArgs {
     pub callback: PromiseCreateArgs,
 }
 
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, BorshSerialize, BorshDeserialize, Clone)]
 pub enum PromiseAction {
     Transfer {
         amount: u128,
@@ -44,7 +44,7 @@ pub enum PromiseAction {
 }
 
 #[must_use]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, BorshSerialize, BorshDeserialize, Clone)]
 pub struct PromiseBatchAction {
     pub target_account_id: AccountId,
     pub actions: Vec<PromiseAction>,

--- a/engine-types/src/types.rs
+++ b/engine-types/src/types.rs
@@ -239,6 +239,7 @@ pub struct StorageBalanceBounds {
 }
 
 /// promise results structure
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PromiseResult {
     NotReady,
     Successful(Vec<u8>),


### PR DESCRIPTION
The purpose of this change is to add geth-like [`debug_traceTransaction`] logic to [Sputnik EVM] (rust-blockchain/evm). On top of that the ability to run a standalone engine that is able to keep in sync with the network EVM.

Why this is an important change is that it is absolutely necessary for this logic for both Block Scout and Etherscan's upcoming block explorer for Aurora.
