### PR TITLE
use default git attributes for Cargo.lock

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-Cargo.lock linguist-generated=true -diff


### PR DESCRIPTION
No super-strong feelings here, I can work-around on my side! But yeah,
the current setup feels a bit odd to me, as it's quite unusual. 


git&github generally handle Cargo.lock reasonably nowdays by default.
Our current explicit setting prevent changes to Cargo.lock being visible
in some tools
(https://marketplace.visualstudio.com/items?itemName=kahole.magit in my
case),  which makes working on upgrading dependencies harder.

Changes to Cargo.lock are the most important ones, as one-line
Cargo.lock addition might bring in thousands of lines of new code. They
generally should be audited with above-average scrunity, not ignored.