### PR TITLE
Feat(Engine): Add custom precompile for NEAR prepaid_gas

### DIFF
--- a/engine-precompiles/src/account_ids.rs
+++ b/engine-precompiles/src/account_ids.rs
@@ -8,9 +8,9 @@ use evm::{Context, ExitError};
 mod costs {
     use crate::prelude::types::EthGas;
 
-    // TODO(#51): Determine the correct amount of gas
+    // TODO(#483): Determine the correct amount of gas
     pub(super) const PREDECESSOR_ACCOUNT_GAS: EthGas = EthGas::new(0);
-    // TODO(#51): Determine the correct amount of gas
+    // TODO(#483): Determine the correct amount of gas
     pub(super) const CURRENT_ACCOUNT_GAS: EthGas = EthGas::new(0);
 }
 

--- a/engine-precompiles/src/native.rs
+++ b/engine-precompiles/src/native.rs
@@ -24,10 +24,10 @@ const ERR_TARGET_TOKEN_NOT_FOUND: &str = "Target token not found";
 mod costs {
     use crate::prelude::types::{EthGas, NearGas};
 
-    // TODO(#51): Determine the correct amount of gas
+    // TODO(#483): Determine the correct amount of gas
     pub(super) const EXIT_TO_NEAR_GAS: EthGas = EthGas::new(0);
 
-    // TODO(#51): Determine the correct amount of gas
+    // TODO(#483): Determine the correct amount of gas
     pub(super) const EXIT_TO_ETHEREUM_GAS: EthGas = EthGas::new(0);
 
     // TODO(#332): Determine the correct amount of gas

--- a/engine-precompiles/src/prepaid_gas.rs
+++ b/engine-precompiles/src/prepaid_gas.rs
@@ -14,7 +14,7 @@ pub const ADDRESS: Address = crate::make_address(0x536822d2, 0x7de53629ef1f84c60
 mod costs {
     use crate::prelude::types::EthGas;
 
-    // TODO(#51): Determine the correct amount of gas
+    // TODO(#483): Determine the correct amount of gas
     pub(super) const PREPAID_GAS_COST: EthGas = EthGas::new(0);
 }
 

--- a/engine-precompiles/src/prepaid_gas.rs
+++ b/engine-precompiles/src/prepaid_gas.rs
@@ -1,0 +1,72 @@
+use super::{EvmPrecompileResult, Precompile};
+use crate::prelude::types::{Address, EthGas};
+use crate::PrecompileOutput;
+use aurora_engine_sdk::env::Env;
+use aurora_engine_types::{vec, U256};
+use evm::{Context, ExitError};
+
+/// predecessor_account_id precompile address
+///
+/// Address: `0x536822d27de53629ef1f84c60555689e9488609f`
+/// This address is computed as: `&keccak("prepaidGas")[12..]`
+pub const ADDRESS: Address = crate::make_address(0x536822d2, 0x7de53629ef1f84c60555689e9488609f);
+
+mod costs {
+    use crate::prelude::types::EthGas;
+
+    // TODO(#51): Determine the correct amount of gas
+    pub(super) const PREPAID_GAS_COST: EthGas = EthGas::new(0);
+}
+
+pub struct PrepaidGas<'a, E> {
+    env: &'a E,
+}
+
+impl<'a, E> PrepaidGas<'a, E> {
+    pub fn new(env: &'a E) -> Self {
+        Self { env }
+    }
+}
+
+impl<'a, E: Env> Precompile for PrepaidGas<'a, E> {
+    fn required_gas(_input: &[u8]) -> Result<EthGas, ExitError> {
+        Ok(costs::PREPAID_GAS_COST)
+    }
+
+    fn run(
+        &self,
+        input: &[u8],
+        target_gas: Option<EthGas>,
+        _context: &Context,
+        _is_static: bool,
+    ) -> EvmPrecompileResult {
+        let cost = Self::required_gas(input)?;
+        if let Some(target_gas) = target_gas {
+            if cost > target_gas {
+                return Err(ExitError::OutOfGas);
+            }
+        }
+
+        let prepaid_gas = self.env.prepaid_gas();
+        let bytes = {
+            let mut buf = vec![0; 32];
+            U256::from(prepaid_gas.as_u64()).to_big_endian(&mut buf);
+            buf
+        };
+        Ok(PrecompileOutput::without_logs(cost, bytes).into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::prelude::sdk::types::near_account_to_evm_address;
+    use crate::prepaid_gas;
+
+    #[test]
+    fn test_prepaid_gas_precompile_id() {
+        assert_eq!(
+            prepaid_gas::ADDRESS,
+            near_account_to_evm_address("prepaidGas".as_bytes())
+        );
+    }
+}

--- a/engine-precompiles/src/random.rs
+++ b/engine-precompiles/src/random.rs
@@ -7,7 +7,7 @@ use evm::{Context, ExitError};
 mod costs {
     use crate::prelude::types::EthGas;
 
-    // TODO(#51): Determine the correct amount of gas
+    // TODO(#483): Determine the correct amount of gas
     pub(super) const RANDOM_BYTES_GAS: EthGas = EthGas::new(0);
 }
 

--- a/engine-tests/src/tests/mod.rs
+++ b/engine-tests/src/tests/mod.rs
@@ -8,6 +8,7 @@ mod eth_connector;
 #[cfg(feature = "meta-call")]
 mod meta_parsing;
 mod one_inch;
+mod prepaid_gas_precompile;
 mod random;
 mod repro;
 mod sanity;

--- a/engine-tests/src/tests/prepaid_gas_precompile.rs
+++ b/engine-tests/src/tests/prepaid_gas_precompile.rs
@@ -1,0 +1,41 @@
+use crate::test_utils::{self, standalone};
+use aurora_engine_precompiles::prepaid_gas;
+use aurora_engine_transactions::legacy::TransactionLegacy;
+use aurora_engine_types::{types::Wei, U256};
+
+#[test]
+fn test_prepaid_gas_precompile() {
+    let mut signer = test_utils::Signer::random();
+    let mut runner = test_utils::deploy_evm();
+    let mut standalone = standalone::StandaloneRunner::default();
+
+    standalone.init_evm();
+    runner.standalone_runner = Some(standalone);
+
+    let transaction = TransactionLegacy {
+        nonce: signer.use_nonce().into(),
+        gas_price: U256::zero(),
+        gas_limit: u64::MAX.into(),
+        to: Some(prepaid_gas::ADDRESS),
+        value: Wei::zero(),
+        data: Vec::new(),
+    };
+
+    const EXPECTED_VALUE: u64 = 157_277_246_352_223;
+    runner.context.prepaid_gas = EXPECTED_VALUE;
+    let result = runner
+        .submit_transaction(&signer.secret_key, transaction.clone())
+        .unwrap();
+
+    assert_eq!(
+        U256::from(EXPECTED_VALUE),
+        U256::from_big_endian(test_utils::unwrap_success_slice(&result)),
+    );
+
+    // confirm the precompile works in view calls too
+    let sender = test_utils::address_from_secret_key(&signer.secret_key);
+    let result = runner
+        .view_call(test_utils::as_view_call(transaction, sender))
+        .unwrap();
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
Adds another custom precompile for Aurora. This one exposes the `prepaid_gas` NEAR host function. It may be useful for Aurora-based cross contract calls in the future.