### PR TITLE
chore: make sure aurora is using the latest cost config

### DIFF
--- a/engine-tests/src/test_utils/mod.rs
+++ b/engine-tests/src/test_utils/mod.rs
@@ -2,6 +2,8 @@ use aurora_engine::parameters::ViewCallArgs;
 use aurora_engine_types::account_id::AccountId;
 use aurora_engine_types::types::NEP141Wei;
 use borsh::{BorshDeserialize, BorshSerialize};
+use near_primitives::runtime::config_store::RuntimeConfigStore;
+use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives_core::config::VMConfig;
 use near_primitives_core::contract::ContractCode;
 use near_primitives_core::profile::ProfileData;
@@ -495,11 +497,11 @@ impl Default for AuroraRunner {
         } else {
             panic!("AuroraRunner requires mainnet-test or testnet-test feature enabled.")
         };
-        let mut wasm_config = VMConfig::test();
-        // See https://github.com/near/nearcore/pull/4979/
-        //wasm_config.regular_op_cost = 2207874;
-        // See https://github.com/near/nearcore/pull/5365
-        wasm_config.regular_op_cost = 822756;
+
+        // Fetch config (mainly costs) for the latest protocol version.
+        let runtime_config_store = RuntimeConfigStore::new(None);
+        let runtime_config = runtime_config_store.get_config(PROTOCOL_VERSION);
+        let wasm_config = runtime_config.wasm_config.clone();
 
         Self {
             aurora_account_id: aurora_account_id.clone(),

--- a/engine-tests/src/tests/one_inch.rs
+++ b/engine-tests/src/tests/one_inch.rs
@@ -105,7 +105,7 @@ fn test_1_inch_limit_order_deploy() {
     // at least 45% of which is from wasm execution
     let wasm_fraction = 100 * profile.wasm_gas() / profile.all_gas();
     assert!(
-        25 <= wasm_fraction && wasm_fraction <= 35,
+        35 <= wasm_fraction && wasm_fraction <= 40,
         "{}% is not between 25% and 35%",
         wasm_fraction
     );


### PR DESCRIPTION
The test needs adjustment because non-wasm cost falls from

17_548_272_829_581

to

14_461_725_193_038

Ie, as the total cost is lower, wasm fraction is now bigger.

Haven't looked into which specific cost change caused decrease. 