### PR TITLE
Fix(engine): Return revert error message during contract deploy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,6 +232,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "auto_impl"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7862e21c893d65a1650125d157eaeec691439379a1cee17ee49031b79236ada4"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1358,9 +1370,10 @@ checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 
 [[package]]
 name = "evm"
-version = "0.31.1"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git#0fbde9fa7797308290f89111c6abe5cee55a5eac"
+version = "0.33.1"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?rev=177e253ad947b7186bfa6920843075556b60ff54#177e253ad947b7186bfa6920843075556b60ff54"
 dependencies = [
+ "auto_impl",
  "environmental",
  "ethereum",
  "evm-core",
@@ -1377,8 +1390,8 @@ dependencies = [
 
 [[package]]
 name = "evm-core"
-version = "0.31.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git#0fbde9fa7797308290f89111c6abe5cee55a5eac"
+version = "0.33.0"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?rev=177e253ad947b7186bfa6920843075556b60ff54#177e253ad947b7186bfa6920843075556b60ff54"
 dependencies = [
  "funty",
  "parity-scale-codec",
@@ -1389,8 +1402,8 @@ dependencies = [
 
 [[package]]
 name = "evm-gasometer"
-version = "0.31.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git#0fbde9fa7797308290f89111c6abe5cee55a5eac"
+version = "0.33.0"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?rev=177e253ad947b7186bfa6920843075556b60ff54#177e253ad947b7186bfa6920843075556b60ff54"
 dependencies = [
  "environmental",
  "evm-core",
@@ -1400,9 +1413,10 @@ dependencies = [
 
 [[package]]
 name = "evm-runtime"
-version = "0.31.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git#0fbde9fa7797308290f89111c6abe5cee55a5eac"
+version = "0.33.0"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?rev=177e253ad947b7186bfa6920843075556b60ff54#177e253ad947b7186bfa6920843075556b60ff54"
 dependencies = [
+ "auto_impl",
  "environmental",
  "evm-core",
  "primitive-types 0.10.1",

--- a/engine-precompiles/Cargo.toml
+++ b/engine-precompiles/Cargo.toml
@@ -19,8 +19,8 @@ base64 = { version = "0.13.0", default-features = false, features = ["alloc"] }
 blake2 = { git = "https://github.com/near/near-blake2.git", version = "0.9.1", default-features = false }
 borsh = { version = "0.8.2", default-features = false }
 bn = { package = "aurora-bn", git = "https://github.com/aurora-is-near/aurora-bn.git", default-features = false }
-evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", default-features = false }
-evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", default-features = false }
+evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", rev = "177e253ad947b7186bfa6920843075556b60ff54", default-features = false }
+evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", rev = "177e253ad947b7186bfa6920843075556b60ff54", default-features = false }
 libsecp256k1 = { version = "0.3.5", default-features = false }
 num = { version = "0.4.0", default-features = false, features = ["alloc"] }
 primitive-types = { version = "0.10.0", default-features = false, features = ["rlp"] }

--- a/engine-precompiles/src/lib.rs
+++ b/engine-precompiles/src/lib.rs
@@ -47,9 +47,9 @@ impl PrecompileOutput {
     }
 }
 
-impl From<PrecompileOutput> for evm::executor::PrecompileOutput {
+impl From<PrecompileOutput> for executor::stack::PrecompileOutput {
     fn from(output: PrecompileOutput) -> Self {
-        evm::executor::PrecompileOutput {
+        executor::stack::PrecompileOutput {
             exit_status: ExitSucceed::Returned,
             cost: output.cost.as_u64(),
             output: output.output,
@@ -58,7 +58,7 @@ impl From<PrecompileOutput> for evm::executor::PrecompileOutput {
     }
 }
 
-type EvmPrecompileResult = Result<evm::executor::PrecompileOutput, ExitError>;
+type EvmPrecompileResult = Result<executor::stack::PrecompileOutput, ExitError>;
 
 /// A precompiled function for use in the EVM.
 pub trait Precompile {
@@ -102,7 +102,7 @@ impl HardFork for Berlin {}
 
 pub struct Precompiles(pub prelude::BTreeMap<Address, Box<dyn Precompile>>);
 
-impl executor::PrecompileSet for Precompiles {
+impl executor::stack::PrecompileSet for Precompiles {
     fn execute(
         &self,
         address: prelude::H160,
@@ -110,10 +110,10 @@ impl executor::PrecompileSet for Precompiles {
         gas_limit: Option<u64>,
         context: &Context,
         is_static: bool,
-    ) -> Option<Result<executor::PrecompileOutput, executor::PrecompileFailure>> {
+    ) -> Option<Result<executor::stack::PrecompileOutput, executor::stack::PrecompileFailure>> {
         self.0.get(&Address::new(address)).map(|p| {
             p.run(input, gas_limit.map(EthGas::new), context, is_static)
-                .map_err(|exit_status| executor::PrecompileFailure::Error { exit_status })
+                .map_err(|exit_status| executor::stack::PrecompileFailure::Error { exit_status })
         })
     }
 

--- a/engine-standalone-storage/Cargo.toml
+++ b/engine-standalone-storage/Cargo.toml
@@ -18,7 +18,7 @@ aurora-engine = { path = "../engine", default-features = false, features = ["std
 aurora-engine-types = { path = "../engine-types", default-features = false, features = ["std"] }
 aurora-engine-sdk = { path = "../engine-sdk", default-features = false, features = ["std"] }
 borsh = { version = "0.8.2" }
-evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", default-features = false }
+evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", rev = "177e253ad947b7186bfa6920843075556b60ff54", default-features = false }
 rocksdb = "0.16.0"
 postgres = "0.19.2"
 serde = "1.0.130"

--- a/engine-standalone-tracing/Cargo.toml
+++ b/engine-standalone-tracing/Cargo.toml
@@ -17,10 +17,10 @@ crate-type = ["lib"]
 aurora-engine = { path = "../engine", default-features = false, features = ["std"] }
 aurora-engine-types = { path = "../engine-types", default-features = false, features = ["std"] }
 aurora-engine-sdk = { path = "../engine-sdk", default-features = false, features = ["std"] }
-evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", default-features = false, features = ["std"] }
-evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", default-features = false, features = ["std", "tracing"] }
-evm-runtime = { git = "https://github.com/aurora-is-near/sputnikvm.git", default-features = false, features = ["std", "tracing"] }
-evm-gasometer = { git = "https://github.com/aurora-is-near/sputnikvm.git", default-features = false, features = ["std", "tracing"] }
+evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", rev = "177e253ad947b7186bfa6920843075556b60ff54", default-features = false, features = ["std"] }
+evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", rev = "177e253ad947b7186bfa6920843075556b60ff54", default-features = false, features = ["std", "tracing"] }
+evm-runtime = { git = "https://github.com/aurora-is-near/sputnikvm.git", rev = "177e253ad947b7186bfa6920843075556b60ff54", default-features = false, features = ["std", "tracing"] }
+evm-gasometer = { git = "https://github.com/aurora-is-near/sputnikvm.git", rev = "177e253ad947b7186bfa6920843075556b60ff54", default-features = false, features = ["std", "tracing"] }
 
 [features]
 default = []

--- a/engine-tests/Cargo.toml
+++ b/engine-tests/Cargo.toml
@@ -21,9 +21,9 @@ engine-standalone-storage = { path = "../engine-standalone-storage", default-fea
 engine-standalone-tracing = { path = "../engine-standalone-tracing", default-features = false }
 borsh = { version = "0.8.2", default-features = false }
 sha3 = { version = "0.9.1", default-features = false }
-evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", default-features = false, features = ["std", "tracing"] }
-evm-runtime = { git = "https://github.com/aurora-is-near/sputnikvm.git", default-features = false, features = ["std", "tracing"] }
-evm-gasometer = { git = "https://github.com/aurora-is-near/sputnikvm.git", default-features = false, features = ["std", "tracing"] }
+evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", rev = "177e253ad947b7186bfa6920843075556b60ff54", default-features = false, features = ["std", "tracing"] }
+evm-runtime = { git = "https://github.com/aurora-is-near/sputnikvm.git", rev = "177e253ad947b7186bfa6920843075556b60ff54", default-features = false, features = ["std", "tracing"] }
+evm-gasometer = { git = "https://github.com/aurora-is-near/sputnikvm.git", rev = "177e253ad947b7186bfa6920843075556b60ff54", default-features = false, features = ["std", "tracing"] }
 rlp = { version = "0.5.0", default-features = false }
 
 [dev-dependencies]

--- a/engine-tests/src/tests/res/reverter.sol
+++ b/engine-tests/src/tests/res/reverter.sol
@@ -1,0 +1,9 @@
+pragma solidity ^0.8.0;
+
+contract ReverterByDefault {
+    uint256 y = 0;
+    constructor(uint256 x) public {
+        require (x < y, "Revert message");
+        y = x;
+    }
+}

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -23,8 +23,8 @@ base64 = { version = "0.13.0", default-features = false, features = ["alloc"] }
 blake2 = { git = "https://github.com/near/near-blake2.git", version = "0.9.1", default-features = false }
 borsh = { version = "0.8.2", default-features = false }
 bn = { package = "aurora-bn", git = "https://github.com/aurora-is-near/aurora-bn.git", default-features = false }
-evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", default-features = false }
-evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", default-features = false }
+evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", rev = "177e253ad947b7186bfa6920843075556b60ff54", default-features = false }
+evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", rev = "177e253ad947b7186bfa6920843075556b60ff54", default-features = false }
 libsecp256k1 = { version = "0.3.5", default-features = false }
 num = { version = "0.4.0", default-features = false, features = ["alloc"] }
 primitive-types = { version = "0.10.0", default-features = false, features = ["rlp"] }

--- a/etc/state-migration-test/Cargo.lock
+++ b/etc/state-migration-test/Cargo.lock
@@ -116,6 +116,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "auto_impl"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7862e21c893d65a1650125d157eaeec691439379a1cee17ee49031b79236ada4"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,9 +391,10 @@ dependencies = [
 
 [[package]]
 name = "evm"
-version = "0.31.1"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git#0fbde9fa7797308290f89111c6abe5cee55a5eac"
+version = "0.33.1"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?rev=177e253ad947b7186bfa6920843075556b60ff54#177e253ad947b7186bfa6920843075556b60ff54"
 dependencies = [
+ "auto_impl",
  "ethereum",
  "evm-core",
  "evm-gasometer",
@@ -394,8 +407,8 @@ dependencies = [
 
 [[package]]
 name = "evm-core"
-version = "0.31.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git#0fbde9fa7797308290f89111c6abe5cee55a5eac"
+version = "0.33.0"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?rev=177e253ad947b7186bfa6920843075556b60ff54#177e253ad947b7186bfa6920843075556b60ff54"
 dependencies = [
  "funty",
  "primitive-types",
@@ -403,8 +416,8 @@ dependencies = [
 
 [[package]]
 name = "evm-gasometer"
-version = "0.31.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git#0fbde9fa7797308290f89111c6abe5cee55a5eac"
+version = "0.33.0"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?rev=177e253ad947b7186bfa6920843075556b60ff54#177e253ad947b7186bfa6920843075556b60ff54"
 dependencies = [
  "evm-core",
  "evm-runtime",
@@ -413,9 +426,10 @@ dependencies = [
 
 [[package]]
 name = "evm-runtime"
-version = "0.31.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git#0fbde9fa7797308290f89111c6abe5cee55a5eac"
+version = "0.33.0"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?rev=177e253ad947b7186bfa6920843075556b60ff54#177e253ad947b7186bfa6920843075556b60ff54"
 dependencies = [
+ "auto_impl",
  "evm-core",
  "primitive-types",
  "sha3 0.8.2",
@@ -762,6 +776,30 @@ checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
 dependencies = [
  "thiserror",
  "toml",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]


### PR DESCRIPTION
@0x3bfc pointed out that presently the Engine always returns the address the contract would be deployed at, regardless of if the deploy execution was successful or not. In this PR we ensure to pass the error message on in the case of failure.