### PR TITLE
Workspace (near-blake2) and toolchain update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,6 @@ dependencies = [
  "aurora-engine-sdk",
  "aurora-engine-types",
  "base64 0.13.0",
- "blake2 0.9.1 (git+https://github.com/near/near-blake2.git)",
  "borsh 0.8.2",
  "byte-slice-cast",
  "ethabi",
@@ -131,6 +130,7 @@ dependencies = [
  "hex",
  "libsecp256k1",
  "logos",
+ "near-blake2",
  "num",
  "primitive-types 0.10.1",
  "rand 0.7.3",
@@ -152,7 +152,6 @@ dependencies = [
  "aurora-engine-sdk",
  "aurora-engine-types",
  "base64 0.13.0",
- "blake2 0.9.1 (git+https://github.com/near/near-blake2.git)",
  "borsh 0.8.2",
  "byte-slice-cast",
  "ethabi",
@@ -161,6 +160,7 @@ dependencies = [
  "hex",
  "libsecp256k1",
  "logos",
+ "near-blake2",
  "num",
  "primitive-types 0.10.1",
  "rand 0.7.3",
@@ -320,16 +320,6 @@ name = "blake2"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a5720225ef5daecf08657f23791354e1685a8c91a4c60c7f3d3b2892f978f4"
-dependencies = [
- "crypto-mac 0.8.0",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "blake2"
-version = "0.9.1"
-source = "git+https://github.com/near/near-blake2.git#736ff607cc8160af87ffa697c14ebef85050138f"
 dependencies = [
  "crypto-mac 0.8.0",
  "digest 0.9.0",
@@ -2148,6 +2138,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "near-blake2"
+version = "0.9.1"
+source = "git+https://github.com/near/near-blake2.git?rev=cebb7df79608a7058017940830d37c37d55d21fe#cebb7df79608a7058017940830d37c37d55d21fe"
+dependencies = [
+ "crypto-mac 0.8.0",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
 name = "near-chain-configs"
 version = "0.1.0"
 source = "git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9#8a377fda0b4ce319385c463f1ae46e4b0b29dcd9"
@@ -2169,7 +2169,7 @@ version = "0.1.0"
 source = "git+https://github.com/near/nearcore.git?rev=0c9ad79a18e431f843e6123cf4559f9c2c5dd228#0c9ad79a18e431f843e6123cf4559f9c2c5dd228"
 dependencies = [
  "arrayref",
- "blake2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blake2",
  "borsh 0.9.1",
  "bs58",
  "c2-chacha",
@@ -2195,7 +2195,7 @@ version = "0.1.0"
 source = "git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9#8a377fda0b4ce319385c463f1ae46e4b0b29dcd9"
 dependencies = [
  "arrayref",
- "blake2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blake2",
  "borsh 0.8.2",
  "bs58",
  "c2-chacha",
@@ -2221,7 +2221,7 @@ version = "0.1.0"
 source = "git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90#8a37d39629885a41dde58b60642bcf1e99407d90"
 dependencies = [
  "arrayref",
- "blake2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blake2",
  "borsh 0.8.2",
  "bs58",
  "c2-chacha",

--- a/engine-precompiles/Cargo.toml
+++ b/engine-precompiles/Cargo.toml
@@ -16,7 +16,7 @@ autobenches = false
 aurora-engine-types = { path = "../engine-types", default-features = false }
 aurora-engine-sdk = { path = "../engine-sdk", default-features = false }
 base64 = { version = "0.13.0", default-features = false, features = ["alloc"] }
-blake2 = { git = "https://github.com/near/near-blake2.git", version = "0.9.1", default-features = false }
+near-blake2 = { git = "https://github.com/near/near-blake2.git", rev = "cebb7df79608a7058017940830d37c37d55d21fe", version = "0.9.1", default-features = false }
 borsh = { version = "0.8.2", default-features = false }
 bn = { package = "aurora-bn", git = "https://github.com/aurora-is-near/aurora-bn.git", default-features = false }
 evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", default-features = false }

--- a/engine-precompiles/src/blake2.rs
+++ b/engine-precompiles/src/blake2.rs
@@ -88,7 +88,7 @@ impl Precompile for Blake2F {
         }
         let finished = input[212] != 0;
 
-        let output = blake2::blake2b_f(rounds, h, m, t, finished).to_vec();
+        let output = near_blake2::blake2b_f(rounds, h, m, t, finished).to_vec();
         Ok(PrecompileOutput::without_logs(cost, output).into())
     }
 }

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ aurora-engine-types = { path = "../engine-types", default-features = false }
 aurora-engine-sdk = { path = "../engine-sdk", default-features = false }
 aurora-engine-precompiles = { path = "../engine-precompiles", default-features = false }
 base64 = { version = "0.13.0", default-features = false, features = ["alloc"] }
-blake2 = { git = "https://github.com/near/near-blake2.git", version = "0.9.1", default-features = false }
+near-blake2 = { git = "https://github.com/near/near-blake2.git", rev = "cebb7df79608a7058017940830d37c37d55d21fe", version = "0.9.1", default-features = false }
 borsh = { version = "0.8.2", default-features = false }
 bn = { package = "aurora-bn", git = "https://github.com/aurora-is-near/aurora-bn.git", default-features = false }
 evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", default-features = false }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2021-08-01"
+channel = "nightly-2021-11-12"
 components = []
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
**Changes in this feature branch:**

- Fix usage of call to `near_blake2` in `enigne-precompiles` code;
- Fixed workspace dependencies only (fix on exact revision in toml for `near-blake2` crate);
- Updated local workspace (minimal, near-blake2 crate, without update for external dependencies);
- Use of current toolchain (nightly from November 12)
These issues was prevent successful project workspace update and was prevent successful project codebase build as well, 
thus was fixed to make compilation and building the whole project in one `wasm32` executable possible on current nightly toolchain (which tested and works fine in local environment, and should work well in CI environment too).
