### PR TITLE
Feat(standalone): Add debug tracing of remaining gas values

### DIFF
--- a/engine-standalone-tracing/src/sputnik.rs
+++ b/engine-standalone-tracing/src/sputnik.rs
@@ -48,14 +48,18 @@ impl evm_gasometer::tracing::EventListener for TransactionTraceBuilder {
     fn event(&mut self, event: evm_gasometer::tracing::Event) {
         use evm_gasometer::tracing::Event;
         match event {
-            Event::RecordCost { cost, snapshot: _ } => {
+            Event::RecordCost { cost, snapshot } => {
                 self.current.gas_cost = EthGas::new(cost);
+                if let Some(snapshot) = snapshot {
+                    self.current.gas =
+                        EthGas::new(snapshot.gas_limit - snapshot.used_gas - snapshot.memory_gas);
+                }
             }
             Event::RecordDynamicCost {
                 gas_cost,
                 memory_gas,
                 gas_refund: _,
-                snapshot: _,
+                snapshot,
             } => {
                 // In SputnikVM memory gas is cumulative (ie this event always shows the total) gas
                 // spent on memory up to this point. But geth traces simply show how much gas each step
@@ -68,6 +72,10 @@ impl evm_gasometer::tracing::EventListener for TransactionTraceBuilder {
                 };
                 self.current_memory_gas = memory_gas;
                 self.current.gas_cost = EthGas::new(gas_cost + memory_cost_diff);
+                if let Some(snapshot) = snapshot {
+                    self.current.gas =
+                        EthGas::new(snapshot.gas_limit - snapshot.used_gas - snapshot.memory_gas);
+                }
             }
             Event::RecordRefund {
                 refund: _,

--- a/engine-standalone-tracing/src/types.rs
+++ b/engine-standalone-tracing/src/types.rs
@@ -151,9 +151,9 @@ pub struct TraceLog {
     pub depth: Depth,
     /// Any errors that may have occurred during execution.
     pub error: Option<String>,
-    /// Gas used to execute the transaction.
+    /// Remaining (unused) gas.
     pub gas: EthGas,
-    /// Gas cost for the transaction.
+    /// Gas cost for the opcode at this step.
     pub gas_cost: EthGas,
     /// The bounded memory.
     pub memory: LogMemory,

--- a/engine-tests/src/tests/standalone/tracing.rs
+++ b/engine-tests/src/tests/standalone/tracing.rs
@@ -210,6 +210,11 @@ fn check_transaction_trace<P: AsRef<Path>>(trace: TransactionTrace, expected_tra
         assert_eq!(log.depth.into_u32(), step.depth, "Depths should match");
         assert_eq!(log.opcode.as_u8(), step.op, "opcodes should match");
         assert_eq!(
+            log.gas.into_u64(),
+            step.gas,
+            "remaining gas values should match"
+        );
+        assert_eq!(
             log.gas_cost.into_u64(),
             step.gas_cost,
             "gas costs should match"


### PR DESCRIPTION
Geth traces include a `gas` value which counts down from the gas limit. In this PR we capture this information from the SputnikVM events and validate it is the same as the values in example traces from etherscan.