### PR TITLE
Increase NEAR Gas for ft_on_transfer

### DIFF
--- a/engine-sdk/src/env.rs
+++ b/engine-sdk/src/env.rs
@@ -1,5 +1,5 @@
 use crate::error::{OneYoctoAttachError, PrivateCallError};
-use crate::prelude::H256;
+use crate::prelude::{NearGas, H256};
 use aurora_engine_types::account_id::AccountId;
 
 /// Timestamp represented by the number of nanoseconds since the Unix Epoch.
@@ -44,7 +44,7 @@ pub trait Env {
     /// Random seed generated for the current block
     fn random_seed(&self) -> H256;
     /// Prepaid NEAR Gas
-    fn prepaid_gas(&self) -> u64;
+    fn prepaid_gas(&self) -> NearGas;
 
     fn assert_private_call(&self) -> Result<(), PrivateCallError> {
         if self.predecessor_account_id() == self.current_account_id() {
@@ -74,7 +74,7 @@ pub struct Fixed {
     pub block_timestamp: Timestamp,
     pub attached_deposit: u128,
     pub random_seed: H256,
-    pub prepaid_gas: u64,
+    pub prepaid_gas: NearGas,
 }
 
 impl Env for Fixed {
@@ -106,7 +106,7 @@ impl Env for Fixed {
         self.random_seed
     }
 
-    fn prepaid_gas(&self) -> u64 {
+    fn prepaid_gas(&self) -> NearGas {
         self.prepaid_gas
     }
 }

--- a/engine-sdk/src/env.rs
+++ b/engine-sdk/src/env.rs
@@ -43,6 +43,8 @@ pub trait Env {
     fn attached_deposit(&self) -> u128;
     /// Random seed generated for the current block
     fn random_seed(&self) -> H256;
+    /// Prepaid NEAR Gas
+    fn prepaid_gas(&self) -> u64;
 
     fn assert_private_call(&self) -> Result<(), PrivateCallError> {
         if self.predecessor_account_id() == self.current_account_id() {
@@ -72,6 +74,7 @@ pub struct Fixed {
     pub block_timestamp: Timestamp,
     pub attached_deposit: u128,
     pub random_seed: H256,
+    pub prepaid_gas: u64,
 }
 
 impl Env for Fixed {
@@ -101,5 +104,9 @@ impl Env for Fixed {
 
     fn random_seed(&self) -> H256 {
         self.random_seed
+    }
+
+    fn prepaid_gas(&self) -> u64 {
+        self.prepaid_gas
     }
 }

--- a/engine-sdk/src/env.rs
+++ b/engine-sdk/src/env.rs
@@ -2,6 +2,8 @@ use crate::error::{OneYoctoAttachError, PrivateCallError};
 use crate::prelude::{NearGas, H256};
 use aurora_engine_types::account_id::AccountId;
 
+pub const DEFAULT_PREPAID_GAS: NearGas = NearGas::new(300_000_000_000_000);
+
 /// Timestamp represented by the number of nanoseconds since the Unix Epoch.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Timestamp(u64);

--- a/engine-sdk/src/near_runtime.rs
+++ b/engine-sdk/src/near_runtime.rs
@@ -392,7 +392,7 @@ pub(crate) mod exports {
         fn account_balance(balance_ptr: u64);
         pub(crate) fn attached_deposit(balance_ptr: u64);
         pub(crate) fn prepaid_gas() -> u64;
-        pub(crate) fn used_gas() -> u64;
+        fn used_gas() -> u64;
         // ############
         // # Math API #
         // ############

--- a/engine-sdk/src/near_runtime.rs
+++ b/engine-sdk/src/near_runtime.rs
@@ -238,8 +238,8 @@ impl crate::env::Env for Runtime {
         }
     }
 
-    fn prepaid_gas(&self) -> u64 {
-        unsafe { exports::prepaid_gas() }
+    fn prepaid_gas(&self) -> NearGas {
+        NearGas::new(unsafe { exports::prepaid_gas() })
     }
 }
 
@@ -392,7 +392,7 @@ pub(crate) mod exports {
         fn account_balance(balance_ptr: u64);
         pub(crate) fn attached_deposit(balance_ptr: u64);
         pub(crate) fn prepaid_gas() -> u64;
-        fn used_gas() -> u64;
+        pub(crate) fn used_gas() -> u64;
         // ############
         // # Math API #
         // ############

--- a/engine-sdk/src/near_runtime.rs
+++ b/engine-sdk/src/near_runtime.rs
@@ -237,6 +237,10 @@ impl crate::env::Env for Runtime {
             bytes
         }
     }
+
+    fn prepaid_gas(&self) -> u64 {
+        unsafe { exports::prepaid_gas() }
+    }
 }
 
 impl crate::promise::PromiseHandler for Runtime {

--- a/engine-standalone-storage/src/relayer_db/mod.rs
+++ b/engine-standalone-storage/src/relayer_db/mod.rs
@@ -81,6 +81,7 @@ where
         block_timestamp: env::Timestamp::new(0),
         attached_deposit: 0,
         random_seed: H256::zero(),
+        prepaid_gas: 0,
     };
     let mut handler = crate::promise::Noop;
 

--- a/engine-standalone-storage/src/relayer_db/mod.rs
+++ b/engine-standalone-storage/src/relayer_db/mod.rs
@@ -2,6 +2,7 @@ use aurora_engine::engine;
 use aurora_engine::transaction::EthTransactionKind;
 use aurora_engine_sdk::env::{self, Env};
 use aurora_engine_types::account_id::AccountId;
+use aurora_engine_types::types::NearGas;
 use aurora_engine_types::H256;
 use postgres::fallible_iterator::FallibleIterator;
 
@@ -81,7 +82,7 @@ where
         block_timestamp: env::Timestamp::new(0),
         attached_deposit: 0,
         random_seed: H256::zero(),
-        prepaid_gas: 0,
+        prepaid_gas: NearGas::new(0),
     };
     let mut handler = crate::promise::Noop;
 

--- a/engine-standalone-storage/src/relayer_db/mod.rs
+++ b/engine-standalone-storage/src/relayer_db/mod.rs
@@ -2,7 +2,6 @@ use aurora_engine::engine;
 use aurora_engine::transaction::EthTransactionKind;
 use aurora_engine_sdk::env::{self, Env, DEFAULT_PREPAID_GAS};
 use aurora_engine_types::account_id::AccountId;
-use aurora_engine_types::types::NearGas;
 use aurora_engine_types::H256;
 use postgres::fallible_iterator::FallibleIterator;
 

--- a/engine-standalone-storage/src/relayer_db/mod.rs
+++ b/engine-standalone-storage/src/relayer_db/mod.rs
@@ -1,6 +1,6 @@
 use aurora_engine::engine;
 use aurora_engine::transaction::EthTransactionKind;
-use aurora_engine_sdk::env::{self, Env};
+use aurora_engine_sdk::env::{self, Env, DEFAULT_PREPAID_GAS};
 use aurora_engine_types::account_id::AccountId;
 use aurora_engine_types::types::NearGas;
 use aurora_engine_types::H256;
@@ -82,7 +82,7 @@ where
         block_timestamp: env::Timestamp::new(0),
         attached_deposit: 0,
         random_seed: H256::zero(),
-        prepaid_gas: NearGas::new(0),
+        prepaid_gas: DEFAULT_PREPAID_GAS,
     };
     let mut handler = crate::promise::Noop;
 

--- a/engine-standalone-storage/src/sync/mod.rs
+++ b/engine-standalone-storage/src/sync/mod.rs
@@ -1,6 +1,5 @@
 use aurora_engine::{connector, engine, parameters};
 use aurora_engine_sdk::env::{self, Env, DEFAULT_PREPAID_GAS};
-use aurora_engine_types::types::NearGas;
 use aurora_engine_types::TryFrom;
 use borsh::BorshDeserialize;
 

--- a/engine-standalone-storage/src/sync/mod.rs
+++ b/engine-standalone-storage/src/sync/mod.rs
@@ -1,5 +1,5 @@
 use aurora_engine::{connector, engine, parameters};
-use aurora_engine_sdk::env::{self, Env};
+use aurora_engine_sdk::env::{self, Env, DEFAULT_PREPAID_GAS};
 use aurora_engine_types::types::NearGas;
 use aurora_engine_types::TryFrom;
 use borsh::BorshDeserialize;
@@ -47,8 +47,7 @@ pub fn consume_message(storage: &mut crate::Storage, message: Message) -> Result
                 block_timestamp: block_metadata.timestamp,
                 attached_deposit: transaction_message.attached_near,
                 random_seed: block_metadata.random_seed,
-                // TODO: fix it?
-                prepaid_gas: NearGas::new(300_000_000_000_000),
+                prepaid_gas: DEFAULT_PREPAID_GAS,
             };
             let io =
                 storage.access_engine_storage_at_position(block_height, transaction_position, &[]);

--- a/engine-standalone-storage/src/sync/mod.rs
+++ b/engine-standalone-storage/src/sync/mod.rs
@@ -46,6 +46,8 @@ pub fn consume_message(storage: &mut crate::Storage, message: Message) -> Result
                 block_timestamp: block_metadata.timestamp,
                 attached_deposit: transaction_message.attached_near,
                 random_seed: block_metadata.random_seed,
+                // TODO: fix it?
+                prepaid_gas: 0,
             };
             let io =
                 storage.access_engine_storage_at_position(block_height, transaction_position, &[]);

--- a/engine-standalone-storage/src/sync/mod.rs
+++ b/engine-standalone-storage/src/sync/mod.rs
@@ -1,5 +1,6 @@
 use aurora_engine::{connector, engine, parameters};
 use aurora_engine_sdk::env::{self, Env};
+use aurora_engine_types::types::NearGas;
 use aurora_engine_types::TryFrom;
 use borsh::BorshDeserialize;
 
@@ -47,7 +48,7 @@ pub fn consume_message(storage: &mut crate::Storage, message: Message) -> Result
                 attached_deposit: transaction_message.attached_near,
                 random_seed: block_metadata.random_seed,
                 // TODO: fix it?
-                prepaid_gas: 0,
+                prepaid_gas: NearGas::new(300_000_000_000_000),
             };
             let io =
                 storage.access_engine_storage_at_position(block_height, transaction_position, &[]);
@@ -145,6 +146,7 @@ pub fn consume_message(storage: &mut crate::Storage, message: Message) -> Result
                         env.predecessor_account_id(),
                         env.current_account_id(),
                         finish_args,
+                        env.prepaid_gas,
                     )?;
 
                     if let Some(promise_args) = maybe_promise_args {

--- a/engine-tests/src/test_utils/standalone/mocks/mod.rs
+++ b/engine-tests/src/test_utils/standalone/mocks/mod.rs
@@ -3,8 +3,10 @@ use aurora_engine::fungible_token::FungibleTokenMetadata;
 use aurora_engine::parameters::{FinishDepositCallArgs, InitCallArgs, NewCallArgs};
 use aurora_engine_sdk::env::Env;
 use aurora_engine_sdk::io::IO;
+use aurora_engine_types::types::NearGas;
 use aurora_engine_types::{account_id::AccountId, types::Wei, Address, H256, U256};
 use engine_standalone_storage::{BlockMetadata, Storage};
+use near_sdk_sim::DEFAULT_GAS;
 
 use crate::test_utils;
 
@@ -44,7 +46,7 @@ pub fn default_env(block_height: u64) -> aurora_engine_sdk::env::Fixed {
         block_timestamp: aurora_engine_sdk::env::Timestamp::new(0),
         attached_deposit: 0,
         random_seed: H256::zero(),
-        prepaid_gas: 0,
+        prepaid_gas: NearGas::new(0),
     }
 }
 
@@ -119,6 +121,7 @@ pub fn mint_evm_account<I: IO + Copy, E: Env>(
             aurora_account_id.clone(),
             aurora_account_id.clone(),
             deposit_args,
+            NearGas::new(DEFAULT_GAS),
         )
         .map_err(unsafe_to_string)
         .unwrap();

--- a/engine-tests/src/test_utils/standalone/mocks/mod.rs
+++ b/engine-tests/src/test_utils/standalone/mocks/mod.rs
@@ -44,6 +44,7 @@ pub fn default_env(block_height: u64) -> aurora_engine_sdk::env::Fixed {
         block_timestamp: aurora_engine_sdk::env::Timestamp::new(0),
         attached_deposit: 0,
         random_seed: H256::zero(),
+        prepaid_gas: 0,
     }
 }
 

