### PR TITLE
Gate all NEAR host functions behind the contract feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,6 @@ dependencies = [
  "rlp",
  "serde",
  "serde_json",
- "sha2 0.9.5",
  "sha3 0.9.1",
  "wee_alloc",
 ]
@@ -180,6 +179,7 @@ version = "1.0.0"
 dependencies = [
  "aurora-engine-types",
  "borsh 0.8.2",
+ "sha2 0.9.5",
  "sha3 0.9.1",
 ]
 

--- a/engine-sdk/Cargo.toml
+++ b/engine-sdk/Cargo.toml
@@ -16,6 +16,7 @@ autobenches = false
 aurora-engine-types = { path = "../engine-types", default-features = false }
 borsh = { version = "0.8.2", default-features = false }
 sha3 = { version = "0.9.1", default-features = false }
+sha2 = { version = "0.9.3", default-features = false }
 
 [features]
 contract = []

--- a/engine-sdk/src/promise.rs
+++ b/engine-sdk/src/promise.rs
@@ -7,10 +7,13 @@ use aurora_engine_types::types::PromiseResult;
 pub struct PromiseId(u64);
 
 impl PromiseId {
+    // TODO: can remove this annotation when there is a standalone implementation that uses PromiseId.
+    #[allow(dead_code)]
     pub(crate) fn new(id: u64) -> Self {
         Self(id)
     }
 
+    #[allow(dead_code)]
     pub(crate) fn raw(self) -> u64 {
         self.0
     }

--- a/engine-sdk/src/types.rs
+++ b/engine-sdk/src/types.rs
@@ -1,5 +1,5 @@
+#[cfg(feature = "contract")]
 use crate::io::IO;
-use crate::panic_utf8;
 use crate::prelude::{Address, H256};
 
 #[cfg(not(feature = "contract"))]
@@ -22,86 +22,96 @@ pub fn keccak(data: &[u8]) -> H256 {
     H256::from_slice(Keccak256::digest(data).as_slice())
 }
 
-#[allow(dead_code)]
 pub fn near_account_to_evm_address(addr: &[u8]) -> Address {
     Address::from_slice(&keccak(addr)[12..])
 }
 
+#[cfg(feature = "contract")]
 pub trait ExpectUtf8<T> {
     fn expect_utf8(self, message: &[u8]) -> T;
 }
 
+#[cfg(feature = "contract")]
 impl<T> ExpectUtf8<T> for Option<T> {
     fn expect_utf8(self, message: &[u8]) -> T {
         match self {
             Some(t) => t,
-            None => panic_utf8(message),
+            None => crate::panic_utf8(message),
         }
     }
 }
 
+#[cfg(feature = "contract")]
 impl<T, E> ExpectUtf8<T> for core::result::Result<T, E> {
     fn expect_utf8(self, message: &[u8]) -> T {
         match self {
             Ok(t) => t,
-            Err(_) => panic_utf8(message),
+            Err(_) => crate::panic_utf8(message),
         }
     }
 }
 
+#[cfg(feature = "contract")]
 pub trait SdkExpect<T> {
     fn sdk_expect(self, msg: &str) -> T;
 }
 
+#[cfg(feature = "contract")]
 impl<T> SdkExpect<T> for Option<T> {
     fn sdk_expect(self, msg: &str) -> T {
         match self {
             Some(t) => t,
-            None => panic_utf8(msg.as_ref()),
+            None => crate::panic_utf8(msg.as_ref()),
         }
     }
 }
 
+#[cfg(feature = "contract")]
 impl<T, E> SdkExpect<T> for core::result::Result<T, E> {
     fn sdk_expect(self, msg: &str) -> T {
         match self {
             Ok(t) => t,
-            Err(_) => panic_utf8(msg.as_ref()),
+            Err(_) => crate::panic_utf8(msg.as_ref()),
         }
     }
 }
 
+#[cfg(feature = "contract")]
 pub trait SdkUnwrap<T> {
     fn sdk_unwrap(self) -> T;
 }
 
+#[cfg(feature = "contract")]
 impl<T> SdkUnwrap<T> for Option<T> {
     fn sdk_unwrap(self) -> T {
         match self {
             Some(t) => t,
-            None => panic_utf8("ERR_UNWRAP".as_bytes()),
+            None => crate::panic_utf8("ERR_UNWRAP".as_bytes()),
         }
     }
 }
 
+#[cfg(feature = "contract")]
 impl<T, E: AsRef<[u8]>> SdkUnwrap<T> for core::result::Result<T, E> {
     fn sdk_unwrap(self) -> T {
         match self {
             Ok(t) => t,
-            Err(e) => panic_utf8(e.as_ref()),
+            Err(e) => crate::panic_utf8(e.as_ref()),
         }
     }
 }
 
+#[cfg(feature = "contract")]
 pub trait SdkProcess<T> {
     fn sdk_process(self);
 }
 
+#[cfg(feature = "contract")]
 impl<T: AsRef<[u8]>, E: AsRef<[u8]>> SdkProcess<T> for Result<T, E> {
     fn sdk_process(self) {
         match self {
             Ok(r) => crate::near_runtime::Runtime.return_output(r.as_ref()),
-            Err(e) => panic_utf8(e.as_ref()),
+            Err(e) => crate::panic_utf8(e.as_ref()),
         }
     }
 }

--- a/engine-tests/Cargo.toml
+++ b/engine-tests/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 autobenches = false
 
 [dependencies]
-aurora-engine = { path = "../engine", default-features = false, features=["sha2"] }
+aurora-engine = { path = "../engine", default-features = false }
 aurora-engine-types = { path = "../engine-types", default-features = false }
 aurora-engine-sdk = { path = "../engine-sdk", default-features = false }
 aurora-engine-precompiles = { path = "../engine-precompiles", default-features = false }

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -30,7 +30,6 @@ num = { version = "0.4.0", default-features = false, features = ["alloc"] }
 primitive-types = { version = "0.10.0", default-features = false, features = ["rlp"] }
 ripemd160 = { version = "0.9.1", default-features = false }
 rlp = { version = "0.5.0", default-features = false }
-sha2 = { version = "0.9.3", default-features = false, optional = true }
 sha3 = { version = "0.9.1", default-features = false }
 wee_alloc = { version = "0.4.5", default-features = false }
 logos = { version = "0.12", default-features = false, features = ["export_derive"] }
@@ -45,7 +44,7 @@ serde_json = "1"
 rand = "0.7.3"
 
 [features]
-default = ["sha2", "std"]
+default = ["std"]
 std = ["borsh/std", "evm/std", "primitive-types/std", "rlp/std", "sha3/std", "ethabi/std", "logos/std", "bn/std", "aurora-engine-types/std"]
 contract = ["aurora-engine-sdk/contract", "aurora-engine-precompiles/contract"]
 evm_bully = []

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -794,15 +794,6 @@ pub fn compute_block_hash(chain_id: [u8; 32], block_height: u64, account_id: &[u
     data.extend_from_slice(account_id);
     data.extend_from_slice(&block_height.to_be_bytes());
 
-    #[cfg(not(feature = "contract"))]
-    {
-        use sha2::Digest;
-
-        let output = sha2::Sha256::digest(&data);
-        H256(output.into())
-    }
-
-    #[cfg(feature = "contract")]
     sdk::sha256(&data)
 }
 

--- a/etc/state-migration-test/Cargo.lock
+++ b/etc/state-migration-test/Cargo.lock
@@ -58,7 +58,6 @@ dependencies = [
  "ripemd160",
  "rjson",
  "rlp",
- "sha2",
  "sha3 0.9.1",
  "wee_alloc",
 ]
@@ -96,6 +95,7 @@ version = "1.0.0"
 dependencies = [
  "aurora-engine-types",
  "borsh",
+ "sha2",
  "sha3 0.9.1",
 ]
 

--- a/etc/state-migration-test/Cargo.toml
+++ b/etc/state-migration-test/Cargo.toml
@@ -38,6 +38,6 @@ rpath = false
 
 [dependencies]
 borsh = { version = "0.8.2", default-features = false }
-aurora-engine = { path = "../../engine", default-features = false, features = ["sha2"] }
-aurora-engine-sdk = { path = "../../engine-sdk", default-features = false }
+aurora-engine = { path = "../../engine", default-features = false }
+aurora-engine-sdk = { path = "../../engine-sdk", default-features = false, features = ["contract"] }
 aurora-engine-types = { path = "../../engine-types", default-features = false }


### PR DESCRIPTION
This is the final step in removing the NEAR host functions from core engine code. All host function access is now gated behind the contract feature flag and the `engine` crate compiles with and without this feature. The standalone engine will not use this feature, allowing it to compile as a standalone binary without any NEAR host functions.

Note: I did not implement any logging for the standalone case. This will need to be done in a future PR.

Note: This PR depends on #355 that one should be reviewed and merged first. To review this PR only look at the last commit.