### PR TITLE
Fix(precompiles): Allow exit precompiles to work in the standalone engine

### DIFF
--- a/engine-precompiles/src/native.rs
+++ b/engine-precompiles/src/native.rs
@@ -1,23 +1,21 @@
 use super::{EvmPrecompileResult, Precompile};
-#[cfg(feature = "contract")]
 use crate::prelude::{
     format,
     parameters::{PromiseArgs, PromiseCreateArgs, WithdrawCallArgs},
-    sdk,
+    sdk::io::{StorageIntermediate, IO},
     storage::{bytes_to_key, KeyPrefix},
-    types::Yocto,
+    types::{Address, Yocto},
     vec, BorshSerialize, Cow, String, ToString, Vec, U256,
 };
-#[cfg(all(feature = "error_refund", feature = "contract"))]
+#[cfg(feature = "error_refund")]
 use crate::prelude::{
     parameters::{PromiseWithCallbackArgs, RefundCallArgs},
     types,
 };
 
-use crate::prelude::types::{Address, EthGas};
+use crate::prelude::types::EthGas;
 use crate::PrecompileOutput;
 use aurora_engine_types::account_id::AccountId;
-#[cfg(feature = "contract")]
 use evm::backend::Log;
 use evm::{Context, ExitError};
 
@@ -191,58 +189,45 @@ pub mod events {
 }
 
 //TransferEthToNear
