### PR TITLE
Use EthTransactionKind reference to serialize into bytes

### DIFF
--- a/engine-standalone-storage/src/relayer_db/mod.rs
+++ b/engine-standalone-storage/src/relayer_db/mod.rs
@@ -93,7 +93,7 @@ where
         let block_hash = row.block_hash;
         let block_metadata = storage.get_block_metadata(block_hash)?;
         let tx: EthTransactionKind = row.into();
-        let transaction_bytes: Vec<u8> = tx.into();
+        let transaction_bytes: Vec<u8> = (&tx).into();
         let tx_hash = aurora_engine_sdk::keccak(&transaction_bytes);
 
         env.block_height = block_height;

--- a/engine-standalone-storage/src/sync/mod.rs
+++ b/engine-standalone-storage/src/sync/mod.rs
@@ -55,7 +55,7 @@ pub fn consume_message(storage: &mut crate::Storage, message: Message) -> Result
                     // Only promises possible from `submit` are exit precompiles and we cannot act on those promises
                     let mut handler = crate::promise::Noop;
                     let engine_state = engine::get_state(&io)?;
-                    let transaction_bytes: Vec<u8> = tx.into();
+                    let transaction_bytes: Vec<u8> = (&tx).into();
                     let tx_hash = aurora_engine_sdk::keccak(&transaction_bytes);
 
                     let _result = engine::submit(

--- a/engine-transactions/src/lib.rs
+++ b/engine-transactions/src/lib.rs
@@ -41,20 +41,20 @@ impl TryFrom<&[u8]> for EthTransactionKind {
     }
 }
 
-impl From<EthTransactionKind> for Vec<u8> {
-    fn from(tx: EthTransactionKind) -> Self {
+impl<'a> From<&'a EthTransactionKind> for Vec<u8> {
+    fn from(tx: &'a EthTransactionKind) -> Self {
         let mut stream = rlp::RlpStream::new();
-        match tx {
+        match &tx {
             EthTransactionKind::Legacy(tx) => {
-                stream.append(&tx);
+                stream.append(tx);
             }
             EthTransactionKind::Eip1559(tx) => {
                 stream.append(&eip_1559::TYPE_BYTE);
-                stream.append(&tx);
+                stream.append(tx);
             }
             EthTransactionKind::Eip2930(tx) => {
                 stream.append(&eip_2930::TYPE_BYTE);
-                stream.append(&tx);
+                stream.append(tx);
             }
         }
         stream.out().to_vec()


### PR DESCRIPTION
It doesn't make sense that turning `EthTransactionKind` into `Vec<u8>` consumes the object when the implementation only requires a reference. Changing the definition to `From<&EthTransactionKind>` keeps the implementation the same and allows more flexibility for users of the `aurora-engine-transactions` library.