### PR TITLE
Fix(Engine): Predecessor id precompile works in view calls

### DIFF
--- a/engine-precompiles/src/account_ids.rs
+++ b/engine-precompiles/src/account_ids.rs
@@ -1,6 +1,7 @@
 use super::{EvmPrecompileResult, Precompile};
 use crate::prelude::types::{Address, EthGas};
 use crate::PrecompileOutput;
+use aurora_engine_sdk::env::Env;
 use aurora_engine_types::account_id::AccountId;
 use evm::{Context, ExitError};
 
@@ -13,26 +14,28 @@ mod costs {
     pub(super) const CURRENT_ACCOUNT_GAS: EthGas = EthGas::new(0);
 }
 
-pub struct PredecessorAccount {
-    predecessor_account_id: AccountId,
+pub struct PredecessorAccount<'a, E> {
+    env: &'a E,
 }
 
-impl PredecessorAccount {
+pub mod predecessor_account {
+    use aurora_engine_types::types::Address;
+
     /// predecessor_account_id precompile address
     ///
     /// Address: `0x723ffbaba940e75e7bf5f6d61dcbf8d9a4de0fd7`
     /// This address is computed as: `&keccak("predecessorAccountId")[12..]`
     pub const ADDRESS: Address =
-        super::make_address(0x723ffbab, 0xa940e75e7bf5f6d61dcbf8d9a4de0fd7);
+        crate::make_address(0x723ffbab, 0xa940e75e7bf5f6d61dcbf8d9a4de0fd7);
+}
 
-    pub fn new(predecessor_account_id: AccountId) -> Self {
-        Self {
-            predecessor_account_id,
-        }
+impl<'a, E> PredecessorAccount<'a, E> {
+    pub fn new(env: &'a E) -> Self {
+        Self { env }
     }
 }
 
-impl Precompile for PredecessorAccount {
+impl<'a, E: Env> Precompile for PredecessorAccount<'a, E> {
     fn required_gas(_input: &[u8]) -> Result<EthGas, ExitError> {
         Ok(costs::PREDECESSOR_ACCOUNT_GAS)
     }
@@ -51,10 +54,8 @@ impl Precompile for PredecessorAccount {
             }
         }
 
-        Ok(
-            PrecompileOutput::without_logs(cost, self.predecessor_account_id.as_bytes().to_vec())
-                .into(),
-        )
+        let predecessor_account_id = self.env.predecessor_account_id();
+        Ok(PrecompileOutput::without_logs(cost, predecessor_account_id.as_bytes().to_vec()).into())
     }
 }
 
@@ -103,13 +104,13 @@ impl Precompile for CurrentAccount {
 
 #[cfg(test)]
 mod tests {
-    use crate::account_ids::{CurrentAccount, PredecessorAccount};
+    use crate::account_ids::{predecessor_account, CurrentAccount};
     use crate::prelude::sdk::types::near_account_to_evm_address;
 
     #[test]
     fn test_predecessor_account_precompile_id() {
         assert_eq!(
-            PredecessorAccount::ADDRESS,
+            predecessor_account::ADDRESS,
             near_account_to_evm_address("predecessorAccountId".as_bytes())
         );
     }

--- a/engine-tests/src/test_utils/mod.rs
+++ b/engine-tests/src/test_utils/mod.rs
@@ -9,7 +9,7 @@ use near_primitives_core::contract::ContractCode;
 use near_primitives_core::profile::ProfileData;
 use near_primitives_core::runtime::fees::RuntimeFeesConfig;
 use near_vm_logic::types::ReturnData;
-use near_vm_logic::{VMContext, VMOutcome};
+use near_vm_logic::{VMContext, VMOutcome, ViewConfig};
 use near_vm_runner::{MockCompiledContractCache, VMError};
 use rlp::RlpStream;
 use secp256k1::{self, Message, PublicKey, SecretKey};
@@ -400,7 +400,11 @@ impl AuroraRunner {
 
     pub fn view_call(&self, args: ViewCallArgs) -> Result<TransactionStatus, VMError> {
         let input = args.try_to_vec().unwrap();
-        let (outcome, maybe_error) = self.one_shot().call("view", "viewer", input);
+        let mut runner = self.one_shot();
+        runner.context.view_config = Some(ViewConfig {
+            max_gas_burnt: u64::MAX,
+        });
+        let (outcome, maybe_error) = runner.call("view", "viewer", input);
         Ok(
             TransactionStatus::try_from_slice(&Self::bytes_from_outcome(outcome, maybe_error)?)
                 .unwrap(),
@@ -412,8 +416,11 @@ impl AuroraRunner {
         args: ViewCallArgs,
     ) -> (Result<TransactionStatus, VMError>, ExecutionProfile) {
         let input = args.try_to_vec().unwrap();
-        let (outcome, maybe_error, profile) =
-            self.one_shot().profiled_call("view", "viewer", input);
+        let mut runner = self.one_shot();
+        runner.context.view_config = Some(ViewConfig {
+            max_gas_burnt: u64::MAX,
+        });
+        let (outcome, maybe_error, profile) = runner.profiled_call("view", "viewer", input);
         let status = Self::bytes_from_outcome(outcome, maybe_error)
             .map(|bytes| TransactionStatus::try_from_slice(&bytes).unwrap());
 

--- a/engine-tests/src/tests/account_id_precompiles.rs
+++ b/engine-tests/src/tests/account_id_precompiles.rs
@@ -41,6 +41,14 @@ fn test_account_id_precompiles() {
         .unwrap();
     assert_eq!(unwrap_ethabi_string(&result), "some-account.near");
 
+    // confirm the precompile works in view calls too
+    let tx = contract.call_method_without_args("predecessorAccountId", 0.into());
+    let sender = test_utils::address_from_secret_key(&signer.secret_key);
+    let result = runner
+        .view_call(test_utils::as_view_call(tx, sender))
+        .unwrap();
+    assert!(result.is_ok());
+
     // double check the case where account_id is the full 64 bytes
     let account_id = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
     assert_eq!(account_id.len(), 64);

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -91,7 +91,7 @@ mod contract {
     };
     use aurora_engine_sdk::env::Env;
     use aurora_engine_sdk::io::{StorageIntermediate, IO};
-    use aurora_engine_sdk::near_runtime::Runtime;
+    use aurora_engine_sdk::near_runtime::{Runtime, ViewEnv};
     use aurora_engine_sdk::promise::PromiseHandler;
 
     #[cfg(feature = "integration-test")]
@@ -452,9 +452,10 @@ mod contract {
     #[no_mangle]
     pub extern "C" fn view() {
         let mut io = Runtime;
+        let env = ViewEnv;
         let args: ViewCallArgs = io.read_input_borsh().sdk_unwrap();
         let current_account_id = io.current_account_id();
-        let engine = Engine::new(args.sender, current_account_id, io, &io).sdk_unwrap();
+        let engine = Engine::new(args.sender, current_account_id, io, &env).sdk_unwrap();
         let result = Engine::view_with_args(&engine, args).sdk_unwrap();
         io.return_output(&result.try_to_vec().sdk_expect("ERR_SERIALIZE"));
     }


### PR DESCRIPTION
This PR addresses the issue of the `predecessor_account_id` precompile failing in view calls. It does this by creating a new instance of the `Env` trait where it inserts default values for the methods that are not defined in NEAR during view calls. This instance of `Env` is used in the Engine's `view` method. To verify this fix works, our tests are also updated to put the NEAR runtime in view-call mode when executing a read-only call. As additional insurance, the call to `Env::predecessor_account_id` is made lazy; instead of calling the method when constructing the `Precompiles` struct, instead the `Env` reference itself is passed to the precompile, so that only when the `predecessor_account_id` precompile is invoked does that method get called. This means if someone accidentally calls another Engine method besides `view` as a view call, it will not necessarily fail if they do not need the `predecessor_account_id`.