### PR TITLE
Engine: further caching optimizations

### DIFF
--- a/engine-tests/src/tests/uniswap.rs
+++ b/engine-tests/src/tests/uniswap.rs
@@ -57,7 +57,7 @@ fn test_uniswap_exact_output() {
     test_utils::assert_gas_bound(profile.all_gas(), 58);
     let wasm_fraction = 100 * profile.wasm_gas() / profile.all_gas();
     assert!(
-        20 <= wasm_fraction && wasm_fraction <= 30,
+        25 <= wasm_fraction && wasm_fraction <= 35,
         "{}% is not between 20% and 30%",
         wasm_fraction
     );


### PR DESCRIPTION
Adding the another size-1 LRU cache for EVM contract code is helpful in reducing duplicate reads because it appears to be a pattern in contracts compiled by solidity to use the `EXTCODESIZE` opcode before calling an address (both operations require reading the target address's code).

Additionally, we can use the caches we have already added in the `Backend::exists` implementation for the Engine. This prevents some duplicate reads where SputnikVM ends up checking if an address is empty twice because it does not assume `Backend::exists` will return false for empty accounts (our implementation does have the property that `exists` returns false if and only if the account is empty, so the second check is redundant for us, but I don't want to make a breaking change to the core assumptions of SputnikVM's API).

Based on the new benchmark in #454 , these changes provide about a 20% reduction in Engine gas usage.