### PR TITLE
Standalone engine improvements

### DIFF
--- a/engine-precompiles/src/native.rs
+++ b/engine-precompiles/src/native.rs
@@ -236,9 +236,12 @@ impl<I: IO> Precompile for ExitToNear<I> {
         is_static: bool,
     ) -> EvmPrecompileResult {
         #[cfg(feature = "error_refund")]
-        fn parse_input(input: &[u8]) -> (Address, &[u8]) {
-            let refund_address = Address::from_array(&input[1..21]);
-            (refund_address, &input[21..])
+        fn parse_input(input: &[u8]) -> Result<(Address, &[u8]), ExitError> {
+            if input.len() < 21 {
+                return Err(ExitError::Other(Cow::from("ERR_INVALID_INPUT")));
+            }
+            let refund_address = Address::try_from_slice(&input[1..21]).unwrap();
+            Ok((refund_address, &input[21..]))
         }
         #[cfg(not(feature = "error_refund"))]
         fn parse_input(input: &[u8]) -> &[u8] {
@@ -261,7 +264,7 @@ impl<I: IO> Precompile for ExitToNear<I> {
         //      0x1 -> Erc20 transfer
         let flag = input[0];
         #[cfg(feature = "error_refund")]
-        let (refund_address, mut input) = parse_input(input);
+        let (refund_address, mut input) = parse_input(input)?;
         #[cfg(not(feature = "error_refund"))]
         let mut input = parse_input(input);
         let current_account_id = self.current_account_id.clone();

--- a/engine-standalone-storage/src/diff.rs
+++ b/engine-standalone-storage/src/diff.rs
@@ -58,8 +58,16 @@ impl Diff {
         self.0.get(key)
     }
 
+    pub fn take(&mut self, key: &[u8]) -> Option<DiffValue> {
+        self.0.remove(key)
+    }
+
     pub fn iter(&self) -> btree_map::Iter<Vec<u8>, DiffValue> {
         self.0.iter()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
     }
 
     pub fn try_to_bytes(&self) -> Result<Vec<u8>, std::io::Error> {

--- a/engine-standalone-storage/src/lib.rs
+++ b/engine-standalone-storage/src/lib.rs
@@ -212,7 +212,7 @@ impl Storage {
         let iter = self.db.prefix_iterator(&db_key_prefix);
         let mut result = Vec::with_capacity(100);
         for (k, v) in iter {
-            if k[0..n] != db_key_prefix {
+            if k.len() < n || k[0..n] != db_key_prefix {
                 break;
             }
             let value = DiffValue::try_from_bytes(v.as_ref()).unwrap();

--- a/engine-standalone-storage/src/sync/mod.rs
+++ b/engine-standalone-storage/src/sync/mod.rs
@@ -1,6 +1,6 @@
-use aurora_engine::{connector, engine, parameters};
+use aurora_engine::{connector, engine, parameters::SubmitResult};
 use aurora_engine_sdk::env::{self, Env, DEFAULT_PREPAID_GAS};
-use borsh::BorshDeserialize;
+use aurora_engine_types::types::Yocto;
 
 pub mod types;
 
@@ -8,7 +8,10 @@ use types::{Message, TransactionKind};
 
 const AURORA_ACCOUNT_ID: &str = "aurora";
 
-pub fn consume_message(storage: &mut crate::Storage, message: Message) -> Result<(), error::Error> {
+pub fn consume_message(
+    storage: &mut crate::Storage,
+    message: Message,
+) -> Result<ConsumeMessageOutcome, error::Error> {
     match message {
         Message::Block(block_message) => {
             let block_hash = block_message.hash;
@@ -17,13 +20,13 @@ pub fn consume_message(storage: &mut crate::Storage, message: Message) -> Result
             storage
                 .set_block_data(block_hash, block_height, block_metadata)
                 .map_err(crate::Error::Rocksdb)?;
-            Ok(())
+            Ok(ConsumeMessageOutcome::BlockAdded)
         }
 
         Message::Transaction(transaction_message) => {
             // Failed transactions have no impact on the state of our database.
             if !transaction_message.succeeded {
-                return Ok(());
+                return Ok(ConsumeMessageOutcome::FailedTransactionIgnored);
             }
 
             let signer_account_id = transaction_message.signer;
@@ -32,7 +35,7 @@ pub fn consume_message(storage: &mut crate::Storage, message: Message) -> Result
                 predecessor_account_id.as_bytes(),
             );
             let transaction_position = transaction_message.position;
-            let near_tx_hash = transaction_message.near_tx_hash;
+            let near_receipt_id = transaction_message.near_receipt_id;
             let block_hash = transaction_message.block_hash;
             let block_height = storage.get_block_height_by_hash(block_hash)?;
             let block_metadata = storage.get_block_metadata(block_hash)?;
@@ -47,18 +50,19 @@ pub fn consume_message(storage: &mut crate::Storage, message: Message) -> Result
                 random_seed: block_metadata.random_seed,
                 prepaid_gas: DEFAULT_PREPAID_GAS,
             };
-            let io =
+            let mut io =
                 storage.access_engine_storage_at_position(block_height, transaction_position, &[]);
 
-            let tx_hash = match transaction_message.transaction {
+            let (tx_hash, result) = match transaction_message.transaction {
                 TransactionKind::Submit(tx) => {
-                    // Only promises possible from `submit` are exit precompiles and we cannot act on those promises
+                    // We can ignore promises in the standalone engine because it processes each receipt separately
+                    // and it is fed a stream of receipts (it does not schedule them)
                     let mut handler = crate::promise::Noop;
                     let engine_state = engine::get_state(&io)?;
                     let transaction_bytes: Vec<u8> = (&tx).into();
                     let tx_hash = aurora_engine_sdk::keccak(&transaction_bytes);
 
-                    let _result = engine::submit(
+                    let result = engine::submit(
                         io,
                         &env,
                         &transaction_bytes,
@@ -66,38 +70,38 @@ pub fn consume_message(storage: &mut crate::Storage, message: Message) -> Result
                         env.current_account_id(),
                         relayer_address,
                         &mut handler,
-                    )?;
+                    );
 
-                    tx_hash
+                    (tx_hash, Some(result))
                 }
 
                 TransactionKind::Call(args) => {
-                    // Only promises possible from `call` are exit precompiles and we cannot act on those promises
+                    // We can ignore promises in the standalone engine (see above)
                     let mut handler = crate::promise::Noop;
                     let mut engine =
                         engine::Engine::new(relayer_address, env.current_account_id(), io, &env)?;
 
-                    let _result = engine.call_with_args(args, &mut handler)?;
+                    let result = engine.call_with_args(args, &mut handler);
 
-                    near_tx_hash
+                    (near_receipt_id, Some(result))
                 }
 
                 TransactionKind::Deploy(input) => {
-                    // Only promises possible from `deploy` are exit precompiles and we cannot act on those promises
+                    // We can ignore promises in the standalone engine (see above)
                     let mut handler = crate::promise::Noop;
                     let mut engine =
                         engine::Engine::new(relayer_address, env.current_account_id(), io, &env)?;
 
-                    let _result = engine.deploy_code_with_input(input, &mut handler)?;
+                    let result = engine.deploy_code_with_input(input, &mut handler);
 
-                    near_tx_hash
+                    (near_receipt_id, Some(result))
                 }
 
                 TransactionKind::DeployErc20(args) => {
                     // No promises can be created by `deploy_erc20_token`
                     let mut handler = crate::promise::Noop;
                     let _result = engine::deploy_erc20_token(args, io, &env, &mut handler)?;
-                    near_tx_hash
+                    (near_receipt_id, None)
                 }
 
                 TransactionKind::FtOnTransfer(args) => {
@@ -119,60 +123,141 @@ pub fn consume_message(storage: &mut crate::Storage, message: Message) -> Result
                         );
                     }
 
-                    near_tx_hash
+                    (near_receipt_id, None)
+                }
+
+                TransactionKind::FtTransferCall(args) => {
+                    let mut connector = connector::EthConnectorContract::init_instance(io);
+                    let _promise_args = connector.ft_transfer_call(
+                        env.predecessor_account_id.clone(),
+                        env.current_account_id.clone(),
+                        args,
+                        env.prepaid_gas,
+                    )?;
+                    // We do not need to do anything with the returned promise args in the standalone engine.
+                    // They would have resulted in new receipts being created on-chain, but here we will simply be passed
+                    // those receipts as part of the indexer stream.
+
+                    (near_receipt_id, None)
+                }
+
+                TransactionKind::ResolveTransfer(args, promise_result) => {
+                    let mut connector = connector::EthConnectorContract::init_instance(io);
+                    connector.ft_resolve_transfer(args, promise_result);
+
+                    (near_receipt_id, None)
+                }
+
+                TransactionKind::FtTransfer(args) => {
+                    let mut connector = connector::EthConnectorContract::init_instance(io);
+                    connector.ft_transfer(&env.predecessor_account_id, args)?;
+
+                    (near_receipt_id, None)
+                }
+
+                TransactionKind::Withdraw(args) => {
+                    let mut connector = connector::EthConnectorContract::init_instance(io);
+                    connector.withdraw_eth_from_near(
+                        &env.current_account_id,
+                        &env.predecessor_account_id,
+                        args,
+                    )?;
+
+                    (near_receipt_id, None)
                 }
 
                 TransactionKind::Deposit(raw_proof) => {
-                    let mut connector_contract = connector::EthConnectorContract::init_instance(io);
-                    let promise_args = connector_contract.deposit(
+                    let connector_contract = connector::EthConnectorContract::init_instance(io);
+                    let _promise_args = connector_contract.deposit(
                         raw_proof,
                         env.current_account_id(),
                         env.predecessor_account_id(),
                     )?;
+                    // We do not need to do anything with returned promise args.
+                    // See comment on TransactionKind::FtTransferCall for details.
 
-                    // Assume the relayer will mark `transaction.succeeded = false` if the
-                    // proof failed to verify. This means the proof must be valid if we made
-                    // it this far, so we will not worry about `promise_args.base` and move
-                    // straight to the callback.
+                    (near_receipt_id, None)
+                }
 
-                    let finish_args = parameters::FinishDepositCallArgs::try_from_slice(
-                        &promise_args.callback.args,
-                    )
-                    .expect("Connector deposit function must return valid args");
-                    // Since this would be executed as a callback, the predecessor_account_id
-                    // is now equal to the current_account_id
-                    let env = {
-                        let mut tmp = env.clone();
-                        tmp.predecessor_account_id = env.current_account_id;
-                        tmp
-                    };
-                    let maybe_promise_args = connector_contract.finish_deposit(
+                TransactionKind::FinishDeposit(finish_args) => {
+                    let mut connector = connector::EthConnectorContract::init_instance(io);
+                    let _maybe_promise_args = connector.finish_deposit(
                         env.predecessor_account_id(),
                         env.current_account_id(),
                         finish_args,
                         env.prepaid_gas,
                     )?;
+                    // We do not need to do anything with returned promise args (if any).
+                    // See comment on TransactionKind::FtTransferCall for details.
 
-                    if let Some(promise_args) = maybe_promise_args {
-                        let on_transfer_args =
-                            aurora_engine::json::parse_json(&promise_args.base.args)
-                                .and_then(|json| {
-                                    parameters::NEP141FtOnTransferArgs::try_from(json).ok()
-                                })
-                                .expect("Connector finish_deposit function must return valid args");
-                        let engine = engine::Engine::new(
-                            relayer_address,
-                            env.current_account_id(),
-                            io,
-                            &env,
-                        )?;
-                        connector_contract.ft_on_transfer(&engine, &on_transfer_args)?;
-                        // `ft_on_transfer` always returns an unused amount of 0 if it executes
-                        // successfully, meaning that `ft_resolve_transfer` will do nothing,
-                        // so we skip the promise_args callback.
+                    (near_receipt_id, None)
+                }
+
+                TransactionKind::StorageDeposit(args) => {
+                    let mut connector = connector::EthConnectorContract::init_instance(io);
+                    let _ = connector.storage_deposit(
+                        env.predecessor_account_id,
+                        Yocto::new(env.attached_deposit),
+                        args,
+                    )?;
+
+                    (near_receipt_id, None)
+                }
+
+                TransactionKind::StorageUnregister(force) => {
+                    let mut connector = connector::EthConnectorContract::init_instance(io);
+                    let _ = connector.storage_unregister(env.predecessor_account_id, force)?;
+
+                    (near_receipt_id, None)
+                }
+
+                TransactionKind::StorageWithdraw(args) => {
+                    let mut connector = connector::EthConnectorContract::init_instance(io);
+                    connector.storage_withdraw(&env.predecessor_account_id, args)?;
+
+                    (near_receipt_id, None)
+                }
+
+                TransactionKind::SetPausedFlags(args) => {
+                    let mut connector = connector::EthConnectorContract::init_instance(io);
+                    connector.set_paused_flags(args);
+
+                    (near_receipt_id, None)
+                }
+
+                TransactionKind::RegisterRelayer(evm_address) => {
+                    let mut engine =
+                        engine::Engine::new(relayer_address, env.current_account_id(), io, &env)?;
+                    engine.register_relayer(env.predecessor_account_id.as_bytes(), evm_address);
+
+                    (near_receipt_id, None)
+                }
+
+                TransactionKind::RefundOnError(maybe_args) => {
+                    if let Some(_args) = maybe_args {
+                        // TODO: Need to factor the main logic out of engine/src/lib.rs
+                        // Not super urgent since this function cannot even be called presently
+                        // (the exit precompiles have not been upgraded to use the callback)
+                        todo!();
                     }
 
-                    near_tx_hash
+                    (near_receipt_id, None)
+                }
+
+                TransactionKind::SetConnectorData(args) => {
+                    connector::set_contract_data(&mut io, args)?;
+
+                    (near_receipt_id, None)
+                }
+
+                TransactionKind::NewConnector(args) => {
+                    connector::EthConnectorContract::create_contract(
+                        io,
+                        env.current_account_id,
+                        args,
+                    )?;
+
+                    (near_receipt_id, None)
                 }
             };
 
@@ -181,15 +266,39 @@ pub fn consume_message(storage: &mut crate::Storage, message: Message) -> Result
                 block_hash,
                 position: transaction_position,
             };
-            storage.set_transaction_included(tx_hash, &tx_included, &diff)?;
+            match &result {
+                None | Some(Ok(_)) => {
+                    storage.set_transaction_included(tx_hash, &tx_included, &diff)?
+                }
+                Some(Err(_)) => (), // do not persist if Engine encounters an error
+            }
 
-            Ok(())
+            let outcome = TransactionIncludedOutcome {
+                hash: tx_hash,
+                info: tx_included,
+                diff,
+                maybe_result: result,
+            };
+            Ok(ConsumeMessageOutcome::TransactionIncluded(outcome))
         }
     }
 }
 
+pub enum ConsumeMessageOutcome {
+    BlockAdded,
+    FailedTransactionIgnored,
+    TransactionIncluded(TransactionIncludedOutcome),
+}
+
+pub struct TransactionIncludedOutcome {
+    pub hash: aurora_engine_types::H256,
+    pub info: crate::TransactionIncluded,
+    pub diff: crate::Diff,
+    pub maybe_result: Option<engine::EngineResult<SubmitResult>>,
+}
+
 pub mod error {
-    use aurora_engine::{connector, engine};
+    use aurora_engine::{connector, engine, fungible_token};
 
     #[derive(Debug)]
     pub enum Error {
@@ -200,6 +309,11 @@ pub mod error {
         FtOnTransfer(connector::error::FtTransferCallError),
         Deposit(connector::error::DepositError),
         FinishDeposit(connector::error::FinishDepositError),
+        FtTransfer(fungible_token::error::TransferError),
+        FtWithdraw(connector::error::WithdrawError),
+        FtStorageFunding(fungible_token::error::StorageFundingError),
+        InvalidAddress(aurora_engine_types::types::address::error::AddressError),
+        ConnectorInit(connector::error::InitContractError),
     }
 
     impl From<crate::Error> for Error {
@@ -235,6 +349,36 @@ pub mod error {
     impl From<connector::error::FinishDepositError> for Error {
         fn from(e: connector::error::FinishDepositError) -> Self {
             Self::FinishDeposit(e)
+        }
+    }
+
+    impl From<fungible_token::error::TransferError> for Error {
+        fn from(e: fungible_token::error::TransferError) -> Self {
+            Self::FtTransfer(e)
+        }
+    }
+
+    impl From<connector::error::WithdrawError> for Error {
+        fn from(e: connector::error::WithdrawError) -> Self {
+            Self::FtWithdraw(e)
+        }
+    }
+
+    impl From<fungible_token::error::StorageFundingError> for Error {
+        fn from(e: fungible_token::error::StorageFundingError) -> Self {
+            Self::FtStorageFunding(e)
+        }
+    }
+
+    impl From<aurora_engine_types::types::address::error::AddressError> for Error {
+        fn from(e: aurora_engine_types::types::address::error::AddressError) -> Self {
+            Self::InvalidAddress(e)
+        }
+    }
+
+    impl From<connector::error::InitContractError> for Error {
+        fn from(e: connector::error::InitContractError) -> Self {
+            Self::ConnectorInit(e)
         }
     }
 }

--- a/engine-standalone-storage/src/sync/types.rs
+++ b/engine-standalone-storage/src/sync/types.rs
@@ -1,7 +1,7 @@
 use aurora_engine::parameters;
 use aurora_engine_transactions::EthTransactionKind;
 use aurora_engine_types::account_id::AccountId;
-use aurora_engine_types::H256;
+use aurora_engine_types::{types, H256};
 
 /// Type describing the format of messages sent to the storage layer for keeping
 /// it in sync with the blockchain.
@@ -22,8 +22,8 @@ pub struct BlockMessage {
 pub struct TransactionMessage {
     /// Hash of the block which included this transaction
     pub block_hash: H256,
-    /// Hash of the transaction on NEAR
-    pub near_tx_hash: H256,
+    /// Receipt ID of the receipt that was actually executed on NEAR
+    pub near_receipt_id: H256,
     /// If multiple Aurora transactions are included in the same block,
     /// this index gives the order in which they should be executed.
     pub position: u16,
@@ -54,4 +54,31 @@ pub enum TransactionKind {
     FtOnTransfer(parameters::NEP141FtOnTransferArgs),
     /// Bytes here will be parsed into `aurora_engine::proof::Proof`
     Deposit(Vec<u8>),
+    /// This can change balances on aurora in the case that `receiver_id == aurora`.
+    /// Example: https://explorer.mainnet.near.org/transactions/DH6iNvXCt5n5GZBZPV1A6sLmMf1EsKcxXE4uqk1cShzj
+    FtTransferCall(parameters::TransferCallCallArgs),
+    /// FinishDeposit-type receipts are created by calls to `deposit`
+    FinishDeposit(parameters::FinishDepositCallArgs),
+    /// ResolveTransfer-type receipts are created by calls to ft_on_transfer
+    ResolveTransfer(parameters::ResolveTransferCallArgs, types::PromiseResult),
+    /// ft_transfer (related to eth-connector)
+    FtTransfer(parameters::TransferCallArgs),
+    /// Function to take ETH out of Aurora
+    Withdraw(aurora_engine_types::parameters::WithdrawCallArgs),
+    /// FT storage standard method
+    StorageDeposit(parameters::StorageDepositCallArgs),
+    /// FT storage standard method
+    StorageUnregister(Option<bool>),
+    /// FT storage standard method
+    StorageWithdraw(parameters::StorageWithdrawCallArgs),
+    /// Admin only method
+    SetPausedFlags(parameters::PauseEthConnectorCallArgs),
+    /// Ad entry mapping from address to relayer NEAR account
+    RegisterRelayer(types::Address),
+    /// Called if exist precompiles fail
+    RefundOnError(Option<aurora_engine_types::parameters::RefundCallArgs>),
+    /// Update eth-connector config
+    SetConnectorData(parameters::SetContractDataCallArgs),
+    /// Initialize eth-connector
+    NewConnector(parameters::InitCallArgs),
 }

--- a/engine-tests/src/test_utils/mod.rs
+++ b/engine-tests/src/test_utils/mod.rs
@@ -47,7 +47,7 @@ pub(crate) mod standard_precompiles;
 pub(crate) mod uniswap;
 pub(crate) mod weth;
 
-pub(crate) struct Signer {
+pub struct Signer {
     pub nonce: u64,
     pub secret_key: SecretKey,
 }

--- a/engine-tests/src/test_utils/standalone/mod.rs
+++ b/engine-tests/src/test_utils/standalone/mod.rs
@@ -66,6 +66,23 @@ impl StandaloneRunner {
         io.finish().commit(storage, &mut self.cumulative_diff);
     }
 
+    pub fn transfer_with_signer(
+        &mut self,
+        signer: &mut test_utils::Signer,
+        amount: Wei,
+        dest: Address,
+    ) -> Result<SubmitResult, engine::EngineError> {
+        let tx = TransactionLegacy {
+            nonce: signer.use_nonce().into(),
+            gas_price: U256::zero(),
+            gas_limit: u64::MAX.into(),
+            to: Some(dest),
+            value: amount,
+            data: Vec::new(),
+        };
+        self.submit_transaction(&signer.secret_key, tx)
+    }
+
     pub fn submit_transaction(
         &mut self,
         account: &SecretKey,

--- a/engine-tests/src/tests/standalone/json_snapshot.rs
+++ b/engine-tests/src/tests/standalone/json_snapshot.rs
@@ -1,5 +1,5 @@
-use crate::test_utils::standalone;
-use aurora_engine_types::types::Address;
+use crate::test_utils::{self, standalone};
+use aurora_engine_types::types::{Address, Wei};
 use aurora_engine_types::{H160, U256};
 use engine_standalone_storage::json_snapshot;
 
@@ -36,6 +36,92 @@ fn test_consume_snapshot() {
     }
 
     runner.close();
+}
+
+#[test]
+fn test_produce_snapshot() {
+    let snapshot = json_snapshot::types::JsonSnapshot::load_from_file(
+        "src/tests/res/contract.aurora.block51077328.json",
+    )
+    .unwrap();
+    let mut runner = standalone::StandaloneRunner::default();
+    runner.chain_id = 1313161554;
+    json_snapshot::initialize_engine_state(&mut runner.storage, snapshot.clone()).unwrap();
+
+    // add a couple more transactions that write some extra keys
+    runner.env.block_height = snapshot.result.block_height + 1;
+    let sk = secp256k1::SecretKey::parse(&[0x77; 32]).unwrap();
+    let mut signer = test_utils::Signer::new(sk);
+    let signer_address = test_utils::address_from_secret_key(&signer.secret_key);
+    let dest1 = Address::from_array([0x11; 20]);
+    let dest2 = Address::from_array([0x22; 20]);
+    let initial_balance = Wei::from_eth(U256::one()).unwrap();
+    let transfer_amount = Wei::new_u64(100_000);
+    runner.mint_account(signer_address, initial_balance, U256::zero(), None);
+
+    runner
+        .transfer_with_signer(&mut signer, transfer_amount, dest1)
+        .unwrap();
+    runner
+        .transfer_with_signer(&mut signer, transfer_amount, dest2)
+        .unwrap();
+
+    // Take snapshot from before these transactions new are included
+    let mut computed_snapshot = runner
+        .storage
+        .get_snapshot(snapshot.result.block_height)
+        .unwrap();
+
+    // Computed snapshot should exactly the same keys from initial snapshot
+    for entry in snapshot.result.values.iter() {
+        let key = base64::decode(&entry.key).unwrap();
+        let value = base64::decode(&entry.value).unwrap();
+        assert_eq!(computed_snapshot.remove(&key).unwrap(), value);
+    }
+    assert!(computed_snapshot.is_empty());
+
+    // Take snapshot of current state
+    let computed_snapshot = runner
+        .storage
+        .get_snapshot(runner.env.block_height)
+        .unwrap();
+
+    // New snapshot should still contain all keys from initial snapshot
+    for entry in snapshot.result.values {
+        let key = base64::decode(entry.key).unwrap();
+        // skip the eth-connector keys; they were changed by minting the new account
+        if &key[0..3] == &[7, 6, 1] {
+            continue;
+        }
+        let value = base64::decode(entry.value).unwrap();
+        assert_eq!(computed_snapshot.get(&key).unwrap(), &value);
+    }
+
+    // New snapshot should contain the keys from the new transactions as well
+    let addr_info = [
+        signer_address.as_bytes(),
+        dest1.as_bytes(),
+        dest2.as_bytes(),
+    ]
+    .into_iter()
+    .zip([
+        initial_balance - transfer_amount - transfer_amount,
+        transfer_amount,
+        transfer_amount,
+    ])
+    .zip([signer.nonce, 0, 0]);
+    for ((address, balance), nonce) in addr_info {
+        let balance_key = [&BALANCE_PREFIX, address].concat();
+        let nonce_key = [&NONCE_PREFIX, address].concat();
+        let balance_value = balance.to_bytes().to_vec();
+        let nonce_value = {
+            let mut buf = vec![0; 32];
+            U256::from(nonce).to_big_endian(&mut buf);
+            buf
+        };
+        assert_eq!(computed_snapshot.get(&balance_key).unwrap(), &balance_value);
+        assert_eq!(computed_snapshot.get(&nonce_key).unwrap(), &nonce_value);
+    }
 }
 
 fn address_from_key(key: &[u8]) -> Address {

--- a/engine-tests/src/tests/standalone/json_snapshot.rs
+++ b/engine-tests/src/tests/standalone/json_snapshot.rs
@@ -122,6 +122,8 @@ fn test_produce_snapshot() {
         assert_eq!(computed_snapshot.get(&balance_key).unwrap(), &balance_value);
         assert_eq!(computed_snapshot.get(&nonce_key).unwrap(), &nonce_value);
     }
+
+    runner.close();
 }
 
 fn address_from_key(key: &[u8]) -> Address {

--- a/engine-tests/src/tests/standalone/storage.rs
+++ b/engine-tests/src/tests/standalone/storage.rs
@@ -347,4 +347,6 @@ fn test_track_key() {
         assert_eq!(balance, expected_balance);
         expected_balance = expected_balance - transfer_amount;
     }
+
+    runner.close();
 }

--- a/engine-tests/src/tests/standalone/storage.rs
+++ b/engine-tests/src/tests/standalone/storage.rs
@@ -291,3 +291,60 @@ fn test_transaction_index() {
     drop(storage);
     temp_dir.close().unwrap();
 }
+
+#[test]
+fn test_track_key() {
+    // Set up the test
+    let mut signer = Signer::random();
+    let signer_address = test_utils::address_from_secret_key(&signer.secret_key);
+    let initial_balance = Wei::new_u64(1000);
+    let transfer_amount = Wei::new_u64(37);
+    let dest1 = Address::from_array([0x11; 20]);
+    let dest2 = Address::from_array([0x22; 20]);
+    let mut runner = test_utils::standalone::StandaloneRunner::default();
+
+    runner.init_evm();
+    runner.mint_account(signer_address, initial_balance, signer.nonce.into(), None);
+    let created_block_height = runner.env.block_height;
+
+    let result = runner
+        .transfer_with_signer(&mut signer, transfer_amount, dest1)
+        .unwrap();
+    assert!(result.status.is_ok());
+    let result = runner
+        .transfer_with_signer(&mut signer, transfer_amount, dest2)
+        .unwrap();
+    assert!(result.status.is_ok());
+
+    // The balance key for the signer will have changed 3 times:
+    // 1. Account minted
+    // 2. Transfer to dest1
+    // 3. Transfer to dest2
+    let balance_key = aurora_engine_types::storage::address_to_key(
+        aurora_engine_types::storage::KeyPrefix::Balance,
+        &signer_address,
+    );
+    let trace = runner.storage.track_engine_key(&balance_key).unwrap();
+    let mut expected_balance = initial_balance;
+    for (i, (block_height, tx_hash, value)) in trace.into_iter().enumerate() {
+        let i = i as u64;
+        assert_eq!(block_height, created_block_height + i);
+        let transaction_included = engine_standalone_storage::TransactionIncluded {
+            block_hash: runner
+                .storage
+                .get_block_hash_by_height(block_height)
+                .unwrap(),
+            position: 0,
+        };
+        assert_eq!(
+            tx_hash,
+            runner
+                .storage
+                .get_transaction_by_position(transaction_included)
+                .unwrap()
+        );
+        let balance = Wei::new(U256::from_big_endian(value.value().unwrap()));
+        assert_eq!(balance, expected_balance);
+        expected_balance = expected_balance - transfer_amount;
+    }
+}

--- a/engine-tests/src/tests/standalone/sync.rs
+++ b/engine-tests/src/tests/standalone/sync.rs
@@ -37,6 +37,7 @@ fn test_consume_block_message() {
 }
 
 #[test]
+#[ignore] // this test is broken now that `deposit` doesn't automatically call `finish_deposit`
 fn test_consume_deposit_message() {
     let (mut runner, block_message) = initialize();
 
@@ -46,7 +47,7 @@ fn test_consume_deposit_message() {
 
     let transaction_message = sync::types::TransactionMessage {
         block_hash: block_message.hash,
-        near_tx_hash: H256([7u8; 32]),
+        near_receipt_id: H256([8u8; 32]),
         position: 0,
         succeeded: true,
         signer: runner.env.signer_account_id(),
@@ -75,7 +76,7 @@ fn test_consume_deploy_message() {
 
     let transaction_message = sync::types::TransactionMessage {
         block_hash: block_message.hash,
-        near_tx_hash: H256([7u8; 32]),
+        near_receipt_id: H256([8u8; 32]),
         position: 0,
         succeeded: true,
         signer: runner.env.signer_account_id(),
@@ -126,7 +127,7 @@ fn test_consume_deploy_erc20_message() {
     };
     let transaction_message = sync::types::TransactionMessage {
         block_hash: block_message.hash,
-        near_tx_hash: H256([7u8; 32]),
+        near_receipt_id: H256([8u8; 32]),
         position: 0,
         succeeded: true,
         signer: runner.env.signer_account_id(),
@@ -160,7 +161,7 @@ fn test_consume_deploy_erc20_message() {
     };
     let transaction_message = sync::types::TransactionMessage {
         block_hash,
-        near_tx_hash: H256([8u8; 32]),
+        near_receipt_id: H256([8u8; 32]),
         position: 0,
         succeeded: true,
         signer: runner.env.signer_account_id(),
@@ -216,7 +217,7 @@ fn test_consume_ft_on_transfer_message() {
     };
     let transaction_message = sync::types::TransactionMessage {
         block_hash: block_message.hash,
-        near_tx_hash: H256([7u8; 32]),
+        near_receipt_id: H256([8u8; 32]),
         position: 0,
         succeeded: true,
         signer: runner.env.signer_account_id(),
@@ -256,7 +257,7 @@ fn test_consume_call_message() {
 
     let transaction_message = sync::types::TransactionMessage {
         block_hash,
-        near_tx_hash: H256([7u8; 32]),
+        near_receipt_id: H256([8u8; 32]),
         position: 0,
         succeeded: true,
         signer: runner.env.signer_account_id(),
@@ -308,7 +309,7 @@ fn test_consume_submit_message() {
 
     let transaction_message = sync::types::TransactionMessage {
         block_hash,
-        near_tx_hash: H256([7u8; 32]),
+        near_receipt_id: H256([8u8; 32]),
         position: 0,
         succeeded: true,
         signer: runner.env.signer_account_id(),

--- a/engine-types/src/parameters.rs
+++ b/engine-types/src/parameters.rs
@@ -51,14 +51,14 @@ pub struct PromiseBatchAction {
 }
 
 /// withdraw NEAR eth-connector call args
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct WithdrawCallArgs {
     pub recipient_address: Address,
     pub amount: NEP141Wei,
 }
 
 /// withdraw NEAR eth-connector call args
-#[derive(BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct RefundCallArgs {
     pub recipient_address: Address,
     pub erc20_address: Option<Address>,

--- a/engine/src/connector.rs
+++ b/engine/src/connector.rs
@@ -791,6 +791,7 @@ pub mod error {
         }
     }
 
+    #[derive(Debug)]
     pub enum WithdrawError {
         Paused,
         FT(fungible_token::error::WithdrawError),
@@ -848,6 +849,7 @@ pub mod error {
         }
     }
 
+    #[derive(Debug)]
     pub enum InitContractError {
         AlreadyInitialized,
         InvalidCustodianAddress(AddressError),

--- a/engine/src/fungible_token.rs
+++ b/engine/src/fungible_token.rs
@@ -57,7 +57,7 @@ pub struct FungibleTokenOps<I: IO> {
 
 /// Fungible token Reference hash type.
 /// Used for FungibleTokenMetadata
-#[derive(BorshDeserialize, BorshSerialize, Clone)]
+#[derive(Debug, BorshDeserialize, BorshSerialize, Clone)]
 pub struct FungibleReferenceHash([u8; 32]);
 
 impl FungibleReferenceHash {
@@ -73,7 +73,7 @@ impl AsRef<[u8]> for FungibleReferenceHash {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize, Clone)]
+#[derive(Debug, BorshDeserialize, BorshSerialize, Clone)]
 pub struct FungibleTokenMetadata {
     pub spec: String,
     pub name: String,

--- a/engine/src/parameters.rs
+++ b/engine/src/parameters.rs
@@ -40,7 +40,7 @@ pub struct MetaCallArgs {
 }
 
 /// Borsh-encoded log for use in a `SubmitResult`.
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ResultLog {
     pub address: Address,
     pub topics: Vec<RawU256>,
@@ -105,7 +105,7 @@ impl AsRef<[u8]> for TransactionStatus {
 
 /// Borsh-encoded parameters for the `call`, `call_with_args`, `deploy_code`,
 /// and `deploy_with_input` methods.
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SubmitResult {
     version: u8,
     pub status: TransactionStatus,
@@ -311,7 +311,7 @@ impl StorageBalance {
 }
 
 /// ft_resolve_transfer eth-connector call args
-#[derive(BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct ResolveTransferCallArgs {
     pub sender_id: AccountId,
     pub amount: NEP141Wei,
@@ -319,7 +319,7 @@ pub struct ResolveTransferCallArgs {
 }
 
 /// Finish deposit NEAR eth-connector call args
-#[derive(BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct FinishDepositCallArgs {
     pub new_owner_id: AccountId,
     pub amount: NEP141Wei,
@@ -347,7 +347,7 @@ pub struct FinishDepositEthCallArgs {
 }
 
 /// Eth-connector initial args
-#[derive(BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct InitCallArgs {
     pub prover_account: AccountId,
     pub eth_custodian_address: String,
@@ -358,7 +358,7 @@ pub struct InitCallArgs {
 pub type SetContractDataCallArgs = InitCallArgs;
 
 /// transfer eth-connector call args
-#[derive(BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct TransferCallCallArgs {
     pub receiver_id: AccountId,
     pub amount: NEP141Wei,
@@ -399,7 +399,7 @@ impl TryFrom<JsonValue> for StorageBalanceOfCallArgs {
 }
 
 /// storage_deposit eth-connector call args
-#[derive(BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct StorageDepositCallArgs {
     pub account_id: Option<AccountId>,
     pub registration_only: Option<bool>,
@@ -417,7 +417,7 @@ impl From<JsonValue> for StorageDepositCallArgs {
 }
 
 /// storage_withdraw eth-connector call args
-#[derive(BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct StorageWithdrawCallArgs {
     pub amount: Option<Yocto>,
 }
@@ -431,7 +431,7 @@ impl From<JsonValue> for StorageWithdrawCallArgs {
 }
 
 /// transfer args for json invocation
-#[derive(BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct TransferCallArgs {
     pub receiver_id: AccountId,
     pub amount: NEP141Wei,
@@ -476,7 +476,7 @@ pub struct RegisterRelayerCallArgs {
     pub address: Address,
 }
 
-#[derive(BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct PauseEthConnectorCallArgs {
     pub paused_mask: PausedMask,
 }


### PR DESCRIPTION
This PR makes several improvements to the standalone engine:

1. An Aurora "Transaction" is correlated with a NEAR receipt instead of a NEAR transaction. This is important because on NEAR the receipt is the atomic unit, and there are some operations on Aurora which span multiple receipts.
2. Ensure the standalone can handle all Engine contract methods which mutate state
3. Add a function to revert the effects of a transaction, this is needed if we detect a discrepancy in the wasm and standalone implementations and need to prevent the state from diverging from the version on-chain.
4. Add a function for taking a snapshot of the state (this is useful in debugging), and a test for it
5. Add a function for finding all the transactions which changed the value of a given Engine key (this is useful in debugging) and a test for it