### PR TITLE
Fix(Engine): Transactions to the zero address are not the same as transactions with empty to field

### DIFF
--- a/engine-transactions/src/backwards_compatibility.rs
+++ b/engine-transactions/src/backwards_compatibility.rs
@@ -1,0 +1,56 @@
+//! Warning: this module _incorrectly_ parses RLP-serialized Ethereum transactions.
+//! This is intentional and needed for our "standalone engine" to be able to reproduce
+//! the Aurora state on the NEAR blockchain before the time a bug was fixed. See
+//! https://github.com/aurora-is-near/aurora-engine/pull/458 for more details, but external
+//! users of this library should _never_ use the adapter in this module.
+
+use crate::{EthTransactionKind, ParseTransactionError};
+use aurora_engine_types::{types::Address, H160};
+
+const ZERO_ADDRESS: Option<Address> = Some(Address::new(H160::zero()));
+
+/// This struct is a modification to the usual `EthTransactionKind` parsing logic.
+/// For blocks strictly less than `bug_fix_height`, it still has the bug where the
+/// zero address in the `to` field is converted to `None`. For blocks greater than
+/// or equal to `bug_fix_height` it correctly parses the transaction.
+pub struct EthTransactionKindAdapter {
+    bug_fix_height: u64,
+}
+
+impl EthTransactionKindAdapter {
+    pub const fn new(bug_fix_height: u64) -> Self {
+        Self { bug_fix_height }
+    }
+
+    pub fn try_parse_bytes(
+        &self,
+        bytes: &[u8],
+        block_height: u64,
+    ) -> Result<EthTransactionKind, ParseTransactionError> {
+        let mut result = EthTransactionKind::try_from(bytes)?;
+
+        // Prior to the bug fix, the zero address was always parsed as None if
+        // it was in the `to` field.
+        if block_height < self.bug_fix_height {
+            match &mut result {
+                EthTransactionKind::Legacy(tx) => {
+                    if tx.transaction.to == ZERO_ADDRESS {
+                        tx.transaction.to = None;
+                    }
+                }
+                EthTransactionKind::Eip1559(tx) => {
+                    if tx.transaction.to == ZERO_ADDRESS {
+                        tx.transaction.to = None;
+                    }
+                }
+                EthTransactionKind::Eip2930(tx) => {
+                    if tx.transaction.to == ZERO_ADDRESS {
+                        tx.transaction.to = None;
+                    }
+                }
+            }
+        }
+
+        Ok(result)
+    }
+}

--- a/engine-transactions/src/legacy.rs
+++ b/engine-transactions/src/legacy.rs
@@ -196,7 +196,14 @@ mod tests {
 
         let encoded_tx = hex::decode("f8d98001831e848094000000000000000000000000000000000000000080b874600060005560648060106000396000f360e060020a6000350480638ada066e146028578063d09de08a1460365780632baeceb714604d57005b5060005460005260206000f3005b5060016000540160005560005460005260206000f3005b5060016000540360005560005460005260206000f300849c8a82cba0668cfa20c8521b28fa8e42f26df0f2c090dda2fb5cbbb60dd616e8d00f93d9d8a00a1e5de8454ce9072cefd8268c0bf8eba2c1206a5e5a43914c1d62962c121d94").unwrap();
         let tx_2 = LegacyEthSignedTransaction::decode(&Rlp::new(&encoded_tx)).unwrap();
-        assert_eq!(tx_1.transaction.to, tx_2.transaction.to);
+
+        // tx_2 has the zero address as its `to` field
+        assert_eq!(tx_2.transaction.to, Some(address_from_arr(&[0u8; 20])));
+
+        // otherwise, tx_1 and tx_2 are identical.
+        let mut tx_2_mod = tx_2.clone();
+        tx_2_mod.transaction.to = None;
+        assert_eq!(tx_1.transaction, tx_2_mod.transaction);
     }
 
     fn address_from_arr(arr: &[u8]) -> Address {

--- a/engine-transactions/src/lib.rs
+++ b/engine-transactions/src/lib.rs
@@ -6,6 +6,7 @@ use aurora_engine_types::{vec, Vec, H160, U256};
 use eip_2930::AccessTuple;
 use rlp::{Decodable, DecoderError, Rlp};
 
+pub mod backwards_compatibility;
 pub mod eip_1559;
 pub mod eip_2930;
 pub mod legacy;

--- a/engine-transactions/src/lib.rs
+++ b/engine-transactions/src/lib.rs
@@ -193,11 +193,7 @@ fn rlp_extract_to(rlp: &Rlp<'_>, index: usize) -> Result<Option<Address>, Decode
     } else {
         let v: H160 = value.as_val()?;
         let addr = Address::new(v);
-        if addr == Address::zero() {
-            Ok(None)
-        } else {
-            Ok(Some(addr))
-        }
+        Ok(Some(addr))
     }
 }
 


### PR DESCRIPTION
Fixes the issue raised in https://github.com/aurora-is-near/aurora-relayer/issues/197

Essentially, if the Engine treats transactions to the zero address the same as transactions with an empty `to` field, then two incorrect things happen

1. Transactions to the zero address create a new contract (this does not happen on Ethereum)
2. The Engine does not correctly derive the sender of transactions to the zero address, causing incorrect state changes and mismatch with the explorer.

This PR fixes these problems by letting the zero address be a possible value of the `to` field.