### PR TITLE
Feat(standalone): Structures and logic for keeping storage in sync with the blockchain

### DIFF
--- a/engine-standalone-storage/src/lib.rs
+++ b/engine-standalone-storage/src/lib.rs
@@ -12,6 +12,8 @@ pub mod error;
 pub mod json_snapshot;
 mod promise;
 pub mod relayer_db;
+/// Functions for receiving new blocks and transactions to keep the storage up to date.
+pub mod sync;
 
 pub use diff::Diff;
 pub use error::Error;

--- a/engine-standalone-storage/src/sync/mod.rs
+++ b/engine-standalone-storage/src/sync/mod.rs
@@ -1,0 +1,232 @@
+use aurora_engine::{connector, engine, parameters};
+use aurora_engine_sdk::env::{self, Env};
+use aurora_engine_types::TryFrom;
+use borsh::BorshDeserialize;
+
+pub mod types;
+
+use types::{Message, TransactionKind};
+
+const AURORA_ACCOUNT_ID: &str = "aurora";
+
+pub fn consume_message(storage: &mut crate::Storage, message: Message) -> Result<(), error::Error> {
+    match message {
+        Message::Block(block_message) => {
+            let block_hash = block_message.hash;
+            let block_height = block_message.height;
+            let block_metadata = block_message.metadata;
+            storage
+                .set_block_data(block_hash, block_height, block_metadata)
+                .map_err(crate::Error::Rocksdb)?;
+            Ok(())
+        }
+
+        Message::Transaction(transaction_message) => {
+            // Failed transactions have no impact on the state of our database.
+            if !transaction_message.succeeded {
+                return Ok(());
+            }
+
+            let signer_account_id = transaction_message.signer;
+            let predecessor_account_id = transaction_message.caller;
+            let relayer_address = aurora_engine_sdk::types::near_account_to_evm_address(
+                predecessor_account_id.as_bytes(),
+            );
+            let transaction_position = transaction_message.position;
+            let near_tx_hash = transaction_message.near_tx_hash;
+            let block_hash = transaction_message.block_hash;
+            let block_height = storage.get_block_height_by_hash(block_hash)?;
+            let block_metadata = storage.get_block_metadata(block_hash)?;
+            let current_account_id = AURORA_ACCOUNT_ID.parse().unwrap();
+            let env = env::Fixed {
+                signer_account_id,
+                current_account_id,
+                predecessor_account_id,
+                block_height,
+                block_timestamp: block_metadata.timestamp,
+                attached_deposit: transaction_message.attached_near,
+                random_seed: block_metadata.random_seed,
+            };
+            let io =
+                storage.access_engine_storage_at_position(block_height, transaction_position, &[]);
+
+            let tx_hash = match transaction_message.transaction {
+                TransactionKind::Submit(tx) => {
+                    // Only promises possible from `submit` are exit precompiles and we cannot act on those promises
+                    let mut handler = crate::promise::Noop;
+                    let engine_state = engine::get_state(&io)?;
+                    let transaction_bytes: Vec<u8> = tx.into();
+                    let tx_hash = aurora_engine_sdk::keccak(&transaction_bytes);
+
+                    let _result = engine::submit(
+                        io,
+                        &env,
+                        &transaction_bytes,
+                        engine_state,
+                        env.current_account_id(),
+                        relayer_address,
+                        &mut handler,
+                    )?;
+
+                    tx_hash
+                }
+
+                TransactionKind::Call(args) => {
+                    // Only promises possible from `call` are exit precompiles and we cannot act on those promises
+                    let mut handler = crate::promise::Noop;
+                    let mut engine =
+                        engine::Engine::new(relayer_address, env.current_account_id(), io, &env)?;
+
+                    let _result = engine.call_with_args(args, &mut handler)?;
+
+                    near_tx_hash
+                }
+
+                TransactionKind::Deploy(input) => {
+                    // Only promises possible from `deploy` are exit precompiles and we cannot act on those promises
+                    let mut handler = crate::promise::Noop;
+                    let mut engine =
+                        engine::Engine::new(relayer_address, env.current_account_id(), io, &env)?;
+
+                    let _result = engine.deploy_code_with_input(input, &mut handler)?;
+
+                    near_tx_hash
+                }
+
+                TransactionKind::DeployErc20(args) => {
+                    // No promises can be created by `deploy_erc20_token`
+                    let mut handler = crate::promise::Noop;
+                    let _result = engine::deploy_erc20_token(args, io, &env, &mut handler)?;
+                    near_tx_hash
+                }
+
+                TransactionKind::FtOnTransfer(args) => {
+                    // No promises can be created by `ft_on_transfer`
+                    let mut handler = crate::promise::Noop;
+                    let mut engine =
+                        engine::Engine::new(relayer_address, env.current_account_id(), io, &env)?;
+
+                    if env.predecessor_account_id == env.current_account_id {
+                        connector::EthConnectorContract::get_instance(io)
+                            .ft_on_transfer(&engine, &args)?;
+                    } else {
+                        engine.receive_erc20_tokens(
+                            &env.predecessor_account_id,
+                            &env.signer_account_id,
+                            &args,
+                            &env.current_account_id,
+                            &mut handler,
+                        );
+                    }
+
+                    near_tx_hash
+                }
+
+                TransactionKind::Deposit(raw_proof) => {
+                    let mut connector_contract = connector::EthConnectorContract::get_instance(io);
+                    let promise_args = connector_contract.deposit(
+                        raw_proof,
+                        env.current_account_id(),
+                        env.predecessor_account_id(),
+                    )?;
+
+                    // Assume the relayer will mark `transaction.succeeded = false` if the
+                    // proof failed to verify. This means the proof must be valid if we made
+                    // it this far, so we will not worry about `promise_args.base` and move
+                    // straight to the callback.
+
+                    let finish_args = parameters::FinishDepositCallArgs::try_from_slice(
+                        &promise_args.callback.args,
+                    )
+                    .expect("Connector deposit function must return valid args");
+                    let maybe_promise_args = connector_contract.finish_deposit(
+                        env.predecessor_account_id(),
+                        env.current_account_id(),
+                        finish_args,
+                    )?;
+
+                    if let Some(promise_args) = maybe_promise_args {
+                        let on_transfer_args =
+                            aurora_engine::json::parse_json(&promise_args.base.args)
+                                .and_then(|json| {
+                                    parameters::NEP141FtOnTransferArgs::try_from(json).ok()
+                                })
+                                .expect("Connector finish_deposit function must return valid args");
+                        let engine = engine::Engine::new(
+                            relayer_address,
+                            env.current_account_id(),
+                            io,
+                            &env,
+                        )?;
+                        connector_contract.ft_on_transfer(&engine, &on_transfer_args)?;
+                        // `ft_on_transfer` always returns an unused amount of 0 if it executes
+                        // successfully, meaning that `ft_resolve_transfer` will do nothing,
+                        // so we skip the promise_args callback.
+                    }
+
+                    near_tx_hash
+                }
+            };
+
+            let diff = io.get_transaction_diff();
+            let tx_included = crate::TransactionIncluded {
+                block_hash,
+                position: transaction_position,
+            };
+            storage.set_transaction_included(tx_hash, &tx_included, &diff)?;
+
+            Ok(())
+        }
+    }
+}
+
+pub mod error {
+    use aurora_engine::{connector, engine};
+
+    #[derive(Debug)]
+    pub enum Error {
+        Storage(crate::Error),
+        EngineState(engine::EngineStateError),
+        Engine(engine::EngineError),
+        DeployErc20(engine::DeployErc20Error),
+        FtOnTransfer(connector::error::FtTransferCallError),
+        Deposit(connector::error::DepositError),
+        FinishDeposit(connector::error::FinishDepositError),
+    }
+
+    impl From<crate::Error> for Error {
+        fn from(e: crate::Error) -> Self {
+            Self::Storage(e)
+        }
+    }
+    impl From<engine::EngineStateError> for Error {
+        fn from(e: engine::EngineStateError) -> Self {
+            Self::EngineState(e)
+        }
+    }
+    impl From<engine::EngineError> for Error {
+        fn from(e: engine::EngineError) -> Self {
+            Self::Engine(e)
+        }
+    }
+    impl From<engine::DeployErc20Error> for Error {
+        fn from(e: engine::DeployErc20Error) -> Self {
+            Self::DeployErc20(e)
+        }
+    }
+    impl From<connector::error::FtTransferCallError> for Error {
+        fn from(e: connector::error::FtTransferCallError) -> Self {
+            Self::FtOnTransfer(e)
+        }
+    }
+    impl From<connector::error::DepositError> for Error {
+        fn from(e: connector::error::DepositError) -> Self {
+            Self::Deposit(e)
+        }
+    }
+    impl From<connector::error::FinishDepositError> for Error {
+        fn from(e: connector::error::FinishDepositError) -> Self {
+            Self::FinishDeposit(e)
+        }
+    }
+}

