### PR TITLE
Refactor(engine): Move submit logic into engine module

### DIFF
--- a/engine/src/transaction/mod.rs
+++ b/engine/src/transaction/mod.rs
@@ -136,6 +136,7 @@ impl NormalizedEthTransaction {
     }
 }
 
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum ParseTransactionError {
     UnknownTransactionType,
     // Per the EIP-2718 spec 0xff is a reserved value


### PR DESCRIPTION
Moves the `submit` logic so that we will be able to call it directly from the standalone engine (useful for debug trace).