### PR TITLE
Benchmark contract performing only pure arithmetic and memory operations

### DIFF
--- a/engine-tests/src/test_utils/solidity.rs
+++ b/engine-tests/src/test_utils/solidity.rs
@@ -22,6 +22,27 @@ struct ExtendedJsonSolidityArtifact {
 }
 
 impl ContractConstructor {
+    /// Same as `compile_from_source` but always recompiles instead of reusing artifacts when they exist.
+    pub fn force_compile<P1, P2, P3>(
+        sources_root: P1,
+        artifacts_base_path: P2,
+        contract_file: P3,
+        contract_name: &str,
+    ) -> Self
+    where
+        P1: AsRef<Path>,
+        P2: AsRef<Path>,
+        P3: AsRef<Path>,
+    {
+        compile(&sources_root, &contract_file, &artifacts_base_path);
+        Self::compile_from_source(
+            sources_root,
+            artifacts_base_path,
+            contract_file,
+            contract_name,
+        )
+    }
+
     // Note: `contract_file` must be relative to `sources_root`
     pub fn compile_from_source<P1, P2, P3>(
         sources_root: P1,

--- a/engine-tests/src/tests/res/bench.sol
+++ b/engine-tests/src/tests/res/bench.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract Bencher {
+    function cpu_ram_soak_test(uint32 loop_limit) public pure {
+        uint8[102400] memory buf;
+        uint32 len = 102400;
+        for (uint32 i=0; i < loop_limit; i++) {
+            uint32 j = (i * 7 + len / 2) % len;
+            uint32 k = (i * 3) % len;
+            uint8 tmp = buf[k];
+            buf[k] = buf[j];
+            buf[j] = tmp;
+        }
+    }
+}


### PR DESCRIPTION
Reproduces in Solidity the [contract used by the nearcore contract runtime](https://github.com/near/nearcore/blob/83fc0f7d6b212bacc49f058e7400743de3e59783/runtime/runtime-params-estimator/test-contract/src/lib.rs#L1031-L1043) team to benchmark wasm. This fulfils a request from @matklad to have such a contract.