-pub struct ExitToNear {
+pub struct ExitToNear<I> {
     current_account_id: AccountId,
+    io: I,
 }
 
-impl ExitToNear {
+pub mod exit_to_near {
+    use aurora_engine_types::types::Address;
+
     /// Exit to NEAR precompile address
     ///
     /// Address: `0xe9217bc70b7ed1f598ddd3199e80b093fa71124f`
     /// This address is computed as: `&keccak("exitToNear")[12..]`
     pub const ADDRESS: Address =
-        super::make_address(0xe9217bc7, 0x0b7ed1f598ddd3199e80b093fa71124f);
+        crate::make_address(0xe9217bc7, 0x0b7ed1f598ddd3199e80b093fa71124f);
+}
 
-    pub fn new(current_account_id: AccountId) -> Self {
-        Self { current_account_id }
+impl<I> ExitToNear<I> {
+    pub fn new(current_account_id: AccountId, io: I) -> Self {
+        Self {
+            current_account_id,
+            io,
+        }
     }
 }
 
-#[cfg(feature = "contract")]
-fn get_nep141_from_erc20(erc20_token: &[u8]) -> AccountId {
-    use sdk::io::{StorageIntermediate, IO};
+fn get_nep141_from_erc20<I: IO>(erc20_token: &[u8], io: &I) -> Result<AccountId, ExitError> {
     AccountId::try_from(
-        sdk::near_runtime::Runtime
-            .read_storage(bytes_to_key(KeyPrefix::Erc20Nep141Map, erc20_token).as_slice())
+        io.read_storage(bytes_to_key(KeyPrefix::Erc20Nep141Map, erc20_token).as_slice())
             .map(|s| s.to_vec())
-            .expect(ERR_TARGET_TOKEN_NOT_FOUND),
+            .ok_or(ExitError::Other(Cow::Borrowed(ERR_TARGET_TOKEN_NOT_FOUND)))?,
     )
-    .unwrap()
+    .map_err(|_| ExitError::Other(Cow::Borrowed("ERR_INVALID_NEP141_ACCOUNT")))
 }
 
-impl Precompile for ExitToNear {
+impl<I: IO> Precompile for ExitToNear<I> {
     fn required_gas(_input: &[u8]) -> Result<EthGas, ExitError> {
         Ok(costs::EXIT_TO_NEAR_GAS)
     }
 
-    #[cfg(not(feature = "contract"))]
-    fn run(
-        &self,
-        input: &[u8],
-        target_gas: Option<EthGas>,
-        _context: &Context,
-        _is_static: bool,
-    ) -> EvmPrecompileResult {
-        if let Some(target_gas) = target_gas {
-            if Self::required_gas(input)? > target_gas {
-                return Err(ExitError::OutOfGas);
-            }
-        }
-
-        Ok(PrecompileOutput::default().into())
-    }
-
-    #[cfg(feature = "contract")]
     fn run(
         &self,
         input: &[u8],
@@ -329,7 +314,7 @@ impl Precompile for ExitToNear {
                 }
 
                 let erc20_address = context.caller;
-                let nep141_address = get_nep141_from_erc20(erc20_address.as_bytes());
+                let nep141_address = get_nep141_from_erc20(erc20_address.as_bytes(), &self.io)?;
 
                 let amount = U256::from_big_endian(&input[..32]);
                 input = &input[32..];
@@ -397,13 +382,13 @@ impl Precompile for ExitToNear {
         let promise = PromiseArgs::Create(transfer_promise);
 
         let promise_log = Log {
-            address: Self::ADDRESS.raw(),
+            address: exit_to_near::ADDRESS.raw(),
             topics: Vec::new(),
             data: promise.try_to_vec().unwrap(),
         };
         let exit_event_log = exit_event.encode();
         let exit_event_log = Log {
-            address: Self::ADDRESS.raw(),
+            address: exit_to_near::ADDRESS.raw(),
             topics: exit_event_log.topics,
             data: exit_event_log.data,
         };
@@ -416,46 +401,36 @@ impl Precompile for ExitToNear {
     }
 }
 
-pub struct ExitToEthereum {
+pub struct ExitToEthereum<I> {
     current_account_id: AccountId,
+    io: I,
 }
 
-impl ExitToEthereum {
+pub mod exit_to_ethereum {
+    use aurora_engine_types::types::Address;
+
     /// Exit to Ethereum precompile address
     ///
     /// Address: `0xb0bd02f6a392af548bdf1cfaee5dfa0eefcc8eab`
     /// This address is computed as: `&keccak("exitToEthereum")[12..]`
     pub const ADDRESS: Address =
-        super::make_address(0xb0bd02f6, 0xa392af548bdf1cfaee5dfa0eefcc8eab);
+        crate::make_address(0xb0bd02f6, 0xa392af548bdf1cfaee5dfa0eefcc8eab);
+}
 
-    pub fn new(current_account_id: AccountId) -> Self {
-        Self { current_account_id }
+impl<I> ExitToEthereum<I> {
+    pub fn new(current_account_id: AccountId, io: I) -> Self {
+        Self {
+            current_account_id,
+            io,
+        }
     }
 }
 
-impl Precompile for ExitToEthereum {
+impl<I: IO> Precompile for ExitToEthereum<I> {
     fn required_gas(_input: &[u8]) -> Result<EthGas, ExitError> {
         Ok(costs::EXIT_TO_ETHEREUM_GAS)
     }
 
-    #[cfg(not(feature = "contract"))]
-    fn run(
-        &self,
-        input: &[u8],
-        target_gas: Option<EthGas>,
-        _context: &Context,
-        _is_static: bool,
-    ) -> EvmPrecompileResult {
-        if let Some(target_gas) = target_gas {
-            if Self::required_gas(input)? > target_gas {
-                return Err(ExitError::OutOfGas);
-            }
-        }
-
-        Ok(PrecompileOutput::default().into())
-    }
-
-    #[cfg(feature = "contract")]
     fn run(
         &self,
         input: &[u8],
@@ -526,7 +501,7 @@ impl Precompile for ExitToEthereum {
                 }
 
                 let erc20_address = context.caller;
-                let nep141_address = get_nep141_from_erc20(erc20_address.as_bytes());
+                let nep141_address = get_nep141_from_erc20(erc20_address.as_bytes(), &self.io)?;
 
                 let amount = U256::from_big_endian(&input[..32]);
                 input = &input[32..];
@@ -577,13 +552,13 @@ impl Precompile for ExitToEthereum {
 
         let promise = PromiseArgs::Create(withdraw_promise).try_to_vec().unwrap();
         let promise_log = Log {
-            address: Self::ADDRESS.raw(),
+            address: exit_to_ethereum::ADDRESS.raw(),
             topics: Vec::new(),
             data: promise,
         };
         let exit_event_log = exit_event.encode();
         let exit_event_log = Log {
-            address: Self::ADDRESS.raw(),
+            address: exit_to_ethereum::ADDRESS.raw(),
             topics: exit_event_log.topics,
             data: exit_event_log.data,
         };
@@ -598,17 +573,17 @@ impl Precompile for ExitToEthereum {
 
 #[cfg(test)]
 mod tests {
-    use super::{ExitToEthereum, ExitToNear};
+    use super::{exit_to_ethereum, exit_to_near};
     use crate::prelude::sdk::types::near_account_to_evm_address;
 
     #[test]
     fn test_precompile_id() {
         assert_eq!(
-            ExitToEthereum::ADDRESS,
+            exit_to_ethereum::ADDRESS,
             near_account_to_evm_address("exitToEthereum".as_bytes())
         );
         assert_eq!(
-            ExitToNear::ADDRESS,
+            exit_to_near::ADDRESS,
             near_account_to_evm_address("exitToNear".as_bytes())
         );
     }

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -418,7 +418,7 @@ mod contract {
                 }
                 // ETH exit; transfer ETH back from precompile address
                 None => {
-                    let exit_address = aurora_engine_precompiles::native::ExitToNear::ADDRESS;
+                    let exit_address = aurora_engine_precompiles::native::exit_to_near::ADDRESS;
                     let mut engine =
                         Engine::new(exit_address, current_account_id, io, &io).sdk_unwrap();
                     let refund_address = args.recipient_address;


### PR DESCRIPTION
To fully verify the standalone engine processes transactions exactly the same as what is deployed on chain, including `SubmitResult` return values, the standalone must be able to run the exit precompiles because they create EVM logs (and therefore have an observable effect on the `SubmitResult`).