### PR TITLE
Borsh deserialized value field for call args

### DIFF
--- a/engine-tests/src/test_utils/self_destruct.rs
+++ b/engine-tests/src/test_utils/self_destruct.rs
@@ -1,5 +1,5 @@
 use crate::prelude::{
-    parameters::CallArgs, parameters::FunctionCallArgs, transaction::legacy::TransactionLegacy,
+    parameters::CallArgs, parameters::FunctionCallArgsV2, transaction::legacy::TransactionLegacy,
     Address, WeiU256, U256,
 };
 use crate::test_utils::{self, solidity, AuroraRunner, Signer};
@@ -173,7 +173,7 @@ impl SelfDestruct {
             .encode_input(&[])
             .unwrap();
 
-        let input = CallArgs::New(FunctionCallArgs {
+        let input = CallArgs::V2(FunctionCallArgsV2 {
             contract: self.contract.address.into(),
             value: WeiU256::default(),
             input: data.to_vec(),

--- a/engine-tests/src/test_utils/self_destruct.rs
+++ b/engine-tests/src/test_utils/self_destruct.rs
@@ -1,5 +1,6 @@
 use crate::prelude::{
-    parameters::FunctionCallArgs, transaction::legacy::TransactionLegacy, Address, WeiU256, U256,
+    parameters::CallArgs, parameters::FunctionCallArgs, transaction::legacy::TransactionLegacy,
+    Address, WeiU256, U256,
 };
 use crate::test_utils::{self, solidity, AuroraRunner, Signer};
 use borsh::BorshSerialize;
@@ -172,11 +173,11 @@ impl SelfDestruct {
             .encode_input(&[])
             .unwrap();
 
-        let input = FunctionCallArgs {
+        let input = CallArgs::New(FunctionCallArgs {
             contract: self.contract.address.into(),
             value: WeiU256::default(),
             input: data.to_vec(),
-        }
+        })
         .try_to_vec()
         .unwrap();
 

--- a/engine-tests/src/test_utils/self_destruct.rs
+++ b/engine-tests/src/test_utils/self_destruct.rs
@@ -1,5 +1,5 @@
 use crate::prelude::{
-    parameters::FunctionCallArgs, transaction::legacy::TransactionLegacy, Address, U256, WeiU256,
+    parameters::FunctionCallArgs, transaction::legacy::TransactionLegacy, Address, WeiU256, U256,
 };
 use crate::test_utils::{self, solidity, AuroraRunner, Signer};
 use borsh::BorshSerialize;

--- a/engine-tests/src/test_utils/self_destruct.rs
+++ b/engine-tests/src/test_utils/self_destruct.rs
@@ -1,5 +1,5 @@
 use crate::prelude::{
-    parameters::FunctionCallArgs, transaction::legacy::TransactionLegacy, Address, U256,
+    parameters::FunctionCallArgs, transaction::legacy::TransactionLegacy, Address, U256, WeiU256,
 };
 use crate::test_utils::{self, solidity, AuroraRunner, Signer};
 use borsh::BorshSerialize;
@@ -174,6 +174,7 @@ impl SelfDestruct {
 
         let input = FunctionCallArgs {
             contract: self.contract.address.into(),
+            value: WeiU256::default(),
             input: data.to_vec(),
         }
         .try_to_vec()

--- a/engine-tests/src/tests/erc20_connector.rs
+++ b/engine-tests/src/tests/erc20_connector.rs
@@ -1,4 +1,4 @@
-use crate::prelude::{Address, Balance, RawAddress, TryInto, Wei, U256, WeiU256};
+use crate::prelude::{Address, Balance, RawAddress, TryInto, Wei, WeiU256, U256};
 use crate::test_utils;
 use crate::test_utils::{create_eth_transaction, origin, AuroraRunner};
 use aurora_engine::parameters::{FunctionCallArgs, SubmitResult};
@@ -95,7 +95,13 @@ impl test_utils::AuroraRunner {
         self.make_call(
             "call",
             origin,
-            (FunctionCallArgs { contract, value: WeiU256::default(), input }).try_to_vec().unwrap(),
+            (FunctionCallArgs {
+                contract,
+                value: WeiU256::default(),
+                input,
+            })
+            .try_to_vec()
+            .unwrap(),
         )
     }
 
@@ -380,7 +386,7 @@ fn test_transfer_erc20_token() {
 // Note: `AuroraRunner` is not suitable for these tests because
 // it does not execute promises; but `near-sdk-sim` does.
 mod sim_tests {
-    use crate::prelude::{types::Wei, Address, U256, WeiU256};
+    use crate::prelude::{types::Wei, Address, WeiU256, U256};
     use crate::test_utils;
     use crate::test_utils::erc20::{ERC20Constructor, ERC20};
     use crate::test_utils::exit_precompile::TesterConstructor;

--- a/engine-tests/src/tests/erc20_connector.rs
+++ b/engine-tests/src/tests/erc20_connector.rs
@@ -1,4 +1,4 @@
-use crate::prelude::{Address, Balance, RawAddress, TryInto, Wei, U256};
+use crate::prelude::{Address, Balance, RawAddress, TryInto, Wei, U256, WeiU256};
 use crate::test_utils;
 use crate::test_utils::{create_eth_transaction, origin, AuroraRunner};
 use aurora_engine::parameters::{FunctionCallArgs, SubmitResult};
@@ -95,7 +95,7 @@ impl test_utils::AuroraRunner {
         self.make_call(
             "call",
             origin,
-            (FunctionCallArgs { contract, input }).try_to_vec().unwrap(),
+            (FunctionCallArgs { contract, value: WeiU256::default(), input }).try_to_vec().unwrap(),
         )
     }
 
@@ -380,7 +380,7 @@ fn test_transfer_erc20_token() {
 // Note: `AuroraRunner` is not suitable for these tests because
 // it does not execute promises; but `near-sdk-sim` does.
 mod sim_tests {
-    use crate::prelude::{types::Wei, Address, U256};
+    use crate::prelude::{types::Wei, Address, U256, WeiU256};
     use crate::test_utils;
     use crate::test_utils::erc20::{ERC20Constructor, ERC20};
     use crate::test_utils::exit_precompile::TesterConstructor;
@@ -707,6 +707,7 @@ mod sim_tests {
         );
         let call_args = FunctionCallArgs {
             contract: erc20.0.address.0,
+            value: WeiU256::default(),
             input,
         };
         source
@@ -746,6 +747,7 @@ mod sim_tests {
         let mint_tx = erc20.mint(dest, amount.into(), 0.into());
         let call_args = FunctionCallArgs {
             contract: erc20.0.address.0,
+            value: WeiU256::default(),
             input: mint_tx.data,
         };
         aurora
@@ -776,6 +778,7 @@ mod sim_tests {
         let balance_tx = erc20.balance_of(address, 0.into());
         let call_args = FunctionCallArgs {
             contract: erc20.0.address.0,
+            value: WeiU256::default(),
             input: balance_tx.data,
         };
         let result = aurora.call("call", &call_args.try_to_vec().unwrap());

--- a/engine-tests/src/tests/erc20_connector.rs
+++ b/engine-tests/src/tests/erc20_connector.rs
@@ -1,7 +1,7 @@
 use crate::prelude::{Address, Balance, RawAddress, TryInto, Wei, WeiU256, U256};
 use crate::test_utils;
 use crate::test_utils::{create_eth_transaction, origin, AuroraRunner};
-use aurora_engine::parameters::{FunctionCallArgs, SubmitResult};
+use aurora_engine::parameters::{CallArgs, FunctionCallArgs, SubmitResult};
 use aurora_engine::transaction::legacy::LegacyEthSignedTransaction;
 use borsh::{BorshDeserialize, BorshSerialize};
 use ethabi::Token;
@@ -95,7 +95,7 @@ impl test_utils::AuroraRunner {
         self.make_call(
             "call",
             origin,
-            (FunctionCallArgs {
+            CallArgs::New(FunctionCallArgs {
                 contract,
                 value: WeiU256::default(),
                 input,
@@ -391,7 +391,7 @@ mod sim_tests {
     use crate::test_utils::erc20::{ERC20Constructor, ERC20};
     use crate::test_utils::exit_precompile::TesterConstructor;
     use crate::tests::state_migration::{deploy_evm, AuroraAccount};
-    use aurora_engine::parameters::{DeployErc20TokenArgs, FunctionCallArgs, SubmitResult};
+    use aurora_engine::parameters::{DeployErc20TokenArgs, CallArgs, FunctionCallArgs, SubmitResult};
     use borsh::BorshSerialize;
     use near_sdk_sim::UserAccount;
     use serde_json::json;
@@ -711,11 +711,11 @@ mod sim_tests {
                 ethabi::Token::Uint(amount.into()),
             ],
         );
-        let call_args = FunctionCallArgs {
+        let call_args = CallArgs::New(FunctionCallArgs {
             contract: erc20.0.address.0,
             value: WeiU256::default(),
             input,
-        };
+        });
         source
             .call(
                 aurora.contract.account_id(),
@@ -751,11 +751,11 @@ mod sim_tests {
             .assert_success();
 
         let mint_tx = erc20.mint(dest, amount.into(), 0.into());
-        let call_args = FunctionCallArgs {
+        let call_args = CallArgs::New(FunctionCallArgs {
             contract: erc20.0.address.0,
             value: WeiU256::default(),
             input: mint_tx.data,
-        };
+        });
         aurora
             .contract
             .call(
@@ -782,11 +782,11 @@ mod sim_tests {
 
     fn erc20_balance(erc20: &ERC20, address: Address, aurora: &AuroraAccount) -> U256 {
         let balance_tx = erc20.balance_of(address, 0.into());
-        let call_args = FunctionCallArgs {
+        let call_args = CallArgs::New(FunctionCallArgs {
             contract: erc20.0.address.0,
             value: WeiU256::default(),
             input: balance_tx.data,
-        };
+        });
         let result = aurora.call("call", &call_args.try_to_vec().unwrap());
         let submit_result: SubmitResult = result.unwrap_borsh();
         U256::from_big_endian(&test_utils::unwrap_success(submit_result))

--- a/engine-tests/src/tests/erc20_connector.rs
+++ b/engine-tests/src/tests/erc20_connector.rs
@@ -391,7 +391,9 @@ mod sim_tests {
     use crate::test_utils::erc20::{ERC20Constructor, ERC20};
     use crate::test_utils::exit_precompile::TesterConstructor;
     use crate::tests::state_migration::{deploy_evm, AuroraAccount};
-    use aurora_engine::parameters::{DeployErc20TokenArgs, CallArgs, FunctionCallArgs, SubmitResult};
+    use aurora_engine::parameters::{
+        CallArgs, DeployErc20TokenArgs, FunctionCallArgs, SubmitResult,
+    };
     use borsh::BorshSerialize;
     use near_sdk_sim::UserAccount;
     use serde_json::json;

--- a/engine-tests/src/tests/erc20_connector.rs
+++ b/engine-tests/src/tests/erc20_connector.rs
@@ -1,7 +1,7 @@
 use crate::prelude::{Address, Balance, RawAddress, TryInto, Wei, WeiU256, U256};
 use crate::test_utils;
 use crate::test_utils::{create_eth_transaction, origin, AuroraRunner};
-use aurora_engine::parameters::{CallArgs, FunctionCallArgs, SubmitResult};
+use aurora_engine::parameters::{CallArgs, FunctionCallArgsV2, SubmitResult};
 use aurora_engine::transaction::legacy::LegacyEthSignedTransaction;
 use borsh::{BorshDeserialize, BorshSerialize};
 use ethabi::Token;
@@ -95,7 +95,7 @@ impl test_utils::AuroraRunner {
         self.make_call(
             "call",
             origin,
-            CallArgs::New(FunctionCallArgs {
+            CallArgs::V2(FunctionCallArgsV2 {
                 contract,
                 value: WeiU256::default(),
                 input,
@@ -392,7 +392,7 @@ mod sim_tests {
     use crate::test_utils::exit_precompile::TesterConstructor;
     use crate::tests::state_migration::{deploy_evm, AuroraAccount};
     use aurora_engine::parameters::{
-        CallArgs, DeployErc20TokenArgs, FunctionCallArgs, SubmitResult,
+        CallArgs, DeployErc20TokenArgs, FunctionCallArgsV2, SubmitResult,
     };
     use borsh::BorshSerialize;
     use near_sdk_sim::UserAccount;
@@ -713,7 +713,7 @@ mod sim_tests {
                 ethabi::Token::Uint(amount.into()),
             ],
         );
-        let call_args = CallArgs::New(FunctionCallArgs {
+        let call_args = CallArgs::V2(FunctionCallArgsV2 {
             contract: erc20.0.address.0,
             value: WeiU256::default(),
             input,
@@ -753,7 +753,7 @@ mod sim_tests {
             .assert_success();
 
         let mint_tx = erc20.mint(dest, amount.into(), 0.into());
-        let call_args = CallArgs::New(FunctionCallArgs {
+        let call_args = CallArgs::V2(FunctionCallArgsV2 {
             contract: erc20.0.address.0,
             value: WeiU256::default(),
             input: mint_tx.data,
@@ -784,7 +784,7 @@ mod sim_tests {
 
     fn erc20_balance(erc20: &ERC20, address: Address, aurora: &AuroraAccount) -> U256 {
         let balance_tx = erc20.balance_of(address, 0.into());
-        let call_args = CallArgs::New(FunctionCallArgs {
+        let call_args = CallArgs::V2(FunctionCallArgsV2 {
             contract: erc20.0.address.0,
             value: WeiU256::default(),
             input: balance_tx.data,

--- a/engine-types/src/types.rs
+++ b/engine-types/src/types.rs
@@ -112,7 +112,7 @@ impl Add for Wei {
 /// Type casting from Wei compatible Borsh-encoded raw value into the Wei value, to attach an ETH balance to the transaction
 impl From<WeiU256> for Wei {
     fn from(value: WeiU256) -> Self {
-        Wei(value.into())
+        Wei(U256::from_big_endian(&value))
     }
 }
 

--- a/engine-types/src/types.rs
+++ b/engine-types/src/types.rs
@@ -8,6 +8,8 @@ pub type RawH256 = [u8; 32]; // Unformatted binary data of fixed length.
 pub type EthAddress = [u8; 20];
 pub type Gas = u64;
 pub type StorageUsage = u64;
+/// Wei compatible Borsh-encoded raw value to attach an ETH balance to the transaction
+pub type WeiU256 = [u8; 32];
 
 /// Selector to call mint function in ERC 20 contract
 ///
@@ -104,6 +106,13 @@ impl Add for Wei {
 
     fn add(self, other: Self) -> Self::Output {
         Self(self.0 + other.0)
+    }
+}
+
+/// Type casting from Wei compatible Borsh-encoded raw value into the Wei value, to attach an ETH balance to the transaction
+impl From<WeiU256> for Wei {
+    fn from(value: WeiU256) -> Self {
+        Wei(value.into())
     }
 }
 

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -1,6 +1,4 @@
-use crate::parameters::{
-    CallArgsType, NEP141FtOnTransferArgs, ResultLog, SubmitResult, ViewCallArgs,
-};
+use crate::parameters::{CallArgs, NEP141FtOnTransferArgs, ResultLog, SubmitResult, ViewCallArgs};
 use core::mem;
 use evm::backend::{Apply, ApplyBackend, Backend, Basic, Log};
 use evm::executor;
@@ -620,16 +618,16 @@ impl<I: IO + Copy + Default> Engine<I> {
     }
 
     /// Call the EVM contract with arguments (attached ETH balance, input, gas limit, etc.)
-    pub fn call_with_args(&mut self, args: CallArgsType) -> EngineResult<SubmitResult> {
+    pub fn call_with_args(&mut self, args: CallArgs) -> EngineResult<SubmitResult> {
         let origin = self.origin();
         match args {
-            CallArgsType::New(call_args) => {
+            CallArgs::New(call_args) => {
                 let contract = Address(call_args.contract);
                 let value = call_args.value.into();
                 let input = call_args.input;
                 self.call(origin, contract, value, input, u64::MAX, Vec::new())
             }
-            CallArgsType::Legacy(call_args) => {
+            CallArgs::Legacy(call_args) => {
                 let contract = Address(call_args.contract);
                 let value = Wei::zero();
                 let input = call_args.input;

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -484,7 +484,7 @@ impl<'env, I: IO + Copy, E: Env> Engine<'env, I, E> {
     ) -> EngineResult<SubmitResult> {
         let origin = self.origin();
         match args {
-            CallArgs::New(call_args) => {
+            CallArgs::V2(call_args) => {
                 let contract = Address(call_args.contract);
                 let value = call_args.value.into();
                 let input = call_args.input;
@@ -498,7 +498,7 @@ impl<'env, I: IO + Copy, E: Env> Engine<'env, I, E> {
                     handler,
                 )
             }
-            CallArgs::Legacy(call_args) => {
+            CallArgs::V1(call_args) => {
                 let contract = Address(call_args.contract);
                 let value = Wei::zero();
                 let input = call_args.input;

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -470,7 +470,7 @@ impl<'env, I: IO + Copy, E: Env> Engine<'env, I, E> {
         Ok(SubmitResult::new(status, used_gas, logs))
     }
 
-    /// Call the EVM contract with arguments (attached ETH balance, input, gas limit, etc.)
+    /// Call the EVM contract with arguments
     pub fn call_with_args(&mut self, args: CallArgs) -> EngineResult<SubmitResult> {
         let origin = self.origin();
         match args {

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -72,7 +72,7 @@ mod contract {
     #[cfg(feature = "evm_bully")]
     use crate::parameters::{BeginBlockArgs, BeginChainArgs};
     use crate::parameters::{
-        CallArgsType, DeployErc20TokenArgs, FunctionCallArgs, FunctionCallArgsLegacy,
+        CallArgs, DeployErc20TokenArgs, FunctionCallArgs, FunctionCallArgsLegacy,
         GetErc20FromNep141CallArgs, GetStorageAtArgs, InitCallArgs, IsUsedProofCallArgs,
         NEP141FtOnTransferArgs, NewCallArgs, PauseEthConnectorCallArgs, SetContractDataCallArgs,
         SubmitResult, TransactionStatus, TransferCallCallArgs, ViewCallArgs,
@@ -209,11 +209,12 @@ mod contract {
     #[no_mangle]
     pub extern "C" fn call() {
         let io = Runtime;
-        let args: Option<CallArgsType> = {
-            if let Ok(value) = io.read_input_borsh::<FunctionCallArgs>() {
-                Some(CallArgsType::New(value))
-            } else if let Ok(value) = io.read_input_borsh::<FunctionCallArgsLegacy>() {
-                Some(CallArgsType::Legacy(value))
+        let bytes = io.read_input();
+        let args: Option<CallArgs> = {
+            if let Ok(value) = bytes.to_value::<FunctionCallArgs>() {
+                Some(CallArgs::New(value))
+            } else if let Ok(value) = bytes.to_value::<FunctionCallArgsLegacy>() {
+                Some(CallArgs::Legacy(value))
             } else {
                 None
             }

--- a/engine/src/parameters.rs
+++ b/engine/src/parameters.rs
@@ -4,7 +4,7 @@ use crate::json::{JsonError, JsonValue};
 use crate::prelude::account_id::AccountId;
 use crate::prelude::{
     format, Balance, BorshDeserialize, BorshSerialize, EthAddress, RawAddress, RawH256, RawU256,
-    SdkUnwrap, String, ToString, TryFrom, Vec,
+    SdkUnwrap, String, ToString, TryFrom, Vec, WeiU256,
 };
 use crate::proof::Proof;
 use evm::backend::Log;
@@ -130,11 +130,31 @@ impl SubmitResult {
     }
 }
 
-/// Borsh-encoded parameters for the `call` function.
+/// Borsh-encoded parameters for the engine `call` function.
 #[derive(BorshSerialize, BorshDeserialize)]
 pub struct FunctionCallArgs {
     pub contract: RawAddress,
+    /// Wei compatible Borsh-encoded value field to attach an ETH balance to the transaction
+    pub value: WeiU256,
     pub input: Vec<u8>,
+}
+
+/// Legacy Borsh-encoded parameters for the engine `call` function, to provide backward type compatibility
+#[derive(BorshSerialize, BorshDeserialize)]
+pub struct FunctionCallArgsLegacy {
+    pub contract: RawAddress,
+    pub input: Vec<u8>,
+}
+
+/// Deserialized values from bytes to current or legacy Borsh-encoded parameters
+/// for passing to the engine `call` function, and to provide backward type compatibility
+#[derive(BorshSerialize, BorshDeserialize)]
+pub enum CallArgsType
+where
+    Self: Sized,
+{
+    New(FunctionCallArgs),
+    Legacy(FunctionCallArgsLegacy)
 }
 
 /// Borsh-encoded parameters for the `view` function.

--- a/engine/src/parameters.rs
+++ b/engine/src/parameters.rs
@@ -503,7 +503,7 @@ mod tests {
 
     #[test]
     fn test_call_args_deserialize() {
-        let new_input = FunctionCallArgs{
+        let new_input = FunctionCallArgs {
             contract: [0u8; 20],
             value: WeiU256::default(),
             input: Vec::new(),
@@ -529,7 +529,7 @@ mod tests {
 
         // Parsing bytes in an old input format - raw data structure (not wrapped into call args enum) with legacy arguments,
         // made for backward compatibility.
- 
+
         // Using old input format (not wrapped into call args enum) - raw data structure with legacy arguments.
         let input_bytes = legacy_input.try_to_vec().unwrap();
         let parsed_data = CallArgs::deserialize(&input_bytes);

--- a/engine/src/parameters.rs
+++ b/engine/src/parameters.rs
@@ -149,12 +149,9 @@ pub struct FunctionCallArgsLegacy {
 /// Deserialized values from bytes to current or legacy Borsh-encoded parameters
 /// for passing to the engine `call` function, and to provide backward type compatibility
 #[derive(BorshSerialize, BorshDeserialize)]
-pub enum CallArgsType
-where
-    Self: Sized,
-{
+pub enum CallArgs {
     New(FunctionCallArgs),
-    Legacy(FunctionCallArgsLegacy)
+    Legacy(FunctionCallArgsLegacy),
 }
 
 /// Borsh-encoded parameters for the `view` function.

--- a/engine/src/parameters.rs
+++ b/engine/src/parameters.rs
@@ -154,6 +154,18 @@ pub enum CallArgs {
     Legacy(FunctionCallArgsLegacy),
 }
 
+impl CallArgs {
+    pub fn deserialize(bytes: &[u8]) -> Option<Self> {
+        if let Ok(value) = FunctionCallArgs::try_from_slice(bytes) {
+            Some(Self::New(value))
+        } else if let Ok(value) = FunctionCallArgsLegacy::try_from_slice(bytes) {
+            Some(Self::Legacy(value))
+        } else {
+            None
+        }
+    }
+}
+
 /// Borsh-encoded parameters for the `view` function.
 #[derive(BorshSerialize, BorshDeserialize, Debug, Eq, PartialEq)]
 pub struct ViewCallArgs {


### PR DESCRIPTION
**Implementation to address [issue of attaching ETH balance to the transation](https://github.com/aurora-is-near/aurora-engine/issues/309)**

PR fixes #309

**Implementation for deserialized values from bytes to current or legacy Borsh-encoded parameters for passing to the engine `call` function, and to provide backward type compatibility:**
- Handling in a generic way current and legacy Borsh-encoded parameters returned by the `io.read_input_borsh()` function call, with fallback to previous `FunctionCallArgsLegacy` data structure, to provide backward type compatibility.
- Type matching from `CallArgsType` into current and legacy Borsh-encoded parameters, for passing to the `call` function, and to provide backward type compatibility.

**Changes in this feature branch:**
- Preserve legacy `FunctionCallArgsLegacy` structure, to provide backward type compatibility.
- Introducing of `CallArgsType` enum for matching type between current or legacy Borsh-encoded parameters, and to provide backward type compatibility with previous data structure.
- Introducing of `Wei` compatible portable implementation of Borsh-encoded type for value field for the new `FunctionCallArgs` structure, to attach an ETH balance to the transaction and to support passing `value` field to the engine `call` function.
- Type casting from `Wei` compatible Borsh-encoded raw value into the `Wei` value, to attach an ETH balance to the transaction.
_(This is the only correct way to overcome Rust's orphaning rules, by implementing local type, compatible with `Wei` and `BorshSerialize`/`BorshDeserialize` macro derived methods, 'cause both of them placed in external crates)._
- Change correspondingly the engine `call()` method on the EVM contract and `Engine::call_with_args()` function.
- Fix tests and test utils.
