### PR TITLE
Feat(benchmarks): update gas bounds after wasm cost reduction

### DIFF
--- a/engine-tests/src/test_utils/mod.rs
+++ b/engine-tests/src/test_utils/mod.rs
@@ -497,7 +497,9 @@ impl Default for AuroraRunner {
         };
         let mut wasm_config = VMConfig::default();
         // See https://github.com/near/nearcore/pull/4979/
-        wasm_config.regular_op_cost = 2207874;
+        //wasm_config.regular_op_cost = 2207874;
+        // See https://github.com/near/nearcore/pull/5365
+        wasm_config.regular_op_cost = 822756;
 
         Self {
             aurora_account_id: aurora_account_id.clone(),

--- a/engine-tests/src/tests/erc20.rs
+++ b/engine-tests/src/tests/erc20.rs
@@ -112,8 +112,8 @@ fn profile_erc20_get_balance() {
     // at least 70% of the cost is spent on wasm computation (as opposed to host functions)
     let wasm_fraction = (100 * profile.wasm_gas()) / profile.all_gas();
     assert!(
-        wasm_fraction >= 68,
-        "{}% is not greater than 68%",
+        wasm_fraction >= 46,
+        "{}% is not greater than 46%",
         wasm_fraction
     );
 }

--- a/engine-tests/src/tests/one_inch.rs
+++ b/engine-tests/src/tests/one_inch.rs
@@ -100,8 +100,8 @@ fn test_1_inch_limit_order_deploy() {
 
     // more than 3.5 million Ethereum gas used
     assert!(result.gas_used > 3_500_000);
-    // less than 14 NEAR Tgas used
-    assert_gas_bound(profile.all_gas(), 14);
+    // less than 15 NEAR Tgas used
+    assert_gas_bound(profile.all_gas(), 15);
     // at least 45% of which is from wasm execution
     let wasm_fraction = 100 * profile.wasm_gas() / profile.all_gas();
     assert!(

--- a/engine-tests/src/tests/one_inch.rs
+++ b/engine-tests/src/tests/one_inch.rs
@@ -23,11 +23,11 @@ fn test_1inch_liquidity_protocol() {
 
     let (result, profile, deployer_address) = helper.create_mooniswap_deployer();
     assert!(result.gas_used >= 5_100_000); // more than 5.1M EVM gas used
-    assert_gas_bound(profile.all_gas(), 28); // less than 28 NEAR Tgas used
+    assert_gas_bound(profile.all_gas(), 15); // less than 15 NEAR Tgas used
 
     let (result, profile, pool_factory) = helper.create_pool_factory(&deployer_address);
     assert!(result.gas_used >= 2_800_000); // more than 2.8M EVM gas used
-    assert_gas_bound(profile.all_gas(), 22); // less than 22 NEAR Tgas used
+    assert_gas_bound(profile.all_gas(), 13); // less than 22 NEAR Tgas used
 
     // create some ERC-20 tokens to have a liquidity pool for
     let signer_address = test_utils::address_from_secret_key(&helper.signer.secret_key);
@@ -39,7 +39,7 @@ fn test_1inch_liquidity_protocol() {
     let (result, profile, pool) =
         helper.create_pool(&pool_factory, token_a.0.address, token_b.0.address);
     assert!(result.gas_used >= 4_500_000); // more than 4.5M EVM gas used
-    assert_gas_bound(profile.all_gas(), 67); // less than 67 NEAR Tgas used
+    assert_gas_bound(profile.all_gas(), 36); // less than 36 NEAR Tgas used
 
     // Approve giving ERC-20 tokens to the pool
     helper.approve_erc20_tokens(&token_a, pool.address());
@@ -57,8 +57,8 @@ fn test_1inch_liquidity_protocol() {
             max_token_b: 10_000.into(),
         },
     );
-    assert!(result.gas_used >= 302_000); // more than 302k EVM gas used
-    assert_gas_bound(profile.all_gas(), 82); // less than 82 NEAR Tgas used
+    assert!(result.gas_used >= 2_000); // more than 302k EVM gas used
+    assert_gas_bound(profile.all_gas(), 46); // less than 46 NEAR Tgas used
 
     // Same here
     helper.runner.context.block_timestamp += 10_000_000 * 1_000_000_000;
@@ -73,7 +73,7 @@ fn test_1inch_liquidity_protocol() {
         },
     );
     assert!(result.gas_used >= 210_000); // more than 210k EVM gas used
-    assert_gas_bound(profile.all_gas(), 90); // less than 90 NEAR Tgas used
+    assert_gas_bound(profile.all_gas(), 50); // less than 49 NEAR Tgas used
 
     let (result, profile) = helper.pool_withdraw(
         &pool,
@@ -84,7 +84,7 @@ fn test_1inch_liquidity_protocol() {
         },
     );
     assert!(result.gas_used >= 150_000); // more than 150k EVM gas used
-    assert_gas_bound(profile.all_gas(), 69); // less than 69 NEAR Tgas used
+    assert_gas_bound(profile.all_gas(), 40); // less than 40 NEAR Tgas used
 }
 
 #[test]
@@ -105,8 +105,8 @@ fn test_1_inch_limit_order_deploy() {
     // at least 70% of which is from wasm execution
     let wasm_fraction = 100 * profile.wasm_gas() / profile.all_gas();
     assert!(
-        wasm_fraction > 65,
-        "{}% is not greater than 65%",
+        wasm_fraction >= 45,
+        "{}% is not greater than 45%",
         wasm_fraction
     );
 }

--- a/engine-tests/src/tests/one_inch.rs
+++ b/engine-tests/src/tests/one_inch.rs
@@ -57,7 +57,7 @@ fn test_1inch_liquidity_protocol() {
             max_token_b: 10_000.into(),
         },
     );
-    assert!(result.gas_used >= 2_000); // more than 302k EVM gas used
+    assert!(result.gas_used >= 302_000); // more than 302k EVM gas used
     assert_gas_bound(profile.all_gas(), 46); // less than 46 NEAR Tgas used
 
     // Same here
@@ -100,9 +100,9 @@ fn test_1_inch_limit_order_deploy() {
 
     // more than 3.5 million Ethereum gas used
     assert!(result.gas_used > 3_500_000);
-    // less than 27 NEAR Tgas used
-    assert_gas_bound(profile.all_gas(), 28);
-    // at least 70% of which is from wasm execution
+    // less than 14 NEAR Tgas used
+    assert_gas_bound(profile.all_gas(), 14);
+    // at least 45% of which is from wasm execution
     let wasm_fraction = 100 * profile.wasm_gas() / profile.all_gas();
     assert!(
         wasm_fraction >= 45,

--- a/engine-tests/src/tests/sanity.rs
+++ b/engine-tests/src/tests/sanity.rs
@@ -93,7 +93,7 @@ fn test_deploy_largest_contract() {
     );
 
     // Less than 28 NEAR Tgas
-    test_utils::assert_gas_bound(profile.all_gas(), 28);
+    test_utils::assert_gas_bound(profile.all_gas(), 15);
 }
 
 #[test]

--- a/engine-tests/src/tests/uniswap.rs
+++ b/engine-tests/src/tests/uniswap.rs
@@ -29,13 +29,13 @@ fn test_uniswap_exact_output() {
 
     let (_result, profile) =
         context.add_equal_liquidity(LIQUIDITY_AMOUNT.into(), &token_a, &token_b);
-    test_utils::assert_gas_bound(profile.all_gas(), 114);
+    test_utils::assert_gas_bound(profile.all_gas(), 64);
     let wasm_fraction = 100 * profile.wasm_gas() / profile.all_gas();
     assert!(wasm_fraction >= 46, "{}% not more than 46%", wasm_fraction);
 
     let (_amount_in, profile) =
         context.exact_output_single(&token_a, &token_b, OUTPUT_AMOUNT.into());
-    test_utils::assert_gas_bound(profile.all_gas(), 68);
+    test_utils::assert_gas_bound(profile.all_gas(), 36);
     let wasm_fraction = 100 * profile.wasm_gas() / profile.all_gas();
     assert!(wasm_fraction >= 52, "{}% not more than 52%", wasm_fraction);
 }

--- a/engine-tests/src/tests/uniswap.rs
+++ b/engine-tests/src/tests/uniswap.rs
@@ -31,13 +31,13 @@ fn test_uniswap_exact_output() {
         context.add_equal_liquidity(LIQUIDITY_AMOUNT.into(), &token_a, &token_b);
     test_utils::assert_gas_bound(profile.all_gas(), 114);
     let wasm_fraction = 100 * profile.wasm_gas() / profile.all_gas();
-    assert!(wasm_fraction >= 68, "{}% not more than 68%", wasm_fraction);
+    assert!(wasm_fraction >= 46, "{}% not more than 46%", wasm_fraction);
 
     let (_amount_in, profile) =
         context.exact_output_single(&token_a, &token_b, OUTPUT_AMOUNT.into());
     test_utils::assert_gas_bound(profile.all_gas(), 68);
     let wasm_fraction = 100 * profile.wasm_gas() / profile.all_gas();
-    assert!(wasm_fraction >= 72, "{}% not more than 72%", wasm_fraction);
+    assert!(wasm_fraction >= 52, "{}% not more than 52%", wasm_fraction);
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]


### PR DESCRIPTION
NEAR is reducing the wasm cost again: near/nearcore#5365

Revisited our gas usage regression tests with the new bounds.

Related to: #380 