### PR TITLE
Remove some sdk usage from core logic

### DIFF
--- a/engine/src/admin_controlled.rs
+++ b/engine/src/admin_controlled.rs
@@ -1,15 +1,8 @@
-use crate::prelude::sdk;
-
 pub type PausedMask = u8;
 
 pub const ERR_PAUSED: &str = "ERR_PAUSED";
 
 pub trait AdminControlled {
-    /// Returns true if the current account is owner
-    fn is_owner(&self) -> bool {
-        sdk::current_account_id() == sdk::predecessor_account_id()
-    }
-
     /// Return the current mask representing all paused events.
     fn get_paused(&self) -> PausedMask;
 
@@ -19,12 +12,12 @@ pub trait AdminControlled {
     fn set_paused(&mut self, paused: PausedMask);
 
     /// Return if the contract is paused for the current flag and user
-    fn is_paused(&self, flag: PausedMask) -> bool {
-        (self.get_paused() & flag) != 0 && !self.is_owner()
+    fn is_paused(&self, flag: PausedMask, is_owner: bool) -> bool {
+        (self.get_paused() & flag) != 0 && !is_owner
     }
 
     /// Asserts the passed paused flag is not set. Panics with "ERR_PAUSED" if the flag is set.
-    fn assert_not_paused(&self, flag: PausedMask) {
-        assert!(!self.is_paused(flag), "{}", ERR_PAUSED);
+    fn assert_not_paused(&self, flag: PausedMask, is_owner: bool) {
+        assert!(!self.is_paused(flag, is_owner), "{}", ERR_PAUSED);
     }
 }

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -74,11 +74,13 @@ mod contract {
     use crate::parameters::{
         DeployErc20TokenArgs, FunctionCallArgs, GetErc20FromNep141CallArgs, GetStorageAtArgs,
         InitCallArgs, IsUsedProofCallArgs, NEP141FtOnTransferArgs, NewCallArgs,
-        PauseEthConnectorCallArgs, SetContractDataCallArgs, SubmitResult, TransactionStatus,
+        PauseEthConnectorCallArgs, ResolveTransferCallArgs, SetContractDataCallArgs,
+        StorageDepositCallArgs, StorageWithdrawCallArgs, SubmitResult, TransactionStatus,
         TransferCallCallArgs, ViewCallArgs,
     };
     use aurora_engine_sdk::io::{StorageIntermediate, IO};
     use aurora_engine_sdk::near_runtime::Runtime;
+    use aurora_engine_types::account_id::AccountId;
 
     use crate::json::parse_json;
     use crate::prelude::parameters::RefundCallArgs;
@@ -198,7 +200,8 @@ mod contract {
     pub extern "C" fn deploy_code() {
         let io = Runtime;
         let input = io.read_input().to_vec();
-        let mut engine = Engine::new(predecessor_address(), io).sdk_unwrap();
+        let current_account_id = AccountId::try_from(sdk::current_account_id()).sdk_unwrap();
+        let mut engine = Engine::new(predecessor_address(), current_account_id, io).sdk_unwrap();
         Engine::deploy_code_with_input(&mut engine, input)
             .map(|res| res.try_to_vec().sdk_expect("ERR_SERIALIZE"))
             .sdk_process();
@@ -210,7 +213,8 @@ mod contract {
     pub extern "C" fn call() {
         let io = Runtime;
         let args: FunctionCallArgs = io.read_input_borsh().sdk_unwrap();
-        let mut engine = Engine::new(predecessor_address(), io).sdk_unwrap();
+        let current_account_id = AccountId::try_from(sdk::current_account_id()).sdk_unwrap();
+        let mut engine = Engine::new(predecessor_address(), current_account_id, io).sdk_unwrap();
         Engine::call_with_args(&mut engine, args)
             .map(|res| res.try_to_vec().sdk_expect("ERR_SERIALIZE"))
             .sdk_process();
@@ -262,7 +266,8 @@ mod contract {
         }
 
         // Figure out what kind of a transaction this is, and execute it:
-        let mut engine = Engine::new_with_state(state, sender, io);
+        let current_account_id = AccountId::try_from(sdk::current_account_id()).sdk_unwrap();
+        let mut engine = Engine::new_with_state(state, sender, current_account_id, io);
         let prepaid_amount = match engine.charge_gas(&sender, &transaction) {
             Ok(gas_result) => gas_result,
             Err(GasPaymentError::OutOfFund) => {
@@ -334,7 +339,9 @@ mod contract {
 
         Engine::check_nonce(&io, &meta_call_args.sender, &meta_call_args.nonce).sdk_unwrap();
 
-        let mut engine = Engine::new_with_state(state, meta_call_args.sender, io);
+        let current_account_id = AccountId::try_from(sdk::current_account_id()).sdk_unwrap();
+        let mut engine =
+            Engine::new_with_state(state, meta_call_args.sender, current_account_id, io);
         let result = engine.call(
             meta_call_args.sender,
             meta_call_args.contract_address,
@@ -353,7 +360,8 @@ mod contract {
         let io = Runtime;
         let relayer_address = io.read_input_arr20().sdk_unwrap();
 
-        let mut engine = Engine::new(predecessor_address(), io).sdk_unwrap();
+        let current_account_id = AccountId::try_from(sdk::current_account_id()).sdk_unwrap();
+        let mut engine = Engine::new(predecessor_address(), current_account_id, io).sdk_unwrap();
         engine.register_relayer(
             sdk::predecessor_account_id().as_slice(),
             Address(relayer_address),
@@ -368,7 +376,10 @@ mod contract {
     #[no_mangle]
     pub extern "C" fn ft_on_transfer() {
         let io = Runtime;
-        let mut engine = Engine::new(predecessor_address(), io).sdk_unwrap();
+        let current_account_id = AccountId::try_from(sdk::current_account_id()).sdk_unwrap();
+        let predecessor_account_id =
+            AccountId::try_from(sdk::predecessor_account_id()).sdk_unwrap();
+        let mut engine = Engine::new(predecessor_address(), current_account_id, io).sdk_unwrap();
 
         let args: NEP141FtOnTransferArgs = parse_json(io.read_input().to_vec().as_slice())
             .sdk_unwrap()
@@ -376,10 +387,10 @@ mod contract {
             .sdk_unwrap();
 
         if sdk::predecessor_account_id() == sdk::current_account_id() {
-            let engine = Engine::new(predecessor_address(), io).sdk_unwrap();
             EthConnectorContract::get_instance(io).ft_on_transfer(&engine, &args);
         } else {
-            engine.receive_erc20_tokens(&args);
+            let signer_account_id = AccountId::try_from(sdk::signer_account_id()).sdk_unwrap();
+            engine.receive_erc20_tokens(&predecessor_account_id, &signer_account_id, &args);
         }
     }
 
@@ -390,7 +401,8 @@ mod contract {
         // Id of the NEP141 token in Near
         let args: DeployErc20TokenArgs = io.read_input_borsh().sdk_unwrap();
 
-        let mut engine = Engine::new(predecessor_address(), io).sdk_unwrap();
+        let current_account_id = AccountId::try_from(sdk::current_account_id()).sdk_unwrap();
+        let mut engine = Engine::new(predecessor_address(), current_account_id, io).sdk_unwrap();
 
         let erc20_admin_address = current_address();
         #[cfg(feature = "error_refund")]
@@ -436,6 +448,7 @@ mod contract {
             sdk::panic_utf8(b"ERR_PROMISE_COUNT");
         }
 
+        let current_account_id = AccountId::try_from(sdk::current_account_id()).sdk_unwrap();
         // Exit call failed; need to refund tokens
         if let PromiseResult::Failed = sdk::promise_result(0) {
             let args: RefundCallArgs = io.read_input_borsh().sdk_unwrap();
@@ -443,7 +456,8 @@ mod contract {
                 // ERC-20 exit; re-mint burned tokens
                 Some(erc20_address) => {
                     let erc20_admin_address = current_address();
-                    let mut engine = Engine::new(erc20_admin_address, io).sdk_unwrap();
+                    let mut engine =
+                        Engine::new(erc20_admin_address, current_account_id, io).sdk_unwrap();
                     let erc20_address = Address(erc20_address);
                     let refund_address = Address(args.recipient_address);
                     let amount = U256::from_big_endian(&args.amount);
@@ -468,7 +482,7 @@ mod contract {
                 // ETH exit; transfer ETH back from precompile address
                 None => {
                     let exit_address = aurora_engine_precompiles::native::ExitToNear::ADDRESS;
-                    let mut engine = Engine::new(exit_address, io).sdk_unwrap();
+                    let mut engine = Engine::new(exit_address, current_account_id, io).sdk_unwrap();
                     let refund_address = Address(args.recipient_address);
                     let amount = Wei::new(U256::from_big_endian(&args.amount));
                     engine
@@ -496,7 +510,9 @@ mod contract {
     pub extern "C" fn view() {
         let mut io = Runtime;
         let args: ViewCallArgs = io.read_input_borsh().sdk_unwrap();
-        let engine = Engine::new(Address::from_slice(&args.sender), io).sdk_unwrap();
+        let current_account_id = AccountId::try_from(sdk::current_account_id()).sdk_unwrap();
+        let engine =
+            Engine::new(Address::from_slice(&args.sender), current_account_id, io).sdk_unwrap();
         let result = Engine::view_with_args(&engine, args).sdk_unwrap();
         io.return_output(&result.try_to_vec().sdk_expect("ERR_SERIALIZE"));
     }
@@ -588,8 +604,10 @@ mod contract {
 
         let io = Runtime;
         let args: InitCallArgs = io.read_input_borsh().sdk_unwrap();
+        let current_account_id = sdk::current_account_id();
+        let owner_id = AccountId::try_from(current_account_id).sdk_unwrap();
 
-        EthConnectorContract::init_contract(io, args);
+        EthConnectorContract::init_contract(io, owner_id, args);
     }
 
     #[no_mangle]
@@ -606,8 +624,16 @@ mod contract {
     #[no_mangle]
     pub extern "C" fn withdraw() {
         let mut io = Runtime;
+        sdk::assert_one_yocto();
         let args = io.read_input_borsh().sdk_unwrap();
-        let result = EthConnectorContract::get_instance(io).withdraw_eth_from_near(args);
+        let current_account_id = AccountId::try_from(sdk::current_account_id()).sdk_unwrap();
+        let predecessor_account_id =
+            AccountId::try_from(sdk::predecessor_account_id()).sdk_unwrap();
+        let result = EthConnectorContract::get_instance(io).withdraw_eth_from_near(
+            &current_account_id,
+            &predecessor_account_id,
+            args,
+        );
         let result_bytes = result.try_to_vec().sdk_expect("ERR_SERIALIZE");
         io.return_output(&result_bytes);
     }
@@ -616,7 +642,14 @@ mod contract {
     pub extern "C" fn deposit() {
         let io = Runtime;
         let raw_proof = io.read_input().to_vec();
-        EthConnectorContract::get_instance(io).deposit(raw_proof)
+        let current_account_id = AccountId::try_from(sdk::current_account_id()).sdk_unwrap();
+        let predecessor_account_id =
+            AccountId::try_from(sdk::predecessor_account_id()).sdk_unwrap();
+        EthConnectorContract::get_instance(io).deposit(
+            raw_proof,
+            current_account_id,
+            predecessor_account_id,
+        )
     }
 
     #[no_mangle]
@@ -624,7 +657,14 @@ mod contract {
         sdk::assert_private_call();
         let io = Runtime;
         let data = io.read_input_borsh().sdk_unwrap();
-        EthConnectorContract::get_instance(io).finish_deposit(data);
+        let current_account_id = AccountId::try_from(sdk::current_account_id()).sdk_unwrap();
+        let predecessor_account_id =
+            AccountId::try_from(sdk::predecessor_account_id()).sdk_unwrap();
+        EthConnectorContract::get_instance(io).finish_deposit(
+            predecessor_account_id,
+            current_account_id,
+            data,
+        );
     }
 
     #[no_mangle]
@@ -670,13 +710,24 @@ mod contract {
     #[no_mangle]
     pub extern "C" fn ft_transfer() {
         let io = Runtime;
-        EthConnectorContract::get_instance(io).ft_transfer();
+        sdk::assert_one_yocto();
+        let predecessor_account_id =
+            AccountId::try_from(sdk::predecessor_account_id()).sdk_unwrap();
+        EthConnectorContract::get_instance(io).ft_transfer(&predecessor_account_id);
     }
 
     #[no_mangle]
     pub extern "C" fn ft_resolve_transfer() {
         let io = Runtime;
-        EthConnectorContract::get_instance(io).ft_resolve_transfer();
+
+        sdk::assert_private_call();
+        // Check if previous promise succeeded
+        assert_eq!(sdk::promise_results_count(), 1);
+
+        let args: ResolveTransferCallArgs = io.read_input().to_value().sdk_unwrap();
+        let promise_result = sdk::promise_result(0);
+
+        EthConnectorContract::get_instance(io).ft_resolve_transfer(args, promise_result);
     }
 
     #[no_mangle]
@@ -689,19 +740,39 @@ mod contract {
         let args = TransferCallCallArgs::from(
             parse_json(&io.read_input().to_vec()).expect_utf8(ERR_FAILED_PARSE.as_bytes()),
         );
-        EthConnectorContract::get_instance(io).ft_transfer_call(args);
+        let current_account_id = AccountId::try_from(sdk::current_account_id()).sdk_unwrap();
+        let predecessor_account_id =
+            AccountId::try_from(sdk::predecessor_account_id()).sdk_unwrap();
+        EthConnectorContract::get_instance(io).ft_transfer_call(
+            predecessor_account_id,
+            current_account_id,
+            args,
+        );
     }
 
     #[no_mangle]
     pub extern "C" fn storage_deposit() {
         let io = Runtime;
-        EthConnectorContract::get_instance(io).storage_deposit()
+        let args = StorageDepositCallArgs::from(parse_json(&io.read_input().to_vec()).sdk_unwrap());
+        let predecessor_account_id =
+            AccountId::try_from(sdk::predecessor_account_id()).sdk_unwrap();
+        let amount = sdk::attached_deposit();
+        EthConnectorContract::get_instance(io).storage_deposit(
+            &predecessor_account_id,
+            amount,
+            args,
+        )
     }
 
     #[no_mangle]
     pub extern "C" fn storage_withdraw() {
         let io = Runtime;
-        EthConnectorContract::get_instance(io).storage_withdraw()
+        sdk::assert_one_yocto();
+        let args =
+            StorageWithdrawCallArgs::from(parse_json(&io.read_input().to_vec()).sdk_unwrap());
+        let predecessor_account_id =
+            AccountId::try_from(sdk::predecessor_account_id()).sdk_unwrap();
+        EthConnectorContract::get_instance(io).storage_withdraw(&predecessor_account_id, args)
     }
 
     #[no_mangle]
@@ -790,7 +861,8 @@ mod contract {
         let address = Address(args.0);
         let nonce = U256::from(args.1);
         let balance = U256::from(args.2);
-        let mut engine = Engine::new(address, io).sdk_unwrap();
+        let current_account_id = AccountId::try_from(sdk::current_account_id()).sdk_unwrap();
+        let mut engine = Engine::new(address, current_account_id, io).sdk_unwrap();
         let state_change = evm::backend::Apply::Modify {
             address,
             basic: evm::backend::Basic { balance, nonce },


### PR DESCRIPTION
The purpose of this PR is to move as much sdk usage related to blockchain environment (e.g. `current_account_id`, `predecessor_account_id`) from core logic, pushing it to `lib` (which is the boundary of our application). This will make it much easier to factor out blockchain context related lookups into a trait (as part of the standalone engine project).

Note: this PR is built on top of #342 and #346 those should be reviewed and merged first. To see only the new changes from this PR only look at the diff from the last commit.