--- a/engine-tests/src/test_utils/standalone/mocks/mod.rs
+++ b/engine-tests/src/test_utils/standalone/mocks/mod.rs
@@ -1,7 +1,7 @@
 use aurora_engine::engine;
 use aurora_engine::fungible_token::FungibleTokenMetadata;
 use aurora_engine::parameters::{FinishDepositCallArgs, InitCallArgs, NewCallArgs};
-use aurora_engine_sdk::env::Env;
+use aurora_engine_sdk::env::{Env, DEFAULT_PREPAID_GAS};
 use aurora_engine_sdk::io::IO;
 use aurora_engine_types::types::NearGas;
 use aurora_engine_types::{account_id::AccountId, types::Wei, Address, H256, U256};

--- a/engine-tests/src/test_utils/standalone/mod.rs
+++ b/engine-tests/src/test_utils/standalone/mod.rs
@@ -2,6 +2,7 @@ use aurora_engine::engine;
 use aurora_engine::parameters::{CallArgs, DeployErc20TokenArgs, SubmitResult, TransactionStatus};
 use aurora_engine::transaction::legacy::{LegacyEthSignedTransaction, TransactionLegacy};
 use aurora_engine_sdk::env::{self, Env};
+use aurora_engine_types::types::NearGas;
 use aurora_engine_types::{types::Wei, Address, H256, U256};
 use borsh::BorshDeserialize;
 use engine_standalone_storage::engine_state;
