### PR TITLE
Move engine transactions module to engine-transactions crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,7 @@ dependencies = [
  "aurora-bn",
  "aurora-engine-precompiles",
  "aurora-engine-sdk",
+ "aurora-engine-transactions",
  "aurora-engine-types",
  "base64 0.13.0",
  "blake2 0.9.1 (git+https://github.com/near/near-blake2.git)",
@@ -214,6 +215,17 @@ dependencies = [
  "sha3 0.9.1",
  "tempfile",
  "wasmer-near",
+]
+
+[[package]]
+name = "aurora-engine-transactions"
+version = "1.0.0"
+dependencies = [
+ "aurora-engine-precompiles",
+ "aurora-engine-sdk",
+ "aurora-engine-types",
+ "evm",
+ "rlp",
 ]
 
 [[package]]
@@ -1202,6 +1214,7 @@ version = "0.1.0"
 dependencies = [
  "aurora-engine",
  "aurora-engine-sdk",
+ "aurora-engine-transactions",
  "aurora-engine-types",
  "base64 0.13.0",
  "borsh 0.8.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,7 @@ dependencies = [
  "aurora-engine",
  "aurora-engine-precompiles",
  "aurora-engine-sdk",
+ "aurora-engine-transactions",
  "aurora-engine-types",
  "base64 0.13.0",
  "borsh 0.8.2",
@@ -225,6 +226,7 @@ dependencies = [
  "aurora-engine-sdk",
  "aurora-engine-types",
  "evm",
+ "hex",
  "rlp",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ members = [
     "engine-standalone-storage",
     "engine-standalone-tracing",
     "engine-tests",
+    "engine-transactions",
     "engine-types",
 ]
 exclude = [

--- a/engine-precompiles/Cargo.toml
+++ b/engine-precompiles/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aurora-engine-precompiles"
 version = "1.0.0"
-authors = ["NEAR <hello@near.org>"]
+authors = ["Aurora Labs <hello@aurora.dev>"]
 edition = "2018"
 description = ""
 documentation = ""

--- a/engine-sdk/Cargo.toml
+++ b/engine-sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aurora-engine-sdk"
 version = "1.0.0"
-authors = ["NEAR <hello@near.org>"]
+authors = ["Aurora Labs <hello@aurora.dev>"]
 edition = "2018"
 description = ""
 documentation = ""

--- a/engine-standalone-storage/Cargo.toml
+++ b/engine-standalone-storage/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["lib"]
 aurora-engine = { path = "../engine", default-features = false, features = ["std"] }
 aurora-engine-types = { path = "../engine-types", default-features = false, features = ["std"] }
 aurora-engine-sdk = { path = "../engine-sdk", default-features = false, features = ["std"] }
+aurora-engine-transactions = { path = "../engine-transactions", default-features = false }
 borsh = { version = "0.8.2" }
 evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", default-features = false }
 rocksdb = "0.16.0"

--- a/engine-standalone-storage/Cargo.toml
+++ b/engine-standalone-storage/Cargo.toml
@@ -2,7 +2,7 @@
 name = "engine-standalone-storage"
 version = "0.1.0"
 edition = "2018"
-authors = ["Aurora <hello@aurora.dev>"]
+authors = ["Aurora Labs <hello@aurora.dev>"]
 description = "Aurora engine standalone storage library. Provides the storage backend used by the standalone engine."
 homepage = "https://github.com/aurora-is-near/aurora-engine"
 repository = "https://github.com/aurora-is-near/aurora-engine"

--- a/engine-standalone-storage/Cargo.toml
+++ b/engine-standalone-storage/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["lib"]
 aurora-engine = { path = "../engine", default-features = false, features = ["std"] }
 aurora-engine-types = { path = "../engine-types", default-features = false, features = ["std"] }
 aurora-engine-sdk = { path = "../engine-sdk", default-features = false, features = ["std"] }
-aurora-engine-transactions = { path = "../engine-transactions", default-features = false }
+aurora-engine-transactions = { path = "../engine-transactions", default-features = false, features = ["std"] }
 borsh = { version = "0.8.2" }
 evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", default-features = false }
 rocksdb = "0.16.0"

--- a/engine-standalone-storage/src/relayer_db/mod.rs
+++ b/engine-standalone-storage/src/relayer_db/mod.rs
@@ -1,6 +1,6 @@
 use aurora_engine::engine;
-use aurora_engine::transaction::EthTransactionKind;
 use aurora_engine_sdk::env::{self, Env, DEFAULT_PREPAID_GAS};
+use aurora_engine_transactions::EthTransactionKind;
 use aurora_engine_types::account_id::AccountId;
 use aurora_engine_types::H256;
 use postgres::fallible_iterator::FallibleIterator;
@@ -166,16 +166,19 @@ pub mod error {
             Self::Storage(e)
         }
     }
+
     impl From<postgres::Error> for Error {
         fn from(e: postgres::Error) -> Self {
             Self::Postgres(e)
         }
     }
+
     impl From<engine::EngineStateError> for Error {
         fn from(e: engine::EngineStateError) -> Self {
             Self::EngineState(e)
         }
     }
+
     impl From<engine::EngineError> for Error {
         fn from(e: engine::EngineError) -> Self {
             Self::Engine(e)

--- a/engine-standalone-storage/src/relayer_db/types.rs
+++ b/engine-standalone-storage/src/relayer_db/types.rs
@@ -1,4 +1,4 @@
-use aurora_engine::transaction::{
+use aurora_engine_transactions::{
     legacy::{LegacyEthSignedTransaction, TransactionLegacy},
     EthTransactionKind,
 };

--- a/engine-standalone-storage/src/sync/types.rs
+++ b/engine-standalone-storage/src/sync/types.rs
@@ -1,5 +1,5 @@
 use aurora_engine::parameters;
-use aurora_engine::transaction::EthTransactionKind;
+use aurora_engine_transactions::EthTransactionKind;
 use aurora_engine_types::account_id::AccountId;
 use aurora_engine_types::H256;
 

--- a/engine-standalone-tracing/Cargo.toml
+++ b/engine-standalone-tracing/Cargo.toml
@@ -2,7 +2,7 @@
 name = "engine-standalone-tracing"
 version = "0.1.0"
 edition = "2018"
-authors = ["Aurora <hello@aurora.dev>"]
+authors = ["Aurora Labs <hello@aurora.dev>"]
 description = "Aurora engine standalone tracing library. Provides functions and types for extracing geth-like traces from standalone engine execution."
 homepage = "https://github.com/aurora-is-near/aurora-engine"
 repository = "https://github.com/aurora-is-near/aurora-engine"

--- a/engine-tests/Cargo.toml
+++ b/engine-tests/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aurora-engine-tests"
 version = "1.0.0"
-authors = ["NEAR <hello@near.org>"]
+authors = ["Aurora Labs <hello@aurora.dev>"]
 edition = "2018"
 description = ""
 documentation = ""
@@ -17,7 +17,7 @@ aurora-engine = { path = "../engine", default-features = false, features = ["std
 aurora-engine-types = { path = "../engine-types", default-features = false, features = ["std"] }
 aurora-engine-sdk = { path = "../engine-sdk", default-features = false, features = ["std"] }
 aurora-engine-precompiles = { path = "../engine-precompiles", default-features = false, features = ["std"] }
-aurora-engine-transactions = { path = "../engine-transactions", default-features = false }
+aurora-engine-transactions = { path = "../engine-transactions", default-features = false, features = ["std"] }
 engine-standalone-storage = { path = "../engine-standalone-storage", default-features = false }
 engine-standalone-tracing = { path = "../engine-standalone-tracing", default-features = false }
 borsh = { version = "0.8.2", default-features = false }

--- a/engine-tests/Cargo.toml
+++ b/engine-tests/Cargo.toml
@@ -17,6 +17,7 @@ aurora-engine = { path = "../engine", default-features = false, features = ["std
 aurora-engine-types = { path = "../engine-types", default-features = false, features = ["std"] }
 aurora-engine-sdk = { path = "../engine-sdk", default-features = false, features = ["std"] }
 aurora-engine-precompiles = { path = "../engine-precompiles", default-features = false, features = ["std"] }
+aurora-engine-transactions = { path = "../engine-transactions", default-features = false }
 engine-standalone-storage = { path = "../engine-standalone-storage", default-features = false }
 engine-standalone-tracing = { path = "../engine-standalone-tracing", default-features = false }
 borsh = { version = "0.8.2", default-features = false }

--- a/engine-tests/src/benches/nft_pagination.rs
+++ b/engine-tests/src/benches/nft_pagination.rs
@@ -1,6 +1,6 @@
 use crate::prelude::{Address, Wei, U256};
 use crate::test_utils::{self, solidity};
-use aurora_engine::transaction::legacy::TransactionLegacy;
+use aurora_engine_transactions::legacy::TransactionLegacy;
 use secp256k1::SecretKey;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -54,6 +54,7 @@ pub(crate) fn measure_gas_usage(
 }
 
 struct MarketPlaceConstructor(solidity::ContractConstructor);
+
 struct MarketPlace(solidity::DeployedContract);
 
 impl MarketPlaceConstructor {

--- a/engine-tests/src/prelude.rs
+++ b/engine-tests/src/prelude.rs
@@ -4,12 +4,13 @@ mod v0 {
     #[cfg(feature = "meta-call")]
     pub use aurora_engine::meta_parsing;
     pub use aurora_engine::parameters;
-    pub use aurora_engine::transaction;
     pub use aurora_engine_sdk as sdk;
+    pub use aurora_engine_transactions as transactions;
     pub use aurora_engine_types::parameters::*;
     pub use aurora_engine_types::storage;
     pub use aurora_engine_types::types::*;
     pub use aurora_engine_types::*;
     pub use borsh::{BorshDeserialize, BorshSerialize};
 }
+
 pub use v0::*;

--- a/engine-tests/src/test_utils/erc20.rs
+++ b/engine-tests/src/test_utils/erc20.rs
@@ -1,4 +1,4 @@
-use crate::prelude::{transaction::legacy::TransactionLegacy, Address, U256};
+use crate::prelude::{transactions::legacy::TransactionLegacy, Address, U256};
 use crate::test_utils::solidity;
 use std::path::{Path, PathBuf};
 use std::sync::Once;

--- a/engine-tests/src/test_utils/exit_precompile.rs
+++ b/engine-tests/src/test_utils/exit_precompile.rs
@@ -1,5 +1,5 @@
 use crate::prelude::{
-    parameters::SubmitResult, transaction::legacy::TransactionLegacy, Address, Wei, U256,
+    parameters::SubmitResult, transactions::legacy::TransactionLegacy, Address, Wei, U256,
 };
 use crate::test_utils::{self, solidity, AuroraRunner, Signer};
 

--- a/engine-tests/src/test_utils/mod.rs
+++ b/engine-tests/src/test_utils/mod.rs
@@ -14,7 +14,7 @@ use secp256k1::{self, Message, PublicKey, SecretKey};
 
 use crate::prelude::fungible_token::{FungibleToken, FungibleTokenMetadata};
 use crate::prelude::parameters::{InitCallArgs, NewCallArgs, SubmitResult, TransactionStatus};
-use crate::prelude::transaction::{
+use crate::prelude::transactions::{
     eip_1559::{self, SignedTransaction1559, Transaction1559},
     eip_2930::{self, SignedTransaction2930, Transaction2930},
     legacy::{LegacyEthSignedTransaction, TransactionLegacy},

--- a/engine-tests/src/test_utils/one_inch/liquidity_protocol.rs
+++ b/engine-tests/src/test_utils/one_inch/liquidity_protocol.rs
@@ -27,7 +27,7 @@ impl<'a> Helper<'a> {
         let (result, profile) = self
             .runner
             .submit_with_signer_profiled(self.signer, |nonce| {
-                crate::prelude::transaction::legacy::TransactionLegacy {
+                crate::prelude::transactions::legacy::TransactionLegacy {
                     nonce,
                     gas_price: Default::default(),
                     gas_limit: u64::MAX.into(),

--- a/engine-tests/src/test_utils/random.rs
+++ b/engine-tests/src/test_utils/random.rs
@@ -1,6 +1,6 @@
 use crate::prelude::U256;
 use crate::test_utils::{self, solidity, AuroraRunner, Signer};
-use aurora_engine::transaction::legacy::TransactionLegacy;
+use aurora_engine_transactions::legacy::TransactionLegacy;
 use aurora_engine_types::H256;
 use ethabi::Constructor;
 

--- a/engine-tests/src/test_utils/self_destruct.rs
+++ b/engine-tests/src/test_utils/self_destruct.rs
@@ -1,5 +1,5 @@
 use crate::prelude::{
-    parameters::CallArgs, parameters::FunctionCallArgsV2, transaction::legacy::TransactionLegacy,
+    parameters::CallArgs, parameters::FunctionCallArgsV2, transactions::legacy::TransactionLegacy,
     Address, WeiU256, U256,
 };
 use crate::test_utils::{self, solidity, AuroraRunner, Signer};

--- a/engine-tests/src/test_utils/solidity.rs
+++ b/engine-tests/src/test_utils/solidity.rs
@@ -1,4 +1,4 @@
-use crate::prelude::{transaction::legacy::TransactionLegacy, Address, U256};
+use crate::prelude::{transactions::legacy::TransactionLegacy, Address, U256};
 use near_sdk::serde_json;
 use serde::Deserialize;
 use std::fs;

--- a/engine-tests/src/test_utils/standalone/mocks/block.rs
+++ b/engine-tests/src/test_utils/standalone/mocks/block.rs
@@ -1,4 +1,4 @@
-use aurora_engine::transaction::legacy::LegacyEthSignedTransaction;
+use aurora_engine_transactions::legacy::LegacyEthSignedTransaction;
 
 /// A vastly simplified block structure
 pub struct Block {

--- a/engine-tests/src/test_utils/standalone/mod.rs
+++ b/engine-tests/src/test_utils/standalone/mod.rs
@@ -1,7 +1,7 @@
 use aurora_engine::engine;
 use aurora_engine::parameters::{CallArgs, DeployErc20TokenArgs, SubmitResult, TransactionStatus};
-use aurora_engine::transaction::legacy::{LegacyEthSignedTransaction, TransactionLegacy};
 use aurora_engine_sdk::env::{self, Env};
+use aurora_engine_transactions::legacy::{LegacyEthSignedTransaction, TransactionLegacy};
 use aurora_engine_types::types::{Address, NearGas, Wei};
 use aurora_engine_types::{H256, U256};
 use borsh::BorshDeserialize;

--- a/engine-tests/src/test_utils/standard_precompiles.rs
+++ b/engine-tests/src/test_utils/standard_precompiles.rs
@@ -1,4 +1,4 @@
-use crate::prelude::{transaction::legacy::TransactionLegacy, U256};
+use crate::prelude::{transactions::legacy::TransactionLegacy, U256};
 use crate::test_utils::solidity;
 use std::path::{Path, PathBuf};
 

--- a/engine-tests/src/test_utils/uniswap.rs
+++ b/engine-tests/src/test_utils/uniswap.rs
@@ -1,6 +1,6 @@
 use crate::prelude::{Address, U256};
 use crate::test_utils::solidity;
-use aurora_engine::transaction::legacy::TransactionLegacy;
+use aurora_engine_transactions::legacy::TransactionLegacy;
 use std::ops::Not;
 use std::path::{Path, PathBuf};
 use std::process::Command;

--- a/engine-tests/src/test_utils/weth.rs
+++ b/engine-tests/src/test_utils/weth.rs
@@ -1,4 +1,4 @@
-use aurora_engine::transaction::legacy::TransactionLegacy;
+use aurora_engine_transactions::legacy::TransactionLegacy;
 use aurora_engine_types::types::{Address, Wei};
 use aurora_engine_types::U256;
 

--- a/engine-tests/src/tests/access_lists.rs
+++ b/engine-tests/src/tests/access_lists.rs
@@ -1,8 +1,8 @@
+use crate::prelude::transactions::eip_2930::{self, AccessTuple, Transaction2930};
+use crate::prelude::transactions::EthTransactionKind;
 use crate::prelude::Wei;
 use crate::prelude::{H256, U256};
 use crate::test_utils;
-use aurora_engine::transaction::eip_2930::{self, AccessTuple, Transaction2930};
-use aurora_engine::transaction::EthTransactionKind;
 use std::convert::TryFrom;
 use std::iter;
 

--- a/engine-tests/src/tests/eip1559.rs
+++ b/engine-tests/src/tests/eip1559.rs
@@ -1,10 +1,10 @@
+use crate::prelude::transactions::eip_1559::{self, SignedTransaction1559, Transaction1559};
+use crate::prelude::transactions::eip_2930::AccessTuple;
+use crate::prelude::transactions::EthTransactionKind;
 use crate::prelude::Wei;
 use crate::prelude::{H256, U256};
 use crate::test_utils;
 use aurora_engine::parameters::SubmitResult;
-use aurora_engine::transaction::eip_1559::{self, SignedTransaction1559, Transaction1559};
-use aurora_engine::transaction::eip_2930::AccessTuple;
-use aurora_engine::transaction::EthTransactionKind;
 use borsh::BorshDeserialize;
 use std::convert::TryFrom;
 use std::iter;

--- a/engine-tests/src/tests/erc20_connector.rs
+++ b/engine-tests/src/tests/erc20_connector.rs
@@ -2,7 +2,7 @@ use crate::prelude::{Address, Balance, TryInto, Wei, WeiU256, U256};
 use crate::test_utils;
 use crate::test_utils::{create_eth_transaction, origin, AuroraRunner};
 use aurora_engine::parameters::{CallArgs, FunctionCallArgsV2, SubmitResult};
-use aurora_engine::transaction::legacy::LegacyEthSignedTransaction;
+use aurora_engine_transactions::legacy::LegacyEthSignedTransaction;
 use borsh::{BorshDeserialize, BorshSerialize};
 use ethabi::Token;
 use near_vm_logic::VMOutcome;
@@ -520,7 +520,7 @@ mod sim_tests {
             nep_141_balance_of(
                 aurora.contract.account_id.as_str(),
                 &aurora.contract,
-                &aurora
+                &aurora,
             ),
             (INITIAL_ETH_BALANCE - ETH_EXIT_AMOUNT).into()
         );
@@ -615,7 +615,7 @@ mod sim_tests {
             nep_141_balance_of(
                 aurora.contract.account_id.as_str(),
                 &aurora.contract,
-                &aurora
+                &aurora,
             ),
             INITIAL_ETH_BALANCE.into()
         );

--- a/engine-tests/src/tests/one_inch.rs
+++ b/engine-tests/src/tests/one_inch.rs
@@ -125,7 +125,7 @@ fn deploy_1_inch_limit_order_contract(
         test_utils::solidity::ContractConstructor::compile_from_extended_json(contract_path);
 
     let nonce = signer.use_nonce();
-    let deploy_tx = crate::prelude::transaction::legacy::TransactionLegacy {
+    let deploy_tx = crate::prelude::transactions::legacy::TransactionLegacy {
         nonce: nonce.into(),
         gas_price: Default::default(),
         gas_limit: u64::MAX.into(),

--- a/engine-tests/src/tests/sanity.rs
+++ b/engine-tests/src/tests/sanity.rs
@@ -194,7 +194,7 @@ fn test_override_state() {
     // deploy contract
     let result = runner
         .submit_with_signer(&mut account1, |nonce| {
-            crate::prelude::transaction::legacy::TransactionLegacy {
+            crate::prelude::transactions::legacy::TransactionLegacy {
                 nonce,
                 gas_price: Default::default(),
                 gas_limit: u64::MAX.into(),

--- a/engine-tests/src/tests/standalone/sync.rs
+++ b/engine-tests/src/tests/standalone/sync.rs
@@ -304,7 +304,7 @@ fn test_consume_submit_message() {
     let signed_transaction =
         test_utils::sign_transaction(transaction, Some(runner.chain_id), &signer.secret_key);
     let eth_transaction =
-        aurora_engine::transaction::EthTransactionKind::Legacy(signed_transaction);
+        crate::prelude::transactions::EthTransactionKind::Legacy(signed_transaction);
 
     let transaction_message = sync::types::TransactionMessage {
         block_hash,

--- a/engine-tests/src/tests/standalone/tracing.rs
+++ b/engine-tests/src/tests/standalone/tracing.rs
@@ -130,7 +130,7 @@ fn test_evm_tracing() {
     runner.init_evm();
 
     // Deploy contract
-    let deploy_tx = aurora_engine::transaction::legacy::TransactionLegacy {
+    let deploy_tx = aurora_engine_transactions::legacy::TransactionLegacy {
         nonce: signer.use_nonce().into(),
         gas_price: U256::zero(),
         gas_limit: u64::MAX.into(),
@@ -145,7 +145,7 @@ fn test_evm_tracing() {
         Address::try_from_slice(test_utils::unwrap_success_slice(&result)).unwrap();
 
     // Interact with contract (and trace execution)
-    let tx = aurora_engine::transaction::legacy::TransactionLegacy {
+    let tx = aurora_engine_transactions::legacy::TransactionLegacy {
         nonce: signer.use_nonce().into(),
         gas_price: U256::zero(),
         gas_limit: 90_000.into(),

--- a/engine-transactions/Cargo.toml
+++ b/engine-transactions/Cargo.toml
@@ -18,6 +18,7 @@ aurora-engine-sdk = { path = "../engine-sdk", default-features = false }
 aurora-engine-precompiles = { path = "../engine-precompiles", default-features = false }
 evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", default-features = false }
 rlp = { version = "0.5.0", default-features = false }
+hex = { version = "0.4", default-features = false, features = ["alloc"] }
 
 [features]
 std = ["aurora-engine-types/std", "aurora-engine-precompiles/std"]

--- a/engine-transactions/Cargo.toml
+++ b/engine-transactions/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aurora-engine-transactions"
 version = "1.0.0"
-authors = ["NEAR <hello@near.org>"]
+authors = ["Aurora Labs <hello@aurora.dev>"]
 edition = "2018"
 description = ""
 documentation = ""
@@ -21,4 +21,4 @@ rlp = { version = "0.5.0", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 
 [features]
-std = ["aurora-engine-types/std", "aurora-engine-precompiles/std"]
+std = ["aurora-engine-types/std", "aurora-engine-precompiles/std", "evm/std", "rlp/std", "hex/std"]

--- a/engine-transactions/Cargo.toml
+++ b/engine-transactions/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "aurora-engine-transactions"
+version = "1.0.0"
+authors = ["NEAR <hello@near.org>"]
+edition = "2018"
+description = ""
+documentation = ""
+readme = true
+homepage = "https://github.com/aurora-is-near/aurora-engine"
+repository = "https://github.com/aurora-is-near/aurora-engine"
+license = "CC0-1.0"
+publish = false
+autobenches = false
+
+[dependencies]
+aurora-engine-types = { path = "../engine-types", default-features = false }
+aurora-engine-sdk = { path = "../engine-sdk", default-features = false }
+aurora-engine-precompiles = { path = "../engine-precompiles", default-features = false }
+evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", default-features = false }
+rlp = { version = "0.5.0", default-features = false }
+
+[features]
+std = ["aurora-engine-types/std", "aurora-engine-precompiles/std"]

--- a/engine-transactions/src/eip_1559.rs
+++ b/engine-transactions/src/eip_1559.rs
@@ -1,34 +1,22 @@
-use crate::prelude::precompiles::secp256k1::ecrecover;
-use crate::prelude::{sdk, Address, Vec, Wei, H160, H256, U256};
+use crate::eip_2930::AccessTuple;
+use aurora_engine_precompiles::secp256k1::ecrecover;
+use aurora_engine_types::types::{Address, Wei};
+use aurora_engine_types::{Vec, U256};
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
 
-/// Type indicator (per EIP-2718) for access list transactions
-pub const TYPE_BYTE: u8 = 0x01;
+/// Type indicator (per EIP-1559)
+pub const TYPE_BYTE: u8 = 0x02;
 
+/// A EIP-1559 transaction kind from the London hard fork.
+///
+/// See [EIP-1559](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md)
+/// for more details.
 #[derive(Debug, Eq, PartialEq, Clone)]
-pub struct AccessTuple {
-    pub address: H160,
-    pub storage_keys: Vec<H256>,
-}
-
-impl Decodable for AccessTuple {
-    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
-        let address = rlp.val_at(0)?;
-        let storage_keys = rlp.list_at(1)?;
-
-        Ok(Self {
-            address,
-            storage_keys,
-        })
-    }
-}
-
-/// See https://eips.ethereum.org/EIPS/eip-2930
-#[derive(Debug, Eq, PartialEq, Clone)]
-pub struct Transaction2930 {
+pub struct Transaction1559 {
     pub chain_id: u64,
     pub nonce: U256,
-    pub gas_price: U256,
+    pub max_priority_fee_per_gas: U256,
+    pub max_fee_per_gas: U256,
     pub gas_limit: U256,
     pub to: Option<Address>,
     pub value: Wei,
@@ -36,22 +24,23 @@ pub struct Transaction2930 {
     pub access_list: Vec<AccessTuple>,
 }
 
-impl Transaction2930 {
+impl Transaction1559 {
     /// RLP encoding of the data for an unsigned message (used to make signature)
     pub fn rlp_append_unsigned(&self, s: &mut RlpStream) {
-        self.rlp_append(s, 8);
+        self.rlp_append(s, 9);
     }
 
     /// RLP encoding for a signed message (used to encode the transaction for sending to tx pool)
     pub fn rlp_append_signed(&self, s: &mut RlpStream) {
-        self.rlp_append(s, 11);
+        self.rlp_append(s, 12);
     }
 
     fn rlp_append(&self, s: &mut RlpStream, list_len: usize) {
         s.begin_list(list_len);
         s.append(&self.chain_id);
         s.append(&self.nonce);
-        s.append(&self.gas_price);
+        s.append(&self.max_priority_fee_per_gas);
+        s.append(&self.max_fee_per_gas);
         s.append(&self.gas_limit);
         match self.to.as_ref() {
             None => s.append(&""),
@@ -72,20 +61,20 @@ impl Transaction2930 {
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]
-pub struct SignedTransaction2930 {
-    pub transaction: Transaction2930,
+pub struct SignedTransaction1559 {
+    pub transaction: Transaction1559,
     /// The parity (0 for even, 1 for odd) of the y-value of a secp256k1 signature.
     pub parity: u8,
     pub r: U256,
     pub s: U256,
 }
 
-impl SignedTransaction2930 {
+impl SignedTransaction1559 {
     pub fn sender(&self) -> Option<Address> {
         let mut rlp_stream = RlpStream::new();
         rlp_stream.append(&TYPE_BYTE);
         self.transaction.rlp_append_unsigned(&mut rlp_stream);
-        let message_hash = sdk::keccak(rlp_stream.as_raw());
+        let message_hash = aurora_engine_sdk::keccak(rlp_stream.as_raw());
         ecrecover(
             message_hash,
             &super::vrs_to_arr(self.parity, self.r, self.s),
@@ -94,7 +83,7 @@ impl SignedTransaction2930 {
     }
 }
 
-impl Encodable for SignedTransaction2930 {
+impl Encodable for SignedTransaction1559 {
     fn rlp_append(&self, s: &mut RlpStream) {
         self.transaction.rlp_append_signed(s);
         s.append(&self.parity);
@@ -103,27 +92,29 @@ impl Encodable for SignedTransaction2930 {
     }
 }
 
-impl Decodable for SignedTransaction2930 {
+impl Decodable for SignedTransaction1559 {
     fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
-        if rlp.item_count() != Ok(11) {
+        if rlp.item_count() != Ok(12) {
             return Err(rlp::DecoderError::RlpIncorrectListLen);
         }
         let chain_id = rlp.val_at(0)?;
         let nonce = rlp.val_at(1)?;
-        let gas_price = rlp.val_at(2)?;
-        let gas_limit = rlp.val_at(3)?;
-        let to = super::rlp_extract_to(rlp, 4)?;
-        let value = Wei::new(rlp.val_at(5)?);
-        let data = rlp.val_at(6)?;
-        let access_list = rlp.list_at(7)?;
-        let parity = rlp.val_at(8)?;
-        let r = rlp.val_at(9)?;
-        let s = rlp.val_at(10)?;
+        let max_priority_fee_per_gas = rlp.val_at(2)?;
+        let max_fee_per_gas = rlp.val_at(3)?;
+        let gas_limit = rlp.val_at(4)?;
+        let to = super::rlp_extract_to(rlp, 5)?;
+        let value = Wei::new(rlp.val_at(6)?);
+        let data = rlp.val_at(7)?;
+        let access_list = rlp.list_at(8)?;
+        let parity = rlp.val_at(9)?;
+        let r = rlp.val_at(10)?;
+        let s = rlp.val_at(11)?;
         Ok(Self {
-            transaction: Transaction2930 {
+            transaction: Transaction1559 {
                 chain_id,
                 nonce,
-                gas_price,
+                max_priority_fee_per_gas,
+                max_fee_per_gas,
                 gas_limit,
                 to,
                 value,

--- a/engine-transactions/src/eip_2930.rs
+++ b/engine-transactions/src/eip_2930.rs
@@ -1,21 +1,36 @@
-use crate::prelude::precompiles::secp256k1::ecrecover;
-use crate::prelude::{Address, Vec, Wei, U256};
-use crate::transaction::eip_2930::AccessTuple;
+use aurora_engine_precompiles::secp256k1::ecrecover;
+use aurora_engine_sdk as sdk;
+use aurora_engine_types::types::{Address, Wei};
+use aurora_engine_types::{Vec, H160, H256, U256};
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
 
-/// Type indicator (per EIP-1559)
-pub const TYPE_BYTE: u8 = 0x02;
+/// Type indicator (per EIP-2718) for access list transactions
+pub const TYPE_BYTE: u8 = 0x01;
 
-/// A EIP-1559 transaction kind from the London hard fork.
-///
-/// See [EIP-1559](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md)
-/// for more details.
 #[derive(Debug, Eq, PartialEq, Clone)]
-pub struct Transaction1559 {
+pub struct AccessTuple {
+    pub address: H160,
+    pub storage_keys: Vec<H256>,
+}
+
+impl Decodable for AccessTuple {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
+        let address = rlp.val_at(0)?;
+        let storage_keys = rlp.list_at(1)?;
+
+        Ok(Self {
+            address,
+            storage_keys,
+        })
+    }
+}
+
+/// See https://eips.ethereum.org/EIPS/eip-2930
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct Transaction2930 {
     pub chain_id: u64,
     pub nonce: U256,
-    pub max_priority_fee_per_gas: U256,
-    pub max_fee_per_gas: U256,
+    pub gas_price: U256,
     pub gas_limit: U256,
     pub to: Option<Address>,
     pub value: Wei,
@@ -23,23 +38,22 @@ pub struct Transaction1559 {
     pub access_list: Vec<AccessTuple>,
 }
 
-impl Transaction1559 {
+impl Transaction2930 {
     /// RLP encoding of the data for an unsigned message (used to make signature)
     pub fn rlp_append_unsigned(&self, s: &mut RlpStream) {
-        self.rlp_append(s, 9);
+        self.rlp_append(s, 8);
     }
 
     /// RLP encoding for a signed message (used to encode the transaction for sending to tx pool)
     pub fn rlp_append_signed(&self, s: &mut RlpStream) {
-        self.rlp_append(s, 12);
+        self.rlp_append(s, 11);
     }
 
     fn rlp_append(&self, s: &mut RlpStream, list_len: usize) {
         s.begin_list(list_len);
         s.append(&self.chain_id);
         s.append(&self.nonce);
-        s.append(&self.max_priority_fee_per_gas);
-        s.append(&self.max_fee_per_gas);
+        s.append(&self.gas_price);
         s.append(&self.gas_limit);
         match self.to.as_ref() {
             None => s.append(&""),
@@ -60,20 +74,20 @@ impl Transaction1559 {
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]
-pub struct SignedTransaction1559 {
-    pub transaction: Transaction1559,
+pub struct SignedTransaction2930 {
+    pub transaction: Transaction2930,
     /// The parity (0 for even, 1 for odd) of the y-value of a secp256k1 signature.
     pub parity: u8,
     pub r: U256,
     pub s: U256,
 }
 
-impl SignedTransaction1559 {
+impl SignedTransaction2930 {
     pub fn sender(&self) -> Option<Address> {
         let mut rlp_stream = RlpStream::new();
         rlp_stream.append(&TYPE_BYTE);
         self.transaction.rlp_append_unsigned(&mut rlp_stream);
-        let message_hash = aurora_engine_sdk::keccak(rlp_stream.as_raw());
+        let message_hash = sdk::keccak(rlp_stream.as_raw());
         ecrecover(
             message_hash,
             &super::vrs_to_arr(self.parity, self.r, self.s),
@@ -82,7 +96,7 @@ impl SignedTransaction1559 {
     }
 }
 
-impl Encodable for SignedTransaction1559 {
+impl Encodable for SignedTransaction2930 {
     fn rlp_append(&self, s: &mut RlpStream) {
         self.transaction.rlp_append_signed(s);
         s.append(&self.parity);
@@ -91,29 +105,27 @@ impl Encodable for SignedTransaction1559 {
     }
 }
 
-impl Decodable for SignedTransaction1559 {
+impl Decodable for SignedTransaction2930 {
     fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
-        if rlp.item_count() != Ok(12) {
+        if rlp.item_count() != Ok(11) {
             return Err(rlp::DecoderError::RlpIncorrectListLen);
         }
         let chain_id = rlp.val_at(0)?;
         let nonce = rlp.val_at(1)?;
-        let max_priority_fee_per_gas = rlp.val_at(2)?;
-        let max_fee_per_gas = rlp.val_at(3)?;
-        let gas_limit = rlp.val_at(4)?;
-        let to = super::rlp_extract_to(rlp, 5)?;
-        let value = Wei::new(rlp.val_at(6)?);
-        let data = rlp.val_at(7)?;
-        let access_list = rlp.list_at(8)?;
-        let parity = rlp.val_at(9)?;
-        let r = rlp.val_at(10)?;
-        let s = rlp.val_at(11)?;
+        let gas_price = rlp.val_at(2)?;
+        let gas_limit = rlp.val_at(3)?;
+        let to = super::rlp_extract_to(rlp, 4)?;
+        let value = Wei::new(rlp.val_at(5)?);
+        let data = rlp.val_at(6)?;
+        let access_list = rlp.list_at(7)?;
+        let parity = rlp.val_at(8)?;
+        let r = rlp.val_at(9)?;
+        let s = rlp.val_at(10)?;
         Ok(Self {
-            transaction: Transaction1559 {
+            transaction: Transaction2930 {
                 chain_id,
                 nonce,
-                max_priority_fee_per_gas,
-                max_fee_per_gas,
+                gas_price,
                 gas_limit,
                 to,
                 value,

--- a/engine-transactions/src/legacy.rs
+++ b/engine-transactions/src/legacy.rs
@@ -151,6 +151,7 @@ impl Decodable for LegacyEthSignedTransaction {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aurora_engine_types::vec;
 
     #[test]
     fn test_eth_signed_no_chain_sender() {

--- a/engine-transactions/src/legacy.rs
+++ b/engine-transactions/src/legacy.rs
@@ -1,5 +1,7 @@
-use crate::prelude::precompiles::secp256k1::ecrecover;
-use crate::prelude::{sdk, Address, Vec, Wei, U256};
+use aurora_engine_precompiles::secp256k1::ecrecover;
+use aurora_engine_sdk as sdk;
+use aurora_engine_types::types::{Address, Wei};
+use aurora_engine_types::{Vec, U256};
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
 
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -40,7 +42,7 @@ impl TransactionLegacy {
     /// Returns self.gas as a u64, or None if self.gas > u64::MAX
     #[allow(unused)]
     pub fn get_gas_limit(&self) -> Option<u64> {
-        use crate::prelude::TryInto;
+        use aurora_engine_types::TryInto;
         self.gas_limit.try_into().ok()
     }
 

--- a/engine-transactions/src/lib.rs
+++ b/engine-transactions/src/lib.rs
@@ -1,3 +1,7 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), feature(alloc_error_handler))]
+#![cfg_attr(feature = "log", feature(panic_info_message))]
+
 use aurora_engine_types::types::{Address, Wei};
 use aurora_engine_types::{vec, TryFrom, Vec, H160, U256};
 use eip_2930::AccessTuple;

--- a/engine-transactions/src/lib.rs
+++ b/engine-transactions/src/lib.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(alloc_error_handler))]
-#![cfg_attr(feature = "log", feature(panic_info_message))]
 
 use aurora_engine_types::types::{Address, Wei};
 use aurora_engine_types::{vec, TryFrom, Vec, H160, U256};

--- a/engine-transactions/src/lib.rs
+++ b/engine-transactions/src/lib.rs
@@ -1,5 +1,5 @@
-use crate::prelude::types::{Address, Wei};
-use crate::prelude::{vec, TryFrom, Vec, H160, U256};
+use aurora_engine_types::types::{Address, Wei};
+use aurora_engine_types::{vec, TryFrom, Vec, H160, U256};
 use eip_2930::AccessTuple;
 use rlp::{Decodable, DecoderError, Rlp};
 

--- a/engine-types/Cargo.toml
+++ b/engine-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aurora-engine-types"
 version = "1.0.0"
-authors = ["NEAR <hello@near.org>"]
+authors = ["Aurora Labs <hello@aurora.dev>"]
 edition = "2018"
 description = ""
 documentation = ""

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -19,6 +19,7 @@ crate-type = ["cdylib", "rlib"]
 aurora-engine-types = { path = "../engine-types", default-features = false }
 aurora-engine-sdk = { path = "../engine-sdk", default-features = false }
 aurora-engine-precompiles = { path = "../engine-precompiles", default-features = false }
+aurora-engine-transactions = { path = "../engine-transactions", default-features = false }
 base64 = { version = "0.13.0", default-features = false, features = ["alloc"] }
 blake2 = { git = "https://github.com/near/near-blake2.git", version = "0.9.1", default-features = false }
 borsh = { version = "0.8.2", default-features = false }

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aurora-engine"
 version = "2.1.0"
-authors = ["NEAR <hello@near.org>"]
+authors = ["Aurora Labs <hello@aurora.dev>"]
 edition = "2018"
 description = ""
 documentation = ""
@@ -46,7 +46,7 @@ rand = "0.7.3"
 
 [features]
 default = ["std"]
-std = ["borsh/std", "evm/std", "primitive-types/std", "rlp/std", "sha3/std", "ethabi/std", "logos/std", "bn/std", "aurora-engine-types/std", "rjson/std", "aurora-engine-precompiles/std"]
+std = ["borsh/std", "evm/std", "primitive-types/std", "rlp/std", "sha3/std", "ethabi/std", "logos/std", "bn/std", "aurora-engine-types/std", "rjson/std", "aurora-engine-precompiles/std", "aurora-engine-transactions/std"]
 contract = ["aurora-engine-sdk/contract", "aurora-engine-precompiles/contract"]
 evm_bully = []
 log = ["aurora-engine-sdk/log", "aurora-engine-precompiles/log"]

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -13,12 +13,12 @@ use aurora_engine_sdk::promise::{PromiseHandler, PromiseId};
 use crate::parameters::{DeployErc20TokenArgs, NewCallArgs, TransactionStatus};
 use crate::prelude::precompiles::native::{ExitToEthereum, ExitToNear};
 use crate::prelude::precompiles::Precompiles;
+use crate::prelude::transactions::{EthTransactionKind, NormalizedEthTransaction};
 use crate::prelude::{
     address_to_key, bytes_to_key, sdk, storage_to_key, u256_to_arr, vec, AccountId, Address,
     BorshDeserialize, BorshSerialize, KeyPrefix, PromiseArgs, PromiseCreateArgs, ToString, TryFrom,
     TryInto, Vec, Wei, ERC20_MINT_SELECTOR, H160, H256, U256,
 };
-use crate::transaction::{EthTransactionKind, NormalizedEthTransaction};
 use aurora_engine_precompiles::PrecompileConstructorContext;
 
 /// Used as the first byte in the concatenation of data used to compute the blockhash.
@@ -82,7 +82,7 @@ pub enum EngineErrorKind {
     EvmFatal(ExitFatal),
     /// Incorrect nonce.
     IncorrectNonce,
-    FailedTransactionParse(crate::transaction::ParseTransactionError),
+    FailedTransactionParse(crate::prelude::transactions::ParseTransactionError),
     InvalidChainId,
     InvalidSignature,
     IntrinsicGasNotMet,
@@ -215,6 +215,7 @@ pub enum DeployErc20Error {
     Engine(EngineError),
     Register(RegisterTokenError),
 }
+
 impl AsRef<[u8]> for DeployErc20Error {
     fn as_ref(&self) -> &[u8] {
         match self {

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -14,7 +14,6 @@ mod map;
 pub mod meta_parsing;
 pub mod parameters;
 pub mod proof;
-pub mod transaction;
 
 pub mod admin_controlled;
 #[cfg_attr(feature = "contract", allow(dead_code))]

--- a/engine/src/prelude.rs
+++ b/engine/src/prelude.rs
@@ -2,6 +2,7 @@ mod v0 {
     pub use aurora_engine_precompiles as precompiles;
     pub use aurora_engine_sdk as sdk;
     pub use aurora_engine_sdk::types::*;
+    pub use aurora_engine_transactions as transactions;
     pub use aurora_engine_types::account_id::*;
     pub use aurora_engine_types::parameters::*;
     pub use aurora_engine_types::storage::*;
@@ -9,4 +10,5 @@ mod v0 {
     pub use aurora_engine_types::*;
     pub use borsh::{BorshDeserialize, BorshSerialize};
 }
+
 pub use v0::*;

--- a/etc/state-migration-test/Cargo.lock
+++ b/etc/state-migration-test/Cargo.lock
@@ -42,6 +42,7 @@ dependencies = [
  "aurora-bn",
  "aurora-engine-precompiles",
  "aurora-engine-sdk",
+ "aurora-engine-transactions",
  "aurora-engine-types",
  "base64",
  "blake2",
@@ -102,6 +103,18 @@ dependencies = [
  "aurora-engine-sdk",
  "aurora-engine-types",
  "borsh",
+]
+
+[[package]]
+name = "aurora-engine-transactions"
+version = "1.0.0"
+dependencies = [
+ "aurora-engine-precompiles",
+ "aurora-engine-sdk",
+ "aurora-engine-types",
+ "evm",
+ "hex",
+ "rlp",
 ]
 
 [[package]]


### PR DESCRIPTION
Move engine `transactions` module to `engine-transactions` crate.

Transactions types should be independent of `engine` crate. It will be easy to reuse only transactions types.