### PR TITLE
Avoid using wasmer directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,7 +213,7 @@ dependencies = [
  "serde_json",
  "sha3 0.9.1",
  "tempfile",
- "wasmer-near",
+ "walrus",
 ]
 
 [[package]]
@@ -1756,6 +1756,12 @@ dependencies = [
  "generic-array 0.12.4",
  "hmac 0.7.1",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "ident_case"
@@ -4427,6 +4433,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "walrus"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb08e48cde54c05f363d984bb54ce374f49e242def9468d2e1b6c2372d291f8"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "leb128",
+ "log",
+ "walrus-macro",
+ "wasmparser 0.77.0",
+]
+
+[[package]]
+name = "walrus-macro"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e5bd22c71e77d60140b0bd5be56155a37e5bd14e24f5f87298040d0cc40d7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5024,6 +5056,12 @@ name = "wasmparser"
 version = "0.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "755a9a4afe3f6cccbbe6d7e965eef44cf260b001f93e547eba84255c1d0187d8"
+
+[[package]]
+name = "wasmparser"
+version = "0.77.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b35c86d22e720a07d954ebbed772d01180501afe7d03d464f413bb5f8914a8d6"
 
 [[package]]
 name = "wasmparser"

--- a/engine-tests/Cargo.toml
+++ b/engine-tests/Cargo.toml
@@ -41,12 +41,12 @@ near-vm-runner = { git = "https://github.com/near/nearcore.git", rev = "0c9ad79a
 near-vm-logic = { git = "https://github.com/near/nearcore.git", rev = "0c9ad79a18e431f843e6123cf4559f9c2c5dd228" }
 near-primitives-core = { git = "https://github.com/near/nearcore.git", rev = "0c9ad79a18e431f843e6123cf4559f9c2c5dd228" }
 near-primitives = { git = "https://github.com/near/nearcore.git", rev = "0c9ad79a18e431f843e6123cf4559f9c2c5dd228" }
-wasmer = { package = "wasmer-near", version = "2.0.1", default-features = false, features = ["singlepass", "universal"] }
 libsecp256k1 = "0.3.5"
 rand = "0.7.3"
 criterion = "0.3.4"
 git2 = "0.13"
 tempfile = "3.2.0"
+walrus = "0.19"
 
 [features]
 meta-call = ["aurora-engine/meta-call"]

--- a/engine-tests/src/tests/sanity.rs
+++ b/engine-tests/src/tests/sanity.rs
@@ -251,9 +251,10 @@ fn test_num_wasm_functions() {
     // Counts the number of functions in our wasm output.
     // See https://github.com/near/nearcore/issues/4814 for context
     let runner = test_utils::deploy_evm();
-    let artifact = get_compiled_artifact(&runner);
-    let module_info = artifact.info();
-    let num_functions = module_info.functions.len();
+    let module = walrus::ModuleConfig::default()
+        .parse(runner.code.code())
+        .unwrap();
+    let num_functions = module.funcs.iter().count();
     assert!(
         num_functions <= 1440,
         "{} is not less than 1440",
@@ -709,26 +710,4 @@ fn query_address_sim(
         near_sdk_sim::transaction::ExecutionStatus::SuccessValue(b) => U256::from_big_endian(&b),
         other => panic!("Unexpected outcome: {:?}", other),
     }
-}
-
-fn get_compiled_artifact(runner: &test_utils::AuroraRunner) -> wasmer::Module {
-    use near_primitives::types::CompiledContractCache;
-
-    let current_protocol_version = u32::MAX;
-    let vm_kind = near_vm_runner::VMKind::for_protocol_version(current_protocol_version);
-    near_vm_runner::precompile_contract(
-        &runner.code,
-        &runner.wasm_config,
-        current_protocol_version,
-        Some(&runner.cache),
-    )
-    .unwrap()
-    .unwrap();
-    let cache_key =
-        near_vm_runner::get_contract_cache_key(&runner.code, vm_kind, &runner.wasm_config);
-    let cache_record =
-        Vec::try_from_slice(&runner.cache.get(cache_key.as_ref()).unwrap().unwrap()[1..]).unwrap();
-    let store = wasmer::Store::new(&wasmer::Universal::new(wasmer::Singlepass::new()).engine());
-
-    unsafe { wasmer::Module::deserialize(&store, &cache_record).unwrap() }
 }


### PR DESCRIPTION
On the nearcore's side, contract runtime team frequently makes
substantial changes to wasmer and wants to change those changes with
aurora. If aurora has a direct dependency to wasmer, we need to apply
more Cargo.toml patches to test this out.

Moreover, wasmer is not needed for this particular test -- we don't need
to compile WASM to machine code (which is what wasmer is doing), we just
need to run some analysis on wasmer. That's a much simpler thing to do
conceptually, and something `walrus` crate is typically used.