### PR TITLE
switch to rebranded blake2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,6 @@ dependencies = [
  "aurora-engine-sdk",
  "aurora-engine-types",
  "base64 0.13.0",
- "blake2 0.9.1 (git+https://github.com/near/near-blake2.git)",
  "borsh 0.8.2",
  "byte-slice-cast",
  "ethabi",
@@ -131,6 +130,7 @@ dependencies = [
  "hex",
  "libsecp256k1",
  "logos",
+ "near-blake2",
  "num",
  "primitive-types 0.10.1",
  "rand 0.7.3",
@@ -151,13 +151,13 @@ dependencies = [
  "aurora-engine-sdk",
  "aurora-engine-types",
  "base64 0.13.0",
- "blake2 0.9.1 (git+https://github.com/near/near-blake2.git)",
  "borsh 0.8.2",
  "ethabi",
  "evm",
  "evm-core",
  "hex",
  "libsecp256k1",
+ "near-blake2",
  "num",
  "primitive-types 0.10.1",
  "rand 0.7.3",
@@ -321,16 +321,6 @@ name = "blake2"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a5720225ef5daecf08657f23791354e1685a8c91a4c60c7f3d3b2892f978f4"
-dependencies = [
- "crypto-mac 0.8.0",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "blake2"
-version = "0.9.1"
-source = "git+https://github.com/near/near-blake2.git#736ff607cc8160af87ffa697c14ebef85050138f"
 dependencies = [
  "crypto-mac 0.8.0",
  "digest 0.9.0",
@@ -2231,6 +2221,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "near-blake2"
+version = "0.9.1"
+source = "git+https://github.com/near/near-blake2.git#cebb7df79608a7058017940830d37c37d55d21fe"
+dependencies = [
+ "crypto-mac 0.8.0",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
 name = "near-chain-configs"
 version = "0.1.0"
 source = "git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9#8a377fda0b4ce319385c463f1ae46e4b0b29dcd9"
@@ -2252,7 +2252,7 @@ version = "0.1.0"
 source = "git+https://github.com/near/nearcore.git?rev=0c9ad79a18e431f843e6123cf4559f9c2c5dd228#0c9ad79a18e431f843e6123cf4559f9c2c5dd228"
 dependencies = [
  "arrayref",
- "blake2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blake2",
  "borsh 0.9.1",
  "bs58",
  "c2-chacha",
@@ -2278,7 +2278,7 @@ version = "0.1.0"
 source = "git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1ae46e4b0b29dcd9#8a377fda0b4ce319385c463f1ae46e4b0b29dcd9"
 dependencies = [
  "arrayref",
- "blake2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blake2",
  "borsh 0.8.2",
  "bs58",
  "c2-chacha",
@@ -2304,7 +2304,7 @@ version = "0.1.0"
 source = "git+https://github.com/near/nearcore.git?rev=8a37d39629885a41dde58b60642bcf1e99407d90#8a37d39629885a41dde58b60642bcf1e99407d90"
 dependencies = [
  "arrayref",
- "blake2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blake2",
  "borsh 0.8.2",
  "bs58",
  "c2-chacha",

--- a/engine-precompiles/Cargo.toml
+++ b/engine-precompiles/Cargo.toml
@@ -16,7 +16,7 @@ autobenches = false
 aurora-engine-types = { path = "../engine-types", default-features = false }
 aurora-engine-sdk = { path = "../engine-sdk", default-features = false }
 base64 = { version = "0.13.0", default-features = false, features = ["alloc"] }
-blake2 = { git = "https://github.com/near/near-blake2.git", version = "0.9.1", default-features = false }
+near-blake2 = { git = "https://github.com/near/near-blake2.git", version = "0.9.1", default-features = false }
 borsh = { version = "0.8.2", default-features = false }
 bn = { package = "aurora-bn", git = "https://github.com/aurora-is-near/aurora-bn.git", default-features = false }
 evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", default-features = false }
@@ -36,7 +36,7 @@ serde_json = "1"
 rand = "0.7.3"
 
 [features]
-std = ["aurora-engine-types/std", "aurora-engine-sdk/std", "borsh/std", "blake2/std", "bn/std", "evm/std", "evm-core/std", "libsecp256k1/std", "ripemd160/std", "sha2/std", "sha3/std", "ethabi/std"]
+std = ["aurora-engine-types/std", "aurora-engine-sdk/std", "borsh/std", "near-blake2/std", "bn/std", "evm/std", "evm-core/std", "libsecp256k1/std", "ripemd160/std", "sha2/std", "sha3/std", "ethabi/std"]
 contract = []
 log = []
 error_refund = []

--- a/engine-precompiles/src/blake2.rs
+++ b/engine-precompiles/src/blake2.rs
@@ -94,7 +94,7 @@ impl Precompile for Blake2F {
         }
         let finished = input[212] != 0;
 
-        let output = blake2::blake2b_f(rounds, h, m, t, finished).to_vec();
+        let output = near_blake2::blake2b_f(rounds, h, m, t, finished).to_vec();
         Ok(PrecompileOutput::without_logs(cost, output).into())
     }
 }

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ aurora-engine-types = { path = "../engine-types", default-features = false }
 aurora-engine-sdk = { path = "../engine-sdk", default-features = false }
 aurora-engine-precompiles = { path = "../engine-precompiles", default-features = false }
 base64 = { version = "0.13.0", default-features = false, features = ["alloc"] }
-blake2 = { git = "https://github.com/near/near-blake2.git", version = "0.9.1", default-features = false }
+near-blake2 = { git = "https://github.com/near/near-blake2.git", version = "0.9.1", default-features = false }
 borsh = { version = "0.8.2", default-features = false }
 bn = { package = "aurora-bn", git = "https://github.com/aurora-is-near/aurora-bn.git", default-features = false }
 evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", default-features = false }

--- a/etc/state-migration-test/Cargo.lock
+++ b/etc/state-migration-test/Cargo.lock
@@ -44,7 +44,6 @@ dependencies = [
  "aurora-engine-sdk",
  "aurora-engine-types",
  "base64",
- "blake2",
  "borsh",
  "byte-slice-cast",
  "ethabi",
@@ -53,6 +52,7 @@ dependencies = [
  "hex",
  "libsecp256k1",
  "logos",
+ "near-blake2",
  "num",
  "primitive-types",
  "ripemd160",
@@ -70,13 +70,13 @@ dependencies = [
  "aurora-engine-sdk",
  "aurora-engine-types",
  "base64",
- "blake2",
  "borsh",
  "ethabi",
  "evm",
  "evm-core",
  "hex",
  "libsecp256k1",
+ "near-blake2",
  "num",
  "primitive-types",
  "ripemd160",
@@ -132,16 +132,6 @@ name = "beef"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6736e2428df2ca2848d846c43e88745121a6654696e349ce0054a420815a7409"
-
-[[package]]
-name = "blake2"
-version = "0.9.1"
-source = "git+https://github.com/near/near-blake2.git#736ff607cc8160af87ffa697c14ebef85050138f"
-dependencies = [
- "crypto-mac",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
-]
 
 [[package]]
 name = "block-buffer"
@@ -613,6 +603,16 @@ name = "memory_units"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
+
+[[package]]
+name = "near-blake2"
+version = "0.9.1"
+source = "git+https://github.com/near/near-blake2.git#cebb7df79608a7058017940830d37c37d55d21fe"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
 
 [[package]]
 name = "num"


### PR DESCRIPTION
This pulls
https://github.com/near/near-blake2/commit/cebb7df79608a7058017940830d37c37d55d21fe
which just renames blake2. It's parent, 736ff60, is what we are using
currently. There are some extra commits on top of that in master, but I
decided not to pull them in just yet, to minimize change.

The primary motivation here is making it easy to upgrade other things:

   blake2 = { git = "https://github.com/near/near-blake2.git", version = "0.9.1", default-features = false }

makes that tricky, as there's no longer `blake2` package at that URL!