--- a/engine-standalone-storage/src/sync/types.rs
+++ b/engine-standalone-storage/src/sync/types.rs
@@ -1,0 +1,56 @@
+use aurora_engine::parameters;
+use aurora_engine::transaction::EthTransactionKind;
+use aurora_engine_types::account_id::AccountId;
+use aurora_engine_types::H256;
+
+/// Type describing the format of messages sent to the storage layer for keeping
+/// it in sync with the blockchain.
+#[derive(Debug, Clone)]
+pub enum Message {
+    Block(BlockMessage),
+    Transaction(Box<TransactionMessage>),
+}
+
+#[derive(Debug, Clone)]
+pub struct BlockMessage {
+    pub height: u64,
+    pub hash: H256,
+    pub metadata: crate::BlockMetadata,
+}
+
+#[derive(Debug, Clone)]
+pub struct TransactionMessage {
+    /// Hash of the block which included this transaction
+    pub block_hash: H256,
+    /// Hash of the transaction on NEAR
+    pub near_tx_hash: H256,
+    /// If multiple Aurora transactions are included in the same block,
+    /// this index gives the order in which they should be executed.
+    pub position: u16,
+    /// True if the transaction executed successfully on the blockchain, false otherwise.
+    pub succeeded: bool,
+    /// NEAR account that signed the transaction
+    pub signer: AccountId,
+    /// NEAR account that called the Aurora engine contract
+    pub caller: AccountId,
+    /// Amount of NEAR token attached to the transaction
+    pub attached_near: u128,
+    /// Details of the transaction that was executed
+    pub transaction: TransactionKind,
+}
+
+#[derive(Debug, Clone)]
+pub enum TransactionKind {
+    /// Raw Ethereum transaction submitted to the engine
+    Submit(EthTransactionKind),
+    /// Ethereum transaction triggered by a NEAR account
+    Call(parameters::CallArgs),
+    /// Input here represents the EVM code used to create the new contract
+    Deploy(Vec<u8>),
+    /// New bridged token
+    DeployErc20(parameters::DeployErc20TokenArgs),
+    /// This type of transaction can impact the aurora state because of the bridge
+    FtOnTransfer(parameters::NEP141FtOnTransferArgs),
+    /// Bytes here will be parsed into `aurora_engine::proof::Proof`
+    Deposit(Vec<u8>),
+}

