### PR TITLE
Factor out NEAR promise host functions into a trait (#353)

### DIFF
--- a/engine-sdk/src/promise.rs
+++ b/engine-sdk/src/promise.rs
@@ -1,0 +1,36 @@
+use aurora_engine_types::parameters::{
+    PromiseBatchAction, PromiseCreateArgs, PromiseWithCallbackArgs,
+};
+use aurora_engine_types::types::PromiseResult;
+
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+pub struct PromiseId(u64);
+
+impl PromiseId {
+    pub(crate) fn new(id: u64) -> Self {
+        Self(id)
+    }
+
+    pub(crate) fn raw(self) -> u64 {
+        self.0
+    }
+}
+
+pub trait PromiseHandler {
+    fn promise_results_count(&self) -> u64;
+    fn promise_result(&self, index: u64) -> Option<PromiseResult>;
+
+    fn promise_create_call(&mut self, args: &PromiseCreateArgs) -> PromiseId;
+    fn promise_attach_callback(
+        &mut self,
+        base: PromiseId,
+        callback: &PromiseCreateArgs,
+    ) -> PromiseId;
+    fn promise_create_batch(&mut self, args: &PromiseBatchAction) -> PromiseId;
+    fn promise_return(&mut self, promise: PromiseId);
+
+    fn promise_crate_with_callback(&mut self, args: &PromiseWithCallbackArgs) -> PromiseId {
+        let base = self.promise_create_call(&args.base);
+        self.promise_attach_callback(base, &args.callback)
+    }
+}

--- a/engine-types/src/parameters.rs
+++ b/engine-types/src/parameters.rs
@@ -3,12 +3,14 @@ use crate::types::*;
 use crate::*;
 use borsh::{BorshDeserialize, BorshSerialize};
 
+#[must_use]
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 pub enum PromiseArgs {
     Create(PromiseCreateArgs),
     Callback(PromiseWithCallbackArgs),
 }
 
+#[must_use]
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 pub struct PromiseCreateArgs {
     pub target_account_id: AccountId,
@@ -18,10 +20,34 @@ pub struct PromiseCreateArgs {
     pub attached_gas: u64,
 }
 
+#[must_use]
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 pub struct PromiseWithCallbackArgs {
     pub base: PromiseCreateArgs,
     pub callback: PromiseCreateArgs,
+}
+
+#[derive(Debug, BorshSerialize, BorshDeserialize)]
+pub enum PromiseAction {
+    Transfer {
+        amount: u128,
+    },
+    DeployConotract {
+        code: Vec<u8>,
+    },
+    FunctionCall {
+        name: String,
+        args: Vec<u8>,
+        attached_yocto: u128,
+        gas: u64,
+    },
+}
+
+#[must_use]
+#[derive(Debug, BorshSerialize, BorshDeserialize)]
+pub struct PromiseBatchAction {
+    pub target_account_id: AccountId,
+    pub actions: Vec<PromiseAction>,
 }
 
 /// withdraw NEAR eth-connector call args


### PR DESCRIPTION
Another step towards removing dependency on NEAR host functions from the engine (allowing it to compile as a standalone binary).

The main changes here are:

1. Connector and FungibleToken never schedule promises, they always return data representing the promise. This data is used to actually schedule the promise at the end of the transaction in `lib.rs`. The reason for this change is to prevent pushing a `PromiseHandler` all the way down into those modules.
2. The engine now needs a `PomiseHandler` to execute EVM transactions. This is because the exit precompiles cause NEAR promises to be scheduled.
3. `storage_unregister` (part of the storage management standard) was not previously exposed as a public method, now it is (and it follows the same patterns as other methods in terms of passing promise data up to `lib.rs`).