### PR TITLE
Fix(dep): Pass std feature on to rjson library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,18 +158,14 @@ dependencies = [
  "evm-core",
  "hex",
  "libsecp256k1",
- "logos",
  "num",
  "primitive-types 0.10.1",
  "rand 0.7.3",
  "ripemd160",
- "rjson",
- "rlp",
  "serde",
  "serde_json",
  "sha2 0.9.5",
  "sha3 0.9.1",
- "wee_alloc",
 ]
 
 [[package]]

--- a/engine-precompiles/Cargo.toml
+++ b/engine-precompiles/Cargo.toml
@@ -25,14 +25,10 @@ libsecp256k1 = { version = "0.3.5", default-features = false }
 num = { version = "0.4.0", default-features = false, features = ["alloc"] }
 primitive-types = { version = "0.10.0", default-features = false, features = ["rlp"] }
 ripemd160 = { version = "0.9.1", default-features = false }
-rlp = { version = "0.5.0", default-features = false }
 sha2 = { version = "0.9.3", default-features = false }
 sha3 = { version = "0.9.1", default-features = false }
-wee_alloc = { version = "0.4.5", default-features = false }
-logos = { version = "0.12", default-features = false, features = ["export_derive"] }
 ethabi = { git = "https://github.com/darwinia-network/ethabi", branch = "xavier-no-std", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
-rjson = { git = "https://github.com/aurora-is-near/rjson", rev = "cc3da949", default-features = false, features = ["integer"] }
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
@@ -40,6 +36,7 @@ serde_json = "1"
 rand = "0.7.3"
 
 [features]
+std = ["aurora-engine-types/std", "aurora-engine-sdk/std", "borsh/std", "blake2/std", "bn/std", "evm/std", "evm-core/std", "libsecp256k1/std", "ripemd160/std", "sha2/std", "sha3/std", "ethabi/std"]
 contract = []
 log = []
 error_refund = []

--- a/engine-precompiles/src/lib.rs
+++ b/engine-precompiles/src/lib.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code)]
-#![feature(array_methods)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(alloc_error_handler))]
 #![cfg_attr(feature = "log", feature(panic_info_message))]

--- a/engine-sdk/src/lib.rs
+++ b/engine-sdk/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(array_methods)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(alloc_error_handler))]
 #![cfg_attr(feature = "log", feature(panic_info_message))]

--- a/engine-tests/Cargo.toml
+++ b/engine-tests/Cargo.toml
@@ -16,7 +16,7 @@ autobenches = false
 aurora-engine = { path = "../engine", default-features = false, features = ["std", "tracing"] }
 aurora-engine-types = { path = "../engine-types", default-features = false, features = ["std"] }
 aurora-engine-sdk = { path = "../engine-sdk", default-features = false, features = ["std"] }
-aurora-engine-precompiles = { path = "../engine-precompiles", default-features = false }
+aurora-engine-precompiles = { path = "../engine-precompiles", default-features = false, features = ["std"] }
 engine-standalone-storage = { path = "../engine-standalone-storage", default-features = false }
 engine-standalone-tracing = { path = "../engine-standalone-tracing", default-features = false }
 borsh = { version = "0.8.2", default-features = false }

--- a/engine-types/src/lib.rs
+++ b/engine-types/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(array_methods)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(alloc_error_handler))]
 #![cfg_attr(feature = "log", feature(panic_info_message))]

--- a/engine-types/src/storage.rs
+++ b/engine-types/src/storage.rs
@@ -78,9 +78,9 @@ pub enum StorageKeyKind {
 impl AsRef<[u8]> for StorageKeyKind {
     fn as_ref(&self) -> &[u8] {
         use StorageKeyKind::*;
-        match self {
-            Normal(v) => v.as_slice(),
-            Generation(v) => v.as_slice(),
+        match &self {
+            Normal(v) => v,
+            Generation(v) => v,
         }
     }
 }

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -45,7 +45,7 @@ rand = "0.7.3"
 
 [features]
 default = ["std"]
-std = ["borsh/std", "evm/std", "primitive-types/std", "rlp/std", "sha3/std", "ethabi/std", "logos/std", "bn/std", "aurora-engine-types/std"]
+std = ["borsh/std", "evm/std", "primitive-types/std", "rlp/std", "sha3/std", "ethabi/std", "logos/std", "bn/std", "aurora-engine-types/std", "rjson/std", "aurora-engine-precompiles/std"]
 contract = ["aurora-engine-sdk/contract", "aurora-engine-precompiles/contract"]
 evm_bully = []
 log = ["aurora-engine-sdk/log", "aurora-engine-precompiles/log"]

--- a/engine/src/fungible_token.rs
+++ b/engine/src/fungible_token.rs
@@ -69,7 +69,7 @@ impl FungibleReferenceHash {
 
 impl AsRef<[u8]> for FungibleReferenceHash {
     fn as_ref(&self) -> &[u8] {
-        self.0.as_slice()
+        &self.0
     }
 }
 

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(array_methods)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(alloc_error_handler))]
 #![cfg_attr(feature = "log", feature(panic_info_message))]

--- a/etc/state-migration-test/Cargo.lock
+++ b/etc/state-migration-test/Cargo.lock
@@ -77,15 +77,11 @@ dependencies = [
  "evm-core",
  "hex",
  "libsecp256k1",
- "logos",
  "num",
  "primitive-types",
  "ripemd160",
- "rjson",
- "rlp",
  "sha2",
  "sha3 0.9.1",
- "wee_alloc",
 ]
 
 [[package]]


### PR DESCRIPTION
The following changes are made in order to engine on stable rust (only works with `std`):

- Pass `std` feature on to `rjson`
- Include `std` feature in `engine-precompiles` and pass it on to its deps
- Remove unnecessary unstable feature `array_methods`