### PR TITLE
Fix features related to panic_info_message

### DIFF
--- a/engine-precompiles/src/lib.rs
+++ b/engine-precompiles/src/lib.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(alloc_error_handler))]
-#![cfg_attr(feature = "log", feature(panic_info_message))]
 
 pub mod account_ids;
 pub mod blake2;

--- a/engine-sdk/src/lib.rs
+++ b/engine-sdk/src/lib.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(alloc_error_handler))]
-#![cfg_attr(feature = "log", feature(panic_info_message))]
 
 #[cfg(feature = "contract")]
 use crate::prelude::Address;

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -1,6 +1,9 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(alloc_error_handler))]
-#![cfg_attr(feature = "log", feature(panic_info_message))]
+#![cfg_attr(
+    all(feature = "log", target_arch = "wasm32"),
+    feature(panic_info_message)
+)]
 
 use aurora_engine_types::parameters::PromiseCreateArgs;
 


### PR DESCRIPTION
1. This feature is only needed in the engine itself (the only crate with a wasm target).
2. We only need this feature when compiling to wasm.

Fixing this will allow enabling the logging feature in the standalone engine (though it still needs a real implementation for this to do anything)