### PR TITLE
Fix(engine): Require chain_id

### DIFF
--- a/engine-tests/src/tests/erc20_connector.rs
+++ b/engine-tests/src/tests/erc20_connector.rs
@@ -184,7 +184,9 @@ impl test_utils::AuroraRunner {
             ],
         );
 
-        let input = create_eth_transaction(Some(token.into()), Wei::zero(), input, None, &sender);
+        let chain_id = Some(self.chain_id);
+        let input =
+            create_eth_transaction(Some(token.into()), Wei::zero(), input, chain_id, &sender);
 
         let result = self.evm_submit(input, origin); // create_eth_transaction()
         result.check_ok();

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -857,6 +857,10 @@ pub fn submit<I: IO + Copy, E: Env, P: PromiseHandler>(
         if U256::from(chain_id) != U256::from(state.chain_id) {
             return Err(EngineErrorKind::InvalidChainId.into());
         }
+    } else {
+        // Do not allow missing chain_id in production
+        #[cfg(not(feature = "evm_bully"))]
+        return Err(EngineErrorKind::InvalidChainId.into());
     }
 
     // Retrieve the signer of the transaction:


### PR DESCRIPTION
I don't think anyone has ever submitted any transaction to Aurora without a `chain_id`, so this should not break anything, and it should close potential shenanigans  since we do not expect any legitimate user to not provide a `chain_id`.