### PR TITLE
Feat(tests): Uniswap multi-hop swap benchmark (#415)

### DIFF
--- a/engine-tests/src/test_utils/uniswap.rs
+++ b/engine-tests/src/test_utils/uniswap.rs
@@ -303,6 +303,16 @@ pub struct ExactOutputSingleParams {
     pub price_limit: U256,
 }
 
+pub struct ExactInputParams {
+    pub token_in: Address,
+    // Vec of poolFee + tokenAddress
+    pub path: Vec<(u64, Address)>,
+    pub recipient: Address,
+    pub deadline: U256,
+    pub amount_in: U256,
+    pub amount_out_min: U256,
+}
+
 impl SwapRouter {
     pub fn exact_output_single(
         &self,
@@ -323,6 +333,42 @@ impl SwapRouter {
                 ethabi::Token::Uint(params.amount_out),
                 ethabi::Token::Uint(params.amount_in_max),
                 ethabi::Token::Uint(params.price_limit),
+            ])])
+            .unwrap();
+
+        TransactionLegacy {
+            nonce,
+            gas_price: Default::default(),
+            gas_limit: u64::MAX.into(),
+            to: Some(self.0.address),
+            value: Default::default(),
+            data,
+        }
+    }
+
+    pub fn exact_input(&self, params: ExactInputParams, nonce: U256) -> TransactionLegacy {
+        let path: Vec<u8> = {
+            // The encoding here is 32-byte address, then 3-byte (24-bit) fee, alternating
+            let mut result = Vec::with_capacity(32 + 35 * params.path.len());
+            result.extend_from_slice(params.token_in.as_bytes());
+            for (fee, token) in params.path.iter() {
+                let fee_bytes = fee.to_be_bytes();
+                result.extend_from_slice(&fee_bytes[5..8]);
+                result.extend_from_slice(token.as_bytes());
+            }
+            result
+        };
+        let data = self
+            .0
+            .abi
+            .function("exactInput")
+            .unwrap()
+            .encode_input(&[ethabi::Token::Tuple(vec![
+                ethabi::Token::Bytes(path),
+                ethabi::Token::Address(params.recipient.raw()),
+                ethabi::Token::Uint(params.deadline),
+                ethabi::Token::Uint(params.amount_in),
+                ethabi::Token::Uint(params.amount_out_min),
             ])])
             .unwrap();
 


### PR DESCRIPTION
The folks on the contract runtime team at nearcore have asked for a test they can try to optimize the performance of. I put together a test where we do a uniswap transaction through 10 pools. This transaction costs 970k EVM gas, and currently 410 Tgas on NEAR. It would be great if the contract runtime team could help us optimize to the point that this transaction costs less than 200 Tgas (factor of 2 improvement).

This test does not make any assertions (other than that the transactions executed successfully) because we do not want to enforce the current cost of this transaction. The test prints results to stdout because this was requested by the contract runtime team.

To run the test:

```
cargo test -p aurora-engine-tests --features mainnet-test test_uniswap_input_multihop -- --nocapture
```

Note: you will need to have run `make mainnet-test-build` first to compile all the wasm and EVM artifacts that are deployed here.

Sample output:

```
------------------------------
Action gas: 0
------ Host functions --------
base -> 591756728085 [0% host]
contract_compile_base -> 35445963 [0% host]
contract_compile_bytes -> 216328638000 [0% host]
read_memory_base -> 2771674718400 [1% host]
read_memory_byte -> 159614171337 [0% host]
write_memory_base -> 2108453735472 [0% host]
write_memory_byte -> 3041404671780 [1% host]
read_register_base -> 1895425385058 [0% host]
read_register_byte -> 110062115598 [0% host]
write_register_base -> 2498735607792 [1% host]
write_register_byte -> 6817971979260 [2% host]
utf8_decoding_base -> 9335337183 [0% host]
utf8_decoding_byte -> 32365433169 [0% host]
keccak256_base -> 17638473825 [0% host]
keccak256_byte -> 13118845155 [0% host]
ecrecover_base -> 3365369625000 [1% host]
log_base -> 10629939150 [0% host]
log_byte -> 1465065801 [0% host]
storage_write_base -> 5777706240000 [2% host]
storage_write_key_byte -> 261350470836 [0% host]
storage_write_value_byte -> 89333392320 [0% host]
storage_write_evicted_byte -> 82220305920 [0% host]
storage_read_base -> 48805028419500 [19% host]
storage_read_key_byte -> 885644826729 [0% host]
storage_read_value_byte -> 10044417158640 [4% host]
storage_remove_base -> 427784244000 [0% host]
storage_remove_key_byte -> 17734258176 [0% host]
touching_trie_node -> 156511011600720 [63% host]
------ Actions --------
------------------------------

NEAR_GAS_WASM 163937885590116
NEAR_GAS_TOTAL 410501502422985
```

cc @nagisa @olonho