### PR TITLE
Feat(standalone): handle ft_transfer_call transactions

### DIFF
--- a/engine-standalone-storage/src/sync/types.rs
+++ b/engine-standalone-storage/src/sync/types.rs
@@ -54,4 +54,7 @@ pub enum TransactionKind {
     FtOnTransfer(parameters::NEP141FtOnTransferArgs),
     /// Bytes here will be parsed into `aurora_engine::proof::Proof`
     Deposit(Vec<u8>),
+    /// This can change balances on aurora in the case that `receiver_id == aurora`.
+    /// Example: https://explorer.mainnet.near.org/transactions/DH6iNvXCt5n5GZBZPV1A6sLmMf1EsKcxXE4uqk1cShzj
+    FtTransferCall(parameters::TransferCallCallArgs),
 }

--- a/engine/src/parameters.rs
+++ b/engine/src/parameters.rs
@@ -358,7 +358,7 @@ pub struct InitCallArgs {
 pub type SetContractDataCallArgs = InitCallArgs;
 
 /// transfer eth-connector call args
-#[derive(BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct TransferCallCallArgs {
     pub receiver_id: AccountId,
     pub amount: NEP141Wei,


### PR DESCRIPTION
This is needed to ensure the standalone engine is catching all state changes on Aurora.