### PR TITLE
Fix:  Meta parsing imports

### DIFF
--- a/engine-tests/Cargo.toml
+++ b/engine-tests/Cargo.toml
@@ -44,7 +44,7 @@ git2 = "0.13"
 
 [features]
 meta-call = ["aurora-engine/meta-call"]
-mainnet-test = ["aurora-engine/mainnet-test"]
-testnet-test = ["aurora-engine/testnet-test"]
-betanet-test = ["aurora-engine/betanet-test"]
+mainnet-test = ["aurora-engine/mainnet-test", "meta-call"]
+testnet-test = ["aurora-engine/testnet-test", "meta-call"]
+betanet-test = ["aurora-engine/betanet-test", "meta-call"]
 error_refund = ["aurora-engine/error_refund", "aurora-engine-precompiles/error_refund"]

--- a/engine-tests/src/prelude.rs
+++ b/engine-tests/src/prelude.rs
@@ -1,9 +1,14 @@
-pub use aurora_engine::connector;
-pub use aurora_engine::fungible_token;
-pub use aurora_engine::parameters;
-pub use aurora_engine::transaction;
-pub use aurora_engine_sdk as sdk;
-pub use aurora_engine_types::parameters::*;
-pub use aurora_engine_types::storage;
-pub use aurora_engine_types::types::*;
-pub use aurora_engine_types::*;
+mod v0 {
+    pub use aurora_engine::connector;
+    pub use aurora_engine::fungible_token;
+    pub use aurora_engine::meta_parsing;
+    pub use aurora_engine::parameters;
+    pub use aurora_engine::transaction;
+    pub use aurora_engine_sdk as sdk;
+    pub use aurora_engine_types::parameters::*;
+    pub use aurora_engine_types::storage;
+    pub use aurora_engine_types::types::*;
+    pub use aurora_engine_types::*;
+    pub use borsh::{BorshDeserialize, BorshSerialize};
+}
+pub use v0::*;

--- a/engine-tests/src/tests/meta_parsing.rs
+++ b/engine-tests/src/tests/meta_parsing.rs
@@ -1,10 +1,8 @@
 use {
-    crate::meta_parsing::{near_erc712_domain, parse_meta_call, prepare_meta_call_args},
-    crate::prelude::keccak,
-    crate::prelude::{u256_to_arr, InternalMetaCallArgs, Wei},
-    crate::prelude::{Address, U256},
-    aurora_engine::parameters::MetaCallArgs,
-    borsh::BorshSerialize,
+    crate::prelude::meta_parsing::{near_erc712_domain, parse_meta_call, prepare_meta_call_args},
+    crate::prelude::parameters::MetaCallArgs,
+    crate::prelude::sdk::keccak,
+    crate::prelude::{u256_to_arr, Address, BorshSerialize, InternalMetaCallArgs, Wei, U256},
     near_crypto::{InMemorySigner, KeyType, PublicKey, Signature, Signer},
 };
 


### PR DESCRIPTION
When running `check --all-targets --all-features`, a compilation error occurs:

```
error[E0432]: unresolved imports `crate::meta_parsing`, `crate::prelude::keccak`
 --> engine-tests/src/tests/meta_parsing.rs:2:12
  |
2 |     crate::meta_parsing::{near_erc712_domain, parse_meta_call, prepare_meta_call_args},
  |            ^^^^^^^^^^^^
  |            |
  |            unresolved import
  |            help: a similar path exists: `aurora_engine::meta_parsing`
3 |     crate::prelude::keccak,
  |     ^^^^^^^^^^^^^^^^^^^^^^ no `keccak` in `prelude`
  ```
  This simply fixes that issue so that the correct imports are being used.