--- a/engine-tests/src/test_utils/standalone/mocks/mod.rs
+++ b/engine-tests/src/test_utils/standalone/mocks/mod.rs
@@ -13,6 +13,9 @@ pub mod promise;
 pub mod storage;
 pub mod tracing;
 
+pub const ETH_CUSTODIAN_ADDRESS: Address =
+    aurora_engine_precompiles::make_address(0xd045f7e1, 0x9b2488924b97f9c145b5e51d0d895a65);
+
 pub fn compute_block_hash(block_height: u64) -> H256 {
     aurora_engine::engine::compute_block_hash([0u8; 32], block_height, b"aurora")
 }
@@ -57,7 +60,7 @@ pub fn init_evm<I: IO + Copy, E: Env>(mut io: I, env: &E) {
 
     let connector_args = InitCallArgs {
         prover_account: test_utils::str_to_account_id("prover.near"),
-        eth_custodian_address: "d045f7e19B2488924B97F9c145b5E51D0D895A65".to_string(),
+        eth_custodian_address: hex::encode(&ETH_CUSTODIAN_ADDRESS),
         metadata: FungibleTokenMetadata::default(),
     };
 

--- a/engine-tests/src/tests/standalone/mod.rs
+++ b/engine-tests/src/tests/standalone/mod.rs
@@ -1,4 +1,5 @@
 mod json_snapshot;
 mod sanity;
 mod storage;
+mod sync;
 mod tracing;

--- a/engine-tests/src/tests/standalone/sync.rs
+++ b/engine-tests/src/tests/standalone/sync.rs
@@ -1,0 +1,411 @@
+use aurora_engine_sdk::env::{Env, Timestamp};
+use aurora_engine_types::{account_id::AccountId, types::Wei, Address, H256, U256};
+use borsh::BorshSerialize;
+use engine_standalone_storage::sync;
+
+use crate::test_utils::{self, standalone::StandaloneRunner};
+
+#[test]
+fn test_consume_block_message() {
+    let (runner, block_message) = initialize();
+
+    assert_eq!(
+        runner
+            .storage
+            .get_block_height_by_hash(block_message.hash)
+            .unwrap(),
+        block_message.height,
+    );
+    assert_eq!(
+        runner
+            .storage
+            .get_block_hash_by_height(block_message.height)
+            .unwrap(),
+        block_message.hash,
+    );
+    assert_eq!(
+        runner
+            .storage
+            .get_block_metadata(block_message.hash)
+            .unwrap(),
+        block_message.metadata,
+    );
+
+    runner.close()
+}
+
+#[test]
+fn test_consume_deposit_message() {
+    let (mut runner, block_message) = initialize();
+
+    let recipient_address = Address([22u8; 20]);
+    let deposit_amount = Wei::new_u64(123_456_789);
+    let proof = mock_proof(recipient_address, deposit_amount);
+
+    let transaction_message = sync::types::TransactionMessage {
+        block_hash: block_message.hash,
+        near_tx_hash: H256([7u8; 32]),
+        position: 0,
+        succeeded: true,
+        signer: runner.env.signer_account_id(),
+        caller: runner.env.predecessor_account_id(),
+        attached_near: 0,
+        transaction: sync::types::TransactionKind::Deposit(proof.try_to_vec().unwrap()),
+    };
+
+    sync::consume_message(
+        &mut runner.storage,
+        sync::types::Message::Transaction(Box::new(transaction_message)),
+    )
+    .unwrap();
+
+    assert_eq!(runner.get_balance(&recipient_address), deposit_amount);
+
+    runner.close()
+}
+
+#[test]
+fn test_consume_deploy_message() {
+    let (mut runner, block_message) = initialize();
+
+    let code = b"hello_world!".to_vec();
+    let input = test_utils::create_deploy_transaction(code.clone(), U256::zero()).data;
+
+    let transaction_message = sync::types::TransactionMessage {
+        block_hash: block_message.hash,
+        near_tx_hash: H256([7u8; 32]),
+        position: 0,
+        succeeded: true,
+        signer: runner.env.signer_account_id(),
+        caller: runner.env.predecessor_account_id(),
+        attached_near: 0,
+        transaction: sync::types::TransactionKind::Deploy(input),
+    };
+
+    sync::consume_message(
+        &mut runner.storage,
+        sync::types::Message::Transaction(Box::new(transaction_message)),
+    )
+    .unwrap();
+
+    let diff = runner
+        .storage
+        .get_transaction_diff(engine_standalone_storage::TransactionIncluded {
+            block_hash: block_message.hash,
+            position: 0,
+        })
+        .unwrap();
+    let mut deployed_address = Address([0u8; 20]);
+    for (key, value) in diff.iter() {
+        match value.value() {
+            Some(bytes) if bytes == code.as_slice() => {
+                deployed_address.0.copy_from_slice(&key[2..22]);
+                break;
+            }
+            _ => continue,
+        }
+    }
+
+    assert_eq!(runner.get_code(&deployed_address), code);
+
+    runner.close()
+}
+
+#[test]
+fn test_consume_deploy_erc20_message() {
+    let (mut runner, block_message) = initialize();
+
+    let token: AccountId = "some_nep141.near".parse().unwrap();
+    let mint_amount: u128 = 555_555;
+    let dest_address = Address([170u8; 20]);
+
+    let args = aurora_engine::parameters::DeployErc20TokenArgs {
+        nep141: token.clone(),
+    };
+    let transaction_message = sync::types::TransactionMessage {
+        block_hash: block_message.hash,
+        near_tx_hash: H256([7u8; 32]),
+        position: 0,
+        succeeded: true,
+        signer: runner.env.signer_account_id(),
+        caller: runner.env.predecessor_account_id(),
+        attached_near: 0,
+        transaction: sync::types::TransactionKind::DeployErc20(args),
+    };
+
+    // Deploy ERC-20 (this would be the flow for bridging a new NEP-141 to Aurora)
+    sync::consume_message(
+        &mut runner.storage,
+        sync::types::Message::Transaction(Box::new(transaction_message)),
+    )
+    .unwrap();
+
+    let io = runner
+        .storage
+        .access_engine_storage_at_position(runner.env.block_height + 1, 0, &[]);
+    let erc20_address = aurora_engine::engine::get_erc20_from_nep141(&io, &token).unwrap();
+
+    runner.env.block_height += 1;
+    runner.env.signer_account_id = "some_account.near".parse().unwrap();
+    runner.env.predecessor_account_id = token.clone();
+    test_utils::standalone::mocks::insert_block(&mut runner.storage, runner.env.block_height);
+    let block_hash = test_utils::standalone::mocks::compute_block_hash(runner.env.block_height);
+
+    let args = aurora_engine::parameters::NEP141FtOnTransferArgs {
+        sender_id: "mr_money_bags.near".parse().unwrap(),
+        amount: mint_amount,
+        msg: hex::encode(dest_address.as_bytes()),
+    };
+    let transaction_message = sync::types::TransactionMessage {
+        block_hash,
+        near_tx_hash: H256([8u8; 32]),
+        position: 0,
+        succeeded: true,
+        signer: runner.env.signer_account_id(),
+        caller: runner.env.predecessor_account_id(),
+        attached_near: 0,
+        transaction: sync::types::TransactionKind::FtOnTransfer(args),
+    };
+
+    // Mint new tokens (via ft_on_transfer flow, same as the bridge)
+    sync::consume_message(
+        &mut runner.storage,
+        sync::types::Message::Transaction(Box::new(transaction_message)),
+    )
+    .unwrap();
+
+    // Check balance is correct
+    let deployed_token = test_utils::erc20::ERC20(
+        test_utils::erc20::ERC20Constructor::load()
+            .0
+            .deployed_at(Address::from_slice(&erc20_address)),
+    );
+    let signer = test_utils::Signer::random();
+    let tx = deployed_token.balance_of(dest_address, signer.nonce.into());
+    let result = runner.submit_transaction(&signer.secret_key, tx).unwrap();
+    assert_eq!(
+        U256::from_big_endian(&test_utils::unwrap_success(result)).low_u128(),
+        mint_amount
+    );
+}
+
+#[test]
+fn test_consume_ft_on_transfer_message() {
+    // Only need to check the case of aurora calling `ft_on_transfer` on itself, the other case
+    // is handled in the `test_consume_deploy_erc20_message` above.
+
+    let (mut runner, block_message) = initialize();
+
+    let mint_amount = 8_675_309;
+    let fee = Wei::zero();
+    let dest_address = Address([221u8; 20]);
+
+    // Mint ETH on Aurora per the bridge workflow
+    let args = aurora_engine::parameters::NEP141FtOnTransferArgs {
+        sender_id: "mr_money_bags.near".parse().unwrap(),
+        amount: mint_amount,
+        msg: [
+            "relayer.near",
+            ":",
+            hex::encode(fee.to_bytes()).as_str(),
+            hex::encode(dest_address.as_bytes()).as_str(),
+        ]
+        .concat(),
+    };
+    let transaction_message = sync::types::TransactionMessage {
+        block_hash: block_message.hash,
+        near_tx_hash: H256([7u8; 32]),
+        position: 0,
+        succeeded: true,
+        signer: runner.env.signer_account_id(),
+        caller: runner.env.predecessor_account_id(),
+        attached_near: 0,
+        transaction: sync::types::TransactionKind::FtOnTransfer(args),
+    };
+
+    sync::consume_message(
+        &mut runner.storage,
+        sync::types::Message::Transaction(Box::new(transaction_message)),
+    )
+    .unwrap();
+
+    assert_eq!(
+        runner.get_balance(&dest_address).raw().low_u128(),
+        mint_amount
+    );
+}
+
+#[test]
+fn test_consume_call_message() {
+    let (mut runner, _) = initialize();
+
+    let caller = "some_account.near";
+    let initial_balance = Wei::new_u64(800_000);
+    let transfer_amount = Wei::new_u64(115_321);
+    let caller_address = aurora_engine_sdk::types::near_account_to_evm_address(caller.as_bytes());
+    let recipient_address = Address([1u8; 20]);
+    runner.mint_account(caller_address, initial_balance, U256::zero(), None);
+
+    runner.env.block_height += 1;
+    runner.env.signer_account_id = caller.parse().unwrap();
+    runner.env.predecessor_account_id = caller.parse().unwrap();
+    test_utils::standalone::mocks::insert_block(&mut runner.storage, runner.env.block_height);
+    let block_hash = test_utils::standalone::mocks::compute_block_hash(runner.env.block_height);
+
+    let transaction_message = sync::types::TransactionMessage {
+        block_hash,
+        near_tx_hash: H256([7u8; 32]),
+        position: 0,
+        succeeded: true,
+        signer: runner.env.signer_account_id(),
+        caller: runner.env.predecessor_account_id(),
+        attached_near: 0,
+        transaction: sync::types::TransactionKind::Call(simple_transfer_args(
+            recipient_address,
+            transfer_amount,
+        )),
+    };
+
+    sync::consume_message(
+        &mut runner.storage,
+        sync::types::Message::Transaction(Box::new(transaction_message)),
+    )
+    .unwrap();
+
+    assert_eq!(runner.get_balance(&recipient_address), transfer_amount);
+    assert_eq!(
+        runner.get_balance(&caller_address),
+        initial_balance - transfer_amount
+    );
+    assert_eq!(runner.get_nonce(&caller_address), U256::one());
+}
+
+#[test]
+fn test_consume_submit_message() {
+    let (mut runner, _) = initialize();
+
+    let mut signer = test_utils::Signer::random();
+    let initial_balance = Wei::new_u64(800_000);
+    let transfer_amount = Wei::new_u64(115_321);
+    let signer_address = test_utils::address_from_secret_key(&signer.secret_key);
+    let recipient_address = Address([1u8; 20]);
+    runner.mint_account(signer_address, initial_balance, signer.nonce.into(), None);
+
+    runner.env.block_height += 1;
+    test_utils::standalone::mocks::insert_block(&mut runner.storage, runner.env.block_height);
+    let block_hash = test_utils::standalone::mocks::compute_block_hash(runner.env.block_height);
+    let transaction = test_utils::transfer(
+        recipient_address,
+        transfer_amount,
+        signer.use_nonce().into(),
+    );
+    let signed_transaction =
+        test_utils::sign_transaction(transaction, Some(runner.chain_id), &signer.secret_key);
+    let eth_transaction =
+        aurora_engine::transaction::EthTransactionKind::Legacy(signed_transaction);
+
+    let transaction_message = sync::types::TransactionMessage {
+        block_hash,
+        near_tx_hash: H256([7u8; 32]),
+        position: 0,
+        succeeded: true,
+        signer: runner.env.signer_account_id(),
+        caller: runner.env.predecessor_account_id(),
+        attached_near: 0,
+        transaction: sync::types::TransactionKind::Submit(eth_transaction),
+    };
+
+    sync::consume_message(
+        &mut runner.storage,
+        sync::types::Message::Transaction(Box::new(transaction_message)),
+    )
+    .unwrap();
+
+    assert_eq!(runner.get_balance(&recipient_address), transfer_amount);
+    assert_eq!(
+        runner.get_balance(&signer_address),
+        initial_balance - transfer_amount
+    );
+    assert_eq!(runner.get_nonce(&signer_address), U256::one());
+}
+
+fn mock_proof(recipient_address: Address, deposit_amount: Wei) -> aurora_engine::proof::Proof {
+    let eth_custodian_address = test_utils::standalone::mocks::ETH_CUSTODIAN_ADDRESS;
+    let deposit_event = aurora_engine::deposit_event::DepositedEvent {
+        eth_custodian_address: eth_custodian_address.0,
+        sender: [0u8; 20],
+        recipient: ["aurora", ":", hex::encode(&recipient_address).as_str()].concat(),
+        amount: deposit_amount.raw(),
+        fee: U256::zero(),
+    };
+
+    let event_schema = ethabi::Event {
+        name: aurora_engine::deposit_event::DEPOSITED_EVENT.into(),
+        inputs: aurora_engine::deposit_event::DepositedEvent::event_params(),
+        anonymous: false,
+    };
+    let log_entry = aurora_engine::log_entry::LogEntry {
+        address: eth_custodian_address,
+        topics: vec![
+            event_schema.signature(),
+            // the sender is not important
+            crate::prelude::H256::zero(),
+        ],
+        data: ethabi::encode(&[
+            ethabi::Token::String(deposit_event.recipient),
+            ethabi::Token::Uint(deposit_event.amount),
+            ethabi::Token::Uint(deposit_event.fee),
+        ]),
+    };
+    aurora_engine::proof::Proof {
+        log_index: 1,
+        // Only this field matters for the purpose of this test
+        log_entry_data: rlp::encode(&log_entry).to_vec(),
+        receipt_index: 1,
+        receipt_data: Vec::new(),
+        header_data: Vec::new(),
+        proof: Vec::new(),
+    }
+}
+
+fn simple_transfer_args(
+    dest_address: Address,
+    transfer_amount: Wei,
+) -> aurora_engine::parameters::CallArgs {
+    aurora_engine::parameters::CallArgs::V2(aurora_engine::parameters::FunctionCallArgsV2 {
+        contract: dest_address.0,
+        value: transfer_amount.to_bytes(),
+        input: Vec::new(),
+    })
+}
+
+fn sample_block() -> sync::types::BlockMessage {
+    let block_height = 101;
+    let block_hash = test_utils::standalone::mocks::compute_block_hash(block_height);
+
+    sync::types::BlockMessage {
+        height: block_height,
+        hash: block_hash,
+        metadata: engine_standalone_storage::BlockMetadata {
+            timestamp: Timestamp::new(1_000_001),
+            random_seed: H256([2u8; 32]),
+        },
+    }
+}
+
+fn initialize() -> (StandaloneRunner, sync::types::BlockMessage) {
+    let mut runner = StandaloneRunner::default();
+    runner.init_evm();
+
+    let block_message = sample_block();
+    sync::consume_message(
+        &mut runner.storage,
+        sync::types::Message::Block(block_message.clone()),
+    )
+    .unwrap();
+
+    let env = test_utils::standalone::mocks::default_env(block_message.height);
+    runner.env = env;
+
+    (runner, block_message)
+}

--- a/engine-types/src/parameters.rs
+++ b/engine-types/src/parameters.rs
@@ -51,7 +51,7 @@ pub struct PromiseBatchAction {
 }
 
 /// withdraw NEAR eth-connector call args
-#[derive(BorshSerialize, BorshDeserialize)]
+#[derive(Debug, BorshSerialize, BorshDeserialize)]
 pub struct WithdrawCallArgs {
     pub recipient_address: EthAddress,
     pub amount: Balance,

--- a/engine/src/connector.rs
+++ b/engine/src/connector.rs
@@ -786,6 +786,7 @@ pub mod error {
     const PROOF_EXIST: &[u8; 15] = b"ERR_PROOF_EXIST";
     const INVALID_ACCOUNT: &[u8; 22] = b"ERR_INVALID_ACCOUNT_ID";
 
+    #[derive(Debug)]
     pub enum ParseEventMessageError {
         TooManyParts,
         InvalidAccount,
@@ -799,6 +800,7 @@ pub mod error {
         }
     }
 
+    #[derive(Debug)]
     pub enum DepositError {
         Paused,
         ProofParseFailed,
@@ -827,6 +829,7 @@ pub mod error {
         }
     }
 
+    #[derive(Debug)]
     pub enum FinishDepositError {
         TransferCall(FtTransferCallError),
         ProofUsed,
@@ -873,6 +876,7 @@ pub mod error {
         }
     }
 
+    #[derive(Debug)]
     pub enum ParseOnTransferMessageError {
         TooManyParts,
         InvalidHexData,
@@ -890,6 +894,7 @@ pub mod error {
         }
     }
 
+    #[derive(Debug)]
     pub enum FtTransferCallError {
         MessageParseFailed(ParseOnTransferMessageError),
         InsufficientAmountForFee,

--- a/engine/src/deposit_event.rs
+++ b/engine/src/deposit_event.rs
@@ -113,6 +113,7 @@ impl DepositedEvent {
 }
 
 pub mod error {
+    #[derive(Debug)]
     pub enum DecodeError {
         RlpFailed,
         SchemaMismatch,
@@ -126,6 +127,7 @@ pub mod error {
         }
     }
 
+    #[derive(Debug)]
     pub enum ParseError {
         LogParseFailed(DecodeError),
         InvalidSender,

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -208,6 +208,7 @@ impl From<BalanceOverflow> for GasPaymentError {
     }
 }
 
+#[derive(Debug)]
 pub enum DeployErc20Error {
     State(EngineStateError),
     Failed(TransactionStatus),

--- a/engine/src/parameters.rs
+++ b/engine/src/parameters.rs
@@ -182,7 +182,7 @@ pub struct ViewCallArgs {
 }
 
 /// Borsh-encoded parameters for `deploy_erc20_token` function.
-#[derive(BorshSerialize, BorshDeserialize, Debug, Eq, PartialEq)]
+#[derive(BorshSerialize, BorshDeserialize, Debug, Eq, PartialEq, Clone)]
 pub struct DeployErc20TokenArgs {
     pub nep141: AccountId,
 }
@@ -233,6 +233,7 @@ pub struct BeginBlockArgs {
 
 /// Borsh-encoded parameters for the `ft_transfer_call` function
 /// for regular NEP-141 tokens.
+#[derive(Debug, Clone)]
 pub struct NEP141FtOnTransferArgs {
     pub sender_id: AccountId,
     pub amount: Balance,

--- a/engine/src/proof.rs
+++ b/engine/src/proof.rs
@@ -1,6 +1,6 @@
 use crate::prelude::{sdk, BorshDeserialize, BorshSerialize, String, ToString, Vec};
 
-#[derive(Default, BorshDeserialize, BorshSerialize, Clone)]
+#[derive(Debug, Default, BorshDeserialize, BorshSerialize, Clone)]
 #[cfg_attr(test, derive(serde::Deserialize, serde::Serialize))]
 pub struct Proof {
     pub log_index: u64,

--- a/engine/src/transaction/eip_1559.rs
+++ b/engine/src/transaction/eip_1559.rs
@@ -61,7 +61,7 @@ impl Transaction1559 {
     }
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct SignedTransaction1559 {
     pub transaction: Transaction1559,
     /// The parity (0 for even, 1 for odd) of the y-value of a secp256k1 signature.

--- a/engine/src/transaction/eip_2930.rs
+++ b/engine/src/transaction/eip_2930.rs
@@ -71,7 +71,7 @@ impl Transaction2930 {
     }
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct SignedTransaction2930 {
     pub transaction: Transaction2930,
     /// The parity (0 for even, 1 for odd) of the y-value of a secp256k1 signature.

--- a/engine/src/transaction/legacy.rs
+++ b/engine/src/transaction/legacy.rs
@@ -60,7 +60,7 @@ impl TransactionLegacy {
     }
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct LegacyEthSignedTransaction {
     /// The unsigned transaction data
     pub transaction: TransactionLegacy,

--- a/engine/src/transaction/mod.rs
+++ b/engine/src/transaction/mod.rs
@@ -9,7 +9,7 @@ use aurora_engine_types::types::Wei;
 use eip_2930::AccessTuple;
 
 /// Typed Transaction Envelope (see https://eips.ethereum.org/EIPS/eip-2718)
-#[derive(Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub enum EthTransactionKind {
     Legacy(legacy::LegacyEthSignedTransaction),
     Eip2930(eip_2930::SignedTransaction2930),


### PR DESCRIPTION
Note: This PR is on top of #379 so that PR should be reviewed and merged first. To review the changes for this PR only look at the last commit.

This PR introduces a high level message format for passing new blockchain information into the standalone storage engine. This will allow it to stay in sync with the blockchain. Note this PR does not yet make use of these data structures; in a future PR they will be constructed based on messages received from the NATS message broker (which is still a work in progress from what I understand from @artob and @JonathanLogan ).

To help guide reviewers, the core logic is found in the `consume_message` function.