@@ -125,7 +126,7 @@ impl StandaloneRunner {
         env.predecessor_account_id = ctx.predecessor_account_id.as_ref().parse().unwrap();
         env.current_account_id = ctx.current_account_id.as_ref().parse().unwrap();
         env.signer_account_id = ctx.signer_account_id.as_ref().parse().unwrap();
-        env.prepaid_gas = ctx.prepaid_gas;
+        env.prepaid_gas = NearGas::new(ctx.prepaid_gas);
 
         let storage = &mut self.storage;
         if method_name == test_utils::SUBMIT {

--- a/engine-tests/src/test_utils/standalone/mod.rs
+++ b/engine-tests/src/test_utils/standalone/mod.rs
@@ -125,6 +125,7 @@ impl StandaloneRunner {
         env.predecessor_account_id = ctx.predecessor_account_id.as_ref().parse().unwrap();
         env.current_account_id = ctx.current_account_id.as_ref().parse().unwrap();
         env.signer_account_id = ctx.signer_account_id.as_ref().parse().unwrap();
+        env.prepaid_gas = ctx.prepaid_gas;
 
         let storage = &mut self.storage;
         if method_name == test_utils::SUBMIT {

--- a/engine-tests/src/tests/standalone/sanity.rs
+++ b/engine-tests/src/tests/standalone/sanity.rs
@@ -30,6 +30,7 @@ fn test_deploy_code() {
         block_timestamp: aurora_engine_sdk::env::Timestamp::new(0),
         attached_deposit: 0,
         random_seed: H256::zero(),
+        prepaid_gas: 0,
     };
     let mut handler = promise::PromiseTracker::default();
     let mut engine = engine::Engine::new_with_state(state, origin, owner_id, io, &env);

--- a/engine-tests/src/tests/standalone/sanity.rs
+++ b/engine-tests/src/tests/standalone/sanity.rs
@@ -1,6 +1,7 @@
 use crate::test_utils::standalone::mocks::{promise, storage};
 use aurora_engine::engine;
-use aurora_engine_types::types::{NearGas, Wei};
+use aurora_engine_sdk::env::DEFAULT_PREPAID_GAS;
+use aurora_engine_types::types::Wei;
 use aurora_engine_types::{account_id::AccountId, Address, H256, U256};
 use std::sync::RwLock;
 

--- a/engine-tests/src/tests/standalone/sanity.rs
+++ b/engine-tests/src/tests/standalone/sanity.rs
@@ -1,6 +1,6 @@
 use crate::test_utils::standalone::mocks::{promise, storage};
 use aurora_engine::engine;
-use aurora_engine_types::types::Wei;
+use aurora_engine_types::types::{NearGas, Wei};
 use aurora_engine_types::{account_id::AccountId, Address, H256, U256};
 use std::sync::RwLock;
 
@@ -30,7 +30,7 @@ fn test_deploy_code() {
         block_timestamp: aurora_engine_sdk::env::Timestamp::new(0),
         attached_deposit: 0,
         random_seed: H256::zero(),
-        prepaid_gas: 0,
+        prepaid_gas: NearGas::new(0),
     };
     let mut handler = promise::PromiseTracker::default();
     let mut engine = engine::Engine::new_with_state(state, origin, owner_id, io, &env);

--- a/engine-types/src/types.rs
+++ b/engine-types/src/types.rs
@@ -20,6 +20,14 @@ pub type WeiU256 = [u8; 32];
 /// Near gas type which wraps an underlying u64.
 pub struct NearGas(u64);
 
+impl Sub<NearGas> for NearGas {
+    type Output = NearGas;
+
+    fn sub(self, rhs: NearGas) -> Self::Output {
+        Self(self.0 - rhs.0)
+    }
+}
+
 impl Display for NearGas {
     fn fmt(&self, f: &mut Formatter<'_>) -> crate::fmt::Result {
         self.0.fmt(f)

--- a/engine/src/connector.rs
+++ b/engine/src/connector.rs
@@ -250,6 +250,7 @@ impl<I: IO + Copy> EthConnectorContract<I> {
         predecessor_account_id: AccountId,
         current_account_id: AccountId,
         data: FinishDepositCallArgs,
+        gas: NearGas,
     ) -> Result<Option<PromiseWithCallbackArgs>, error::FinishDepositError> {
         sdk::log!(&format!("Finish deposit with the amount: {}", data.amount));
 
@@ -266,6 +267,7 @@ impl<I: IO + Copy> EthConnectorContract<I> {
                 predecessor_account_id,
                 current_account_id,
                 transfer_call_args,
+                gas,
             )?;
             Ok(Some(promise))
         } else {
@@ -472,6 +474,7 @@ impl<I: IO + Copy> EthConnectorContract<I> {
         predecessor_account_id: AccountId,
         current_account_id: AccountId,
         args: TransferCallCallArgs,
+        gas: NearGas,
     ) -> Result<PromiseWithCallbackArgs, error::FtTransferCallError> {
         sdk::log!(&format!(
             "Transfer call to {} amount {}",
@@ -520,6 +523,7 @@ impl<I: IO + Copy> EthConnectorContract<I> {
                 &args.memo,
                 args.msg,
                 current_account_id,
+                gas,
             )
             .map_err(Into::into)
     }

--- a/engine/src/connector.rs
+++ b/engine/src/connector.rs
@@ -267,7 +267,7 @@ impl<I: IO + Copy> EthConnectorContract<I> {
                 predecessor_account_id,
                 current_account_id,
                 transfer_call_args,
-                gas,
+                prepaid_gas,
             )?;
             Ok(Some(promise))
         } else {
@@ -523,7 +523,7 @@ impl<I: IO + Copy> EthConnectorContract<I> {
                 &args.memo,
                 args.msg,
                 current_account_id,
-                gas,
+                prepaid_gas,
             )
             .map_err(Into::into)
     }

--- a/engine/src/connector.rs
+++ b/engine/src/connector.rs
@@ -24,8 +24,7 @@ pub const ERR_NOT_ENOUGH_BALANCE_FOR_FEE: &str = "ERR_NOT_ENOUGH_BALANCE_FOR_FEE
 /// Indicate zero attached balance for promise call
 pub const ZERO_ATTACHED_BALANCE: Balance = 0;
 //// NEAR Gas for calling `fininsh_deposit` promise. Used in the `deposit` logic.
-/// 40Tgas + GAS_FOR_FT_ON_TRANSFER = 80 TGas
-const GAS_FOR_FINISH_DEPOSIT: NearGas = NearGas::new(80_000_000_000_000);
+pub const GAS_FOR_FINISH_DEPOSIT: NearGas = NearGas::new(50_000_000_000_000);
 /// NEAR Gas for calling `verify_log_entry` promise. Used in the `deposit` logic.
 // Note: Is 40Tgas always enough?
 const GAS_FOR_VERIFY_LOG_ENTRY: NearGas = NearGas::new(40_000_000_000_000);

--- a/engine/src/connector.rs
+++ b/engine/src/connector.rs
@@ -23,8 +23,9 @@ use aurora_engine_sdk::io::{StorageIntermediate, IO};
 pub const ERR_NOT_ENOUGH_BALANCE_FOR_FEE: &str = "ERR_NOT_ENOUGH_BALANCE_FOR_FEE";
 /// Indicate zero attached balance for promise call
 pub const ZERO_ATTACHED_BALANCE: Balance = 0;
-/// NEAR Gas for calling `fininsh_deposit` promise. Used in the `deposit` logic.
-const GAS_FOR_FINISH_DEPOSIT: NearGas = NearGas::new(50_000_000_000_000);
+//// NEAR Gas for calling `fininsh_deposit` promise. Used in the `deposit` logic.
+/// 40Tgas + GAS_FOR_FT_ON_TRANSFER = 80 TGas
+const GAS_FOR_FINISH_DEPOSIT: NearGas = NearGas::new(80_000_000_000_000);
 /// NEAR Gas for calling `verify_log_entry` promise. Used in the `deposit` logic.
 // Note: Is 40Tgas always enough?
 const GAS_FOR_VERIFY_LOG_ENTRY: NearGas = NearGas::new(40_000_000_000_000);

--- a/engine/src/fungible_token.rs
+++ b/engine/src/fungible_token.rs
@@ -14,7 +14,7 @@ use aurora_engine_sdk::io::{StorageIntermediate, IO};
 /// Gas for `resolve_transfer`: 5 TGas
 const GAS_FOR_RESOLVE_TRANSFER: NearGas = NearGas::new(5_000_000_000_000);
 /// Gas for `ft_on_transfer`
-const GAS_FOR_FT_TRANSFER_CALL: NearGas = NearGas::new(25_000_000_000_000);
+const GAS_FOR_FT_TRANSFER_CALL: NearGas = NearGas::new(35_000_000_000_000);
 
 #[derive(Debug, Default, BorshDeserialize, BorshSerialize)]
 pub struct FungibleToken {

--- a/engine/src/fungible_token.rs
+++ b/engine/src/fungible_token.rs
@@ -325,7 +325,8 @@ impl<I: IO + Copy> FungibleTokenOps<I> {
             method: "ft_on_transfer".to_string(),
             args: data1.into_bytes(),
             attached_balance: ZERO_ATTACHED_BALANCE,
-            attached_gas: (gas - GAS_FOR_FT_TRANSFER_CALL - GAS_FOR_RESOLVE_TRANSFER).into_u64(),
+            attached_gas: (prepaid_gas - GAS_FOR_FT_TRANSFER_CALL - GAS_FOR_RESOLVE_TRANSFER)
+                .into_u64(),
         };
         let ft_resolve_transfer_call = PromiseCreateArgs {
             target_account_id: current_account_id,

--- a/engine/src/fungible_token.rs
+++ b/engine/src/fungible_token.rs
@@ -11,8 +11,10 @@ use crate::prelude::{
 };
 use aurora_engine_sdk::io::{StorageIntermediate, IO};
 
+/// Gas for `resolve_transfer`: 5 TGas
 const GAS_FOR_RESOLVE_TRANSFER: NearGas = NearGas::new(5_000_000_000_000);
-const GAS_FOR_FT_ON_TRANSFER: NearGas = NearGas::new(10_000_000_000_000);
+/// Gas for `ft_on_transfer` transfer: 25 TGas + GAS_FOR_RESOLVE_TRANSFER
+const GAS_FOR_FT_ON_TRANSFER: NearGas = NearGas::new(30_000_000_000_000);
 
 #[derive(Debug, Default, BorshDeserialize, BorshSerialize)]
 pub struct FungibleToken {

--- a/engine/src/fungible_token.rs
+++ b/engine/src/fungible_token.rs
@@ -13,6 +13,8 @@ use aurora_engine_sdk::io::{StorageIntermediate, IO};
 
 /// Gas for `resolve_transfer`: 5 TGas
 const GAS_FOR_RESOLVE_TRANSFER: NearGas = NearGas::new(5_000_000_000_000);
+/// Gas for `ft_on_transfer`
+const GAS_FOR_FT_TRANSFER_CALL: NearGas = NearGas::new(25_000_000_000_000);
 
 #[derive(Debug, Default, BorshDeserialize, BorshSerialize)]
 pub struct FungibleToken {
@@ -287,6 +289,7 @@ impl<I: IO + Copy> FungibleTokenOps<I> {
         self.get_account_eth_balance(account_id).unwrap_or(0)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn ft_transfer_call(
         &mut self,
         sender_id: AccountId,
@@ -295,20 +298,8 @@ impl<I: IO + Copy> FungibleTokenOps<I> {
         memo: &Option<String>,
         msg: String,
         current_account_id: AccountId,
+        gas: NearGas,
     ) -> Result<PromiseWithCallbackArgs, error::TransferError> {
-        use aurora_engine_sdk::env::Env;
-        #[cfg(feature = "contract")]
-        let gas = {
-            use aurora_engine_sdk::near_runtime::Runtime;
-            let env = Runtime;
-            env.prepaid_gas()
-        };
-        #[cfg(not(feature = "contract"))]
-        let gas = {
-            use aurora_engine_sdk::env::Fixed;
-            Fixed::prepaid_gas()
-        };
-
         // Special case for Aurora transfer itself - we shouldn't transfer
         if sender_id != receiver_id {
             self.internal_transfer_eth_on_near(&sender_id, &receiver_id, amount, memo)?;
@@ -334,7 +325,7 @@ impl<I: IO + Copy> FungibleTokenOps<I> {
             method: "ft_on_transfer".to_string(),
             args: data1.into_bytes(),
             attached_balance: ZERO_ATTACHED_BALANCE,
-            attached_gas: gas - crate::connector::GAS_FOR_FINISH_DEPOSIT.into_u64(),
+            attached_gas: (gas - GAS_FOR_FT_TRANSFER_CALL - GAS_FOR_RESOLVE_TRANSFER).into_u64(),
         };
         let ft_resolve_transfer_call = PromiseCreateArgs {
             target_account_id: current_account_id,

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -612,7 +612,12 @@ mod contract {
         let current_account_id = io.current_account_id();
         let predecessor_account_id = io.predecessor_account_id();
         let maybe_promise_args = EthConnectorContract::init_instance(io)
-            .finish_deposit(predecessor_account_id, current_account_id, data)
+            .finish_deposit(
+                predecessor_account_id,
+                current_account_id,
+                data,
+                io.prepaid_gas(),
+            )
             .sdk_unwrap();
 
         if let Some(promise_args) = maybe_promise_args {
@@ -711,7 +716,12 @@ mod contract {
         let current_account_id = io.current_account_id();
         let predecessor_account_id = io.predecessor_account_id();
         let promise_args = EthConnectorContract::init_instance(io)
-            .ft_transfer_call(predecessor_account_id, current_account_id, args)
+            .ft_transfer_call(
+                predecessor_account_id,
+                current_account_id,
+                args,
+                io.prepaid_gas(),
+            )
             .sdk_unwrap();
         let promise_id = io.promise_crate_with_callback(&promise_args);
         io.promise_return(promise_id);


### PR DESCRIPTION
PR related to the issue: #381

Increased NEAR Gas:
* `deposit` to 80 Tgas
* `ft_on_transfer` 30 TGas

## Solution
The main solution is not to fix the amount of gas for promise call `ft_on_transfer`. For this, a formula is introduced according to which we can use more gas, depending on how much gas was initially released. 

`GAS_FOR_FT_ON_TRANSFER = prepaid_gas - GAS_FOR_FT_TRANSFER_CALL - GAS_FOR_RESOLVE_TRASNFER`

* added new Sdk and Env method - `prepaid_gas`
* introduced a new constant `GAS_FOR_FT_TRANSFER_CALL = 35 TGas`. This constant indicates how much gas is allocated to make a call `ft_transfer_call`.
* To invoke a ft_on_transfer` promise, a formula for gas counting has been introduced: `GAS_FOR_FT_ON_TRANSFER = prepaid_gas - GAS_FOR_FT_TRANSFER_CALL - GAS_FOR_RESOLVE_TRASNFER`

This will allow the use of dedicated gas for this method. 