### PR TITLE
Feat(standalone): Persist transaction data

### DIFF
--- a/engine-standalone-storage/src/error.rs
+++ b/engine-standalone-storage/src/error.rs
@@ -5,6 +5,7 @@ use crate::TransactionIncluded;
 #[derive(Debug, PartialEq, Clone)]
 pub enum Error {
     BlockNotFound(H256),
+    Borsh(String),
     NoBlockAtHeight(u64),
     TransactionNotFound(TransactionIncluded),
     TransactionHashNotFound(H256),
@@ -14,5 +15,11 @@ pub enum Error {
 impl From<rocksdb::Error> for Error {
     fn from(e: rocksdb::Error) -> Self {
         Self::Rocksdb(e)
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(e: std::io::Error) -> Self {
+        Self::Borsh(e.to_string())
     }
 }

--- a/engine-standalone-storage/src/lib.rs
+++ b/engine-standalone-storage/src/lib.rs
@@ -346,10 +346,10 @@ impl Storage {
         block_height: u64,
         transaction_position: u16,
         input: &'input [u8],
-        mut f: F,
+        f: F,
     ) -> EngineAccessResult<R>
     where
-        F: for<'output> FnMut(engine_state::EngineStateAccess<'db, 'input, 'output>) -> R,
+        F: for<'output> FnOnce(engine_state::EngineStateAccess<'db, 'input, 'output>) -> R,
     {
         let diff = RefCell::new(Diff::default());
         let engine_output = Cell::new(Vec::new());

--- a/engine-standalone-storage/src/lib.rs
+++ b/engine-standalone-storage/src/lib.rs
@@ -4,6 +4,7 @@ use rocksdb::DB;
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::path::Path;
+use sync::types::TransactionMessage;
 
 const VERSION: u8 = 0;
 
@@ -28,7 +29,7 @@ const ENGINE_KEY_SUFFIX_LEN: usize = (64 / 8) + (16 / 8);
 pub enum StoragePrefix {
     BlockHash = 0x00,
     BlockHeight = 0x01,
-    TransactionPosition = 0x02,
+    TransactionData = 0x02,
     TransactionHash = 0x03,
     Diff = 0x04,
     Engine = 0x05,
@@ -108,20 +109,17 @@ impl Storage {
         self.db.write(batch)
     }
 
-    pub fn get_transaction_by_hash(
+    pub fn get_transaction_data(
         &self,
         tx_hash: H256,
-    ) -> Result<TransactionIncluded, error::Error> {
-        let storage_key =
-            construct_storage_key(StoragePrefix::TransactionPosition, tx_hash.as_ref());
-        self.db
+    ) -> Result<sync::types::TransactionMessage, error::Error> {
+        let storage_key = construct_storage_key(StoragePrefix::TransactionData, tx_hash.as_ref());
+        let bytes = self
+            .db
             .get_pinned(storage_key)?
-            .map(|slice| {
-                let mut buf = [0u8; 34];
-                buf.copy_from_slice(slice.as_ref());
-                TransactionIncluded::from_bytes(buf)
-            })
-            .ok_or(error::Error::TransactionHashNotFound(tx_hash))
+            .ok_or(error::Error::TransactionHashNotFound(tx_hash))?;
+        let message = TransactionMessage::try_from_slice(bytes.as_ref())?;
+        Ok(message)
     }
 
     pub fn get_transaction_by_position(
@@ -150,7 +148,7 @@ impl Storage {
     pub fn set_transaction_included(
         &mut self,
         tx_hash: H256,
-        tx_included: &TransactionIncluded,
+        tx_included: &TransactionMessage,
         diff: &Diff,
     ) -> Result<(), error::Error> {
         let batch = rocksdb::WriteBatch::default();
@@ -162,7 +160,7 @@ impl Storage {
     pub fn revert_transaction_included(
         &mut self,
         tx_hash: H256,
-        tx_included: &TransactionIncluded,
+        tx_included: &TransactionMessage,
         diff: &Diff,
     ) -> Result<(), error::Error> {
         let batch = rocksdb::WriteBatch::default();
@@ -174,20 +172,24 @@ impl Storage {
     fn process_transaction<F: Fn(&mut rocksdb::WriteBatch, &[u8], &[u8])>(
         &mut self,
         tx_hash: H256,
-        tx_included: &TransactionIncluded,
+        tx_msg: &TransactionMessage,
         diff: &Diff,
         mut batch: rocksdb::WriteBatch,
         action: F,
     ) -> Result<(), error::Error> {
+        let tx_included = TransactionIncluded {
+            block_hash: tx_msg.block_hash,
+            position: tx_msg.position,
+        };
         let tx_included_bytes = tx_included.to_bytes();
         let block_height = self.get_block_height_by_hash(tx_included.block_hash)?;
 
         let storage_key = construct_storage_key(StoragePrefix::TransactionHash, &tx_included_bytes);
         action(&mut batch, &storage_key, tx_hash.as_ref());
 
-        let storage_key =
-            construct_storage_key(StoragePrefix::TransactionPosition, tx_hash.as_ref());
-        action(&mut batch, &storage_key, &tx_included_bytes);
+        let storage_key = construct_storage_key(StoragePrefix::TransactionData, tx_hash.as_ref());
+        let msg_bytes = tx_msg.to_bytes();
+        action(&mut batch, &storage_key, &msg_bytes);
 
         let storage_key = construct_storage_key(StoragePrefix::Diff, &tx_included_bytes);
         let diff_bytes = diff.try_to_bytes().unwrap();

--- a/engine-standalone-storage/src/relayer_db/mod.rs
+++ b/engine-standalone-storage/src/relayer_db/mod.rs
@@ -141,11 +141,17 @@ where
         }
 
         let diff = io.get_transaction_diff();
-        let tx_included = crate::TransactionIncluded {
+        let tx_msg = crate::TransactionMessage {
             block_hash,
+            near_receipt_id: near_tx_hash,
             position: transaction_position,
+            succeeded: true,
+            signer: env.signer_account_id(),
+            caller: env.predecessor_account_id(),
+            attached_near: 0,
+            transaction: crate::sync::types::TransactionKind::Submit(tx),
         };
-        storage.set_transaction_included(tx_hash, &tx_included, &diff)?;
+        storage.set_transaction_included(tx_hash, &tx_msg, &diff)?;
     }
     Ok(())
 }
@@ -189,6 +195,7 @@ pub mod error {
 #[cfg(test)]
 mod test {
     use super::FallibleIterator;
+    use crate::sync::types::{TransactionKind, TransactionMessage};
     use aurora_engine::{connector, engine, parameters};
     use aurora_engine_types::H256;
 
@@ -237,9 +244,15 @@ mod test {
             storage
                 .set_transaction_included(
                     H256::zero(),
-                    &crate::TransactionIncluded {
+                    &TransactionMessage {
                         block_hash,
                         position: 0,
+                        near_receipt_id: H256::zero(),
+                        succeeded: true,
+                        signer: "aurora".parse().unwrap(),
+                        caller: "aurora".parse().unwrap(),
+                        attached_near: 0,
+                        transaction: TransactionKind::Unknown,
                     },
                     &diff,
                 )

--- a/engine-standalone-storage/src/sync/mod.rs
+++ b/engine-standalone-storage/src/sync/mod.rs
@@ -1,9 +1,11 @@
 use aurora_engine::{connector, engine, parameters::SubmitResult};
 use aurora_engine_sdk::env::{self, Env, DEFAULT_PREPAID_GAS};
-use aurora_engine_types::{parameters::PromiseWithCallbackArgs, types::Yocto};
+use aurora_engine_types::{parameters::PromiseWithCallbackArgs, types::Yocto, H256};
 
 pub mod types;
 
+use crate::engine_state::EngineStateAccess;
+use crate::{BlockMetadata, Diff, Storage};
 use types::{Message, TransactionKind};
 
 use self::types::TransactionMessage;
@@ -11,7 +13,7 @@ use self::types::TransactionMessage;
 const AURORA_ACCOUNT_ID: &str = "aurora";
 
 pub fn consume_message(
-    storage: &mut crate::Storage,
+    storage: &mut Storage,
     message: Message,
 ) -> Result<ConsumeMessageOutcome, error::Error> {
     match message {
@@ -31,260 +33,23 @@ pub fn consume_message(
                 return Ok(ConsumeMessageOutcome::FailedTransactionIgnored);
             }
 
-            let signer_account_id = transaction_message.signer.clone();
-            let predecessor_account_id = transaction_message.caller.clone();
-            let relayer_address = aurora_engine_sdk::types::near_account_to_evm_address(
-                predecessor_account_id.as_bytes(),
-            );
             let transaction_position = transaction_message.position;
-            let near_receipt_id = transaction_message.near_receipt_id;
             let block_hash = transaction_message.block_hash;
             let block_height = storage.get_block_height_by_hash(block_hash)?;
             let block_metadata = storage.get_block_metadata(block_hash)?;
-            let current_account_id = AURORA_ACCOUNT_ID.parse().unwrap();
-            let env = env::Fixed {
-                signer_account_id,
-                current_account_id,
-                predecessor_account_id,
-                block_height,
-                block_timestamp: block_metadata.timestamp,
-                attached_deposit: transaction_message.attached_near,
-                random_seed: block_metadata.random_seed,
-                prepaid_gas: DEFAULT_PREPAID_GAS,
-            };
-            let mut io =
+            let io =
                 storage.access_engine_storage_at_position(block_height, transaction_position, &[]);
 
-            let (tx_hash, result) = match &transaction_message.transaction {
-                TransactionKind::Submit(tx) => {
-                    // We can ignore promises in the standalone engine because it processes each receipt separately
-                    // and it is fed a stream of receipts (it does not schedule them)
-                    let mut handler = crate::promise::Noop;
-                    let engine_state = engine::get_state(&io)?;
-                    let transaction_bytes: Vec<u8> = tx.into();
-                    let tx_hash = aurora_engine_sdk::keccak(&transaction_bytes);
-
-                    let result = engine::submit(
-                        io,
-                        &env,
-                        &transaction_bytes,
-                        engine_state,
-                        env.current_account_id(),
-                        relayer_address,
-                        &mut handler,
-                    );
-
-                    (tx_hash, Some(TransactionExecutionResult::Submit(result)))
-                }
-
-                TransactionKind::Call(args) => {
-                    // We can ignore promises in the standalone engine (see above)
-                    let mut handler = crate::promise::Noop;
-                    let mut engine =
-                        engine::Engine::new(relayer_address, env.current_account_id(), io, &env)?;
-
-                    let result = engine.call_with_args(args.clone(), &mut handler);
-
-                    (
-                        near_receipt_id,
-                        Some(TransactionExecutionResult::Submit(result)),
-                    )
-                }
-
-                TransactionKind::Deploy(input) => {
-                    // We can ignore promises in the standalone engine (see above)
-                    let mut handler = crate::promise::Noop;
-                    let mut engine =
-                        engine::Engine::new(relayer_address, env.current_account_id(), io, &env)?;
-
-                    let result = engine.deploy_code_with_input(input.clone(), &mut handler);
-
-                    (
-                        near_receipt_id,
-                        Some(TransactionExecutionResult::Submit(result)),
-                    )
-                }
-
-                TransactionKind::DeployErc20(args) => {
-                    // No promises can be created by `deploy_erc20_token`
-                    let mut handler = crate::promise::Noop;
-                    let _result = engine::deploy_erc20_token(args.clone(), io, &env, &mut handler)?;
-                    (near_receipt_id, None)
-                }
-
-                TransactionKind::FtOnTransfer(args) => {
-                    // No promises can be created by `ft_on_transfer`
-                    let mut handler = crate::promise::Noop;
-                    let mut engine =
-                        engine::Engine::new(relayer_address, env.current_account_id(), io, &env)?;
-
-                    if env.predecessor_account_id == env.current_account_id {
-                        connector::EthConnectorContract::init_instance(io)
-                            .ft_on_transfer(&engine, args)?;
-                    } else {
-                        engine.receive_erc20_tokens(
-                            &env.predecessor_account_id,
-                            &env.signer_account_id,
-                            args,
-                            &env.current_account_id,
-                            &mut handler,
-                        );
-                    }
-
-                    (near_receipt_id, None)
-                }
-
-                TransactionKind::FtTransferCall(args) => {
-                    let mut connector = connector::EthConnectorContract::init_instance(io);
-                    let promise_args = connector.ft_transfer_call(
-                        env.predecessor_account_id.clone(),
-                        env.current_account_id.clone(),
-                        args.clone(),
-                        env.prepaid_gas,
-                    )?;
-
-                    (
-                        near_receipt_id,
-                        Some(TransactionExecutionResult::Promise(promise_args)),
-                    )
-                }
-
-                TransactionKind::ResolveTransfer(args, promise_result) => {
-                    let mut connector = connector::EthConnectorContract::init_instance(io);
-                    connector.ft_resolve_transfer(args.clone(), promise_result.clone());
-
-                    (near_receipt_id, None)
-                }
-
-                TransactionKind::FtTransfer(args) => {
-                    let mut connector = connector::EthConnectorContract::init_instance(io);
-                    connector.ft_transfer(&env.predecessor_account_id, args.clone())?;
-
-                    (near_receipt_id, None)
-                }
-
-                TransactionKind::Withdraw(args) => {
-                    let mut connector = connector::EthConnectorContract::init_instance(io);
-                    connector.withdraw_eth_from_near(
-                        &env.current_account_id,
-                        &env.predecessor_account_id,
-                        args.clone(),
-                    )?;
-
-                    (near_receipt_id, None)
-                }
-
-                TransactionKind::Deposit(raw_proof) => {
-                    let connector_contract = connector::EthConnectorContract::init_instance(io);
-                    let promise_args = connector_contract.deposit(
-                        raw_proof.clone(),
-                        env.current_account_id(),
-                        env.predecessor_account_id(),
-                    )?;
-
-                    (
-                        near_receipt_id,
-                        Some(TransactionExecutionResult::Promise(promise_args)),
-                    )
-                }
-
-                TransactionKind::FinishDeposit(finish_args) => {
-                    let mut connector = connector::EthConnectorContract::init_instance(io);
-                    let maybe_promise_args = connector.finish_deposit(
-                        env.predecessor_account_id(),
-                        env.current_account_id(),
-                        finish_args.clone(),
-                        env.prepaid_gas,
-                    )?;
-
-                    (
-                        near_receipt_id,
-                        maybe_promise_args.map(TransactionExecutionResult::Promise),
-                    )
-                }
-
-                TransactionKind::StorageDeposit(args) => {
-                    let mut connector = connector::EthConnectorContract::init_instance(io);
-                    let _ = connector.storage_deposit(
-                        env.predecessor_account_id,
-                        Yocto::new(env.attached_deposit),
-                        args.clone(),
-                    )?;
-
-                    (near_receipt_id, None)
-                }
-
-                TransactionKind::StorageUnregister(force) => {
-                    let mut connector = connector::EthConnectorContract::init_instance(io);
-                    let _ = connector.storage_unregister(env.predecessor_account_id, *force)?;
-
-                    (near_receipt_id, None)
-                }
-
-                TransactionKind::StorageWithdraw(args) => {
-                    let mut connector = connector::EthConnectorContract::init_instance(io);
-                    connector.storage_withdraw(&env.predecessor_account_id, args.clone())?;
-
-                    (near_receipt_id, None)
-                }
-
-                TransactionKind::SetPausedFlags(args) => {
-                    let mut connector = connector::EthConnectorContract::init_instance(io);
-                    connector.set_paused_flags(args.clone());
-
-                    (near_receipt_id, None)
-                }
-
-                TransactionKind::RegisterRelayer(evm_address) => {
-                    let mut engine =
-                        engine::Engine::new(relayer_address, env.current_account_id(), io, &env)?;
-                    engine.register_relayer(env.predecessor_account_id.as_bytes(), *evm_address);
-
-                    (near_receipt_id, None)
-                }
-
-                TransactionKind::RefundOnError(maybe_args) => {
-                    let result: Result<
-                        Option<TransactionExecutionResult>,
-                        engine::EngineStateError,
-                    > = maybe_args
-                        .clone()
-                        .map(|args| {
-                            let mut handler = crate::promise::Noop;
-                            let engine_state = engine::get_state(&io)?;
-                            let result =
-                                engine::refund_on_error(io, &env, engine_state, args, &mut handler);
-                            Ok(TransactionExecutionResult::Submit(result))
-                        })
-                        .transpose();
-
-                    (near_receipt_id, result?)
-                }
-
-                TransactionKind::SetConnectorData(args) => {
-                    connector::set_contract_data(&mut io, args.clone())?;
-
-                    (near_receipt_id, None)
-                }
-
-                TransactionKind::NewConnector(args) => {
-                    connector::EthConnectorContract::create_contract(
-                        io,
-                        env.current_account_id,
-                        args.clone(),
-                    )?;
-
-                    (near_receipt_id, None)
-                }
-                TransactionKind::Unknown => (near_receipt_id, None),
-            };
-
-            let diff = io.get_transaction_diff();
+            let (tx_hash, diff, result) = execute_transaction(
+                transaction_message.as_ref(),
+                block_height,
+                &block_metadata,
+                io,
+            )?;
             match &result {
                 Some(TransactionExecutionResult::Submit(Err(_))) => (), // do not persist if Engine encounters an error
                 _ => storage.set_transaction_included(tx_hash, &transaction_message, &diff)?,
             }
-
             let outcome = TransactionIncludedOutcome {
                 hash: tx_hash,
                 info: *transaction_message,
@@ -296,6 +61,277 @@ pub fn consume_message(
             )))
         }
     }
+}
+
+pub fn execute_transaction_message(
+    storage: &Storage,
+    transaction_message: TransactionMessage,
+) -> Result<TransactionIncludedOutcome, error::Error> {
+    let transaction_position = transaction_message.position;
+    let block_hash = transaction_message.block_hash;
+    let block_height = storage.get_block_height_by_hash(block_hash)?;
+    let block_metadata = storage.get_block_metadata(block_hash)?;
+    let result = storage.with_engine_access(block_height, transaction_position, &[], |io| {
+        execute_transaction(&transaction_message, block_height, &block_metadata, io)
+    });
+    let (tx_hash, diff, maybe_result) = result.result?;
+    let outcome = TransactionIncludedOutcome {
+        hash: tx_hash,
+        info: transaction_message,
+        diff,
+        maybe_result,
+    };
+    Ok(outcome)
+}
+
+fn execute_transaction<'db, 'input, 'output>(
+    transaction_message: &TransactionMessage,
+    block_height: u64,
+    block_metadata: &BlockMetadata,
+    io: EngineStateAccess<'db, 'input, 'output>,
+) -> Result<(H256, Diff, Option<TransactionExecutionResult>), error::Error> {
+    let signer_account_id = transaction_message.signer.clone();
+    let predecessor_account_id = transaction_message.caller.clone();
+    let relayer_address =
+        aurora_engine_sdk::types::near_account_to_evm_address(predecessor_account_id.as_bytes());
+    let near_receipt_id = transaction_message.near_receipt_id;
+    let current_account_id = AURORA_ACCOUNT_ID.parse().unwrap();
+    let env = env::Fixed {
+        signer_account_id,
+        current_account_id,
+        predecessor_account_id,
+        block_height,
+        block_timestamp: block_metadata.timestamp,
+        attached_deposit: transaction_message.attached_near,
+        random_seed: block_metadata.random_seed,
+        prepaid_gas: DEFAULT_PREPAID_GAS,
+    };
+
+    let (tx_hash, result) = match &transaction_message.transaction {
+        TransactionKind::Submit(tx) => {
+            // We can ignore promises in the standalone engine because it processes each receipt separately
+            // and it is fed a stream of receipts (it does not schedule them)
+            let mut handler = crate::promise::Noop;
+            let engine_state = engine::get_state(&io)?;
+            let transaction_bytes: Vec<u8> = tx.into();
+            let tx_hash = aurora_engine_sdk::keccak(&transaction_bytes);
+
+            let result = engine::submit(
+                io,
+                &env,
+                &transaction_bytes,
+                engine_state,
+                env.current_account_id(),
+                relayer_address,
+                &mut handler,
+            );
+
+            (tx_hash, Some(TransactionExecutionResult::Submit(result)))
+        }
+
+        TransactionKind::Call(args) => {
+            // We can ignore promises in the standalone engine (see above)
+            let mut handler = crate::promise::Noop;
+            let mut engine =
+                engine::Engine::new(relayer_address, env.current_account_id(), io, &env)?;
+
+            let result = engine.call_with_args(args.clone(), &mut handler);
+
+            (
+                near_receipt_id,
+                Some(TransactionExecutionResult::Submit(result)),
+            )
+        }
+
+        TransactionKind::Deploy(input) => {
+            // We can ignore promises in the standalone engine (see above)
+            let mut handler = crate::promise::Noop;
+            let mut engine =
+                engine::Engine::new(relayer_address, env.current_account_id(), io, &env)?;
+
+            let result = engine.deploy_code_with_input(input.clone(), &mut handler);
+
+            (
+                near_receipt_id,
+                Some(TransactionExecutionResult::Submit(result)),
+            )
+        }
+
+        TransactionKind::DeployErc20(args) => {
+            // No promises can be created by `deploy_erc20_token`
+            let mut handler = crate::promise::Noop;
+            let _result = engine::deploy_erc20_token(args.clone(), io, &env, &mut handler)?;
+            (near_receipt_id, None)
+        }
+
+        TransactionKind::FtOnTransfer(args) => {
+            // No promises can be created by `ft_on_transfer`
+            let mut handler = crate::promise::Noop;
+            let mut engine =
+                engine::Engine::new(relayer_address, env.current_account_id(), io, &env)?;
+
+            if env.predecessor_account_id == env.current_account_id {
+                connector::EthConnectorContract::init_instance(io).ft_on_transfer(&engine, args)?;
+            } else {
+                engine.receive_erc20_tokens(
+                    &env.predecessor_account_id,
+                    &env.signer_account_id,
+                    args,
+                    &env.current_account_id,
+                    &mut handler,
+                );
+            }
+
+            (near_receipt_id, None)
+        }
+
+        TransactionKind::FtTransferCall(args) => {
+            let mut connector = connector::EthConnectorContract::init_instance(io);
+            let promise_args = connector.ft_transfer_call(
+                env.predecessor_account_id.clone(),
+                env.current_account_id.clone(),
+                args.clone(),
+                env.prepaid_gas,
+            )?;
+
+            (
+                near_receipt_id,
+                Some(TransactionExecutionResult::Promise(promise_args)),
+            )
+        }
+
+        TransactionKind::ResolveTransfer(args, promise_result) => {
+            let mut connector = connector::EthConnectorContract::init_instance(io);
+            connector.ft_resolve_transfer(args.clone(), promise_result.clone());
+
+            (near_receipt_id, None)
+        }
+
+        TransactionKind::FtTransfer(args) => {
+            let mut connector = connector::EthConnectorContract::init_instance(io);
+            connector.ft_transfer(&env.predecessor_account_id, args.clone())?;
+
+            (near_receipt_id, None)
+        }
+
+        TransactionKind::Withdraw(args) => {
+            let mut connector = connector::EthConnectorContract::init_instance(io);
+            connector.withdraw_eth_from_near(
+                &env.current_account_id,
+                &env.predecessor_account_id,
+                args.clone(),
+            )?;
+
+            (near_receipt_id, None)
+        }
+
+        TransactionKind::Deposit(raw_proof) => {
+            let connector_contract = connector::EthConnectorContract::init_instance(io);
+            let promise_args = connector_contract.deposit(
+                raw_proof.clone(),
+                env.current_account_id(),
+                env.predecessor_account_id(),
+            )?;
+
+            (
+                near_receipt_id,
+                Some(TransactionExecutionResult::Promise(promise_args)),
+            )
+        }
+
+        TransactionKind::FinishDeposit(finish_args) => {
+            let mut connector = connector::EthConnectorContract::init_instance(io);
+            let maybe_promise_args = connector.finish_deposit(
+                env.predecessor_account_id(),
+                env.current_account_id(),
+                finish_args.clone(),
+                env.prepaid_gas,
+            )?;
+
+            (
+                near_receipt_id,
+                maybe_promise_args.map(TransactionExecutionResult::Promise),
+            )
+        }
+
+        TransactionKind::StorageDeposit(args) => {
+            let mut connector = connector::EthConnectorContract::init_instance(io);
+            let _ = connector.storage_deposit(
+                env.predecessor_account_id,
+                Yocto::new(env.attached_deposit),
+                args.clone(),
+            )?;
+
+            (near_receipt_id, None)
+        }
+
+        TransactionKind::StorageUnregister(force) => {
+            let mut connector = connector::EthConnectorContract::init_instance(io);
+            let _ = connector.storage_unregister(env.predecessor_account_id, *force)?;
+
+            (near_receipt_id, None)
+        }
+
+        TransactionKind::StorageWithdraw(args) => {
+            let mut connector = connector::EthConnectorContract::init_instance(io);
+            connector.storage_withdraw(&env.predecessor_account_id, args.clone())?;
+
+            (near_receipt_id, None)
+        }
+
+        TransactionKind::SetPausedFlags(args) => {
+            let mut connector = connector::EthConnectorContract::init_instance(io);
+            connector.set_paused_flags(args.clone());
+
+            (near_receipt_id, None)
+        }
+
+        TransactionKind::RegisterRelayer(evm_address) => {
+            let mut engine =
+                engine::Engine::new(relayer_address, env.current_account_id(), io, &env)?;
+            engine.register_relayer(env.predecessor_account_id.as_bytes(), *evm_address);
+
+            (near_receipt_id, None)
+        }
+
+        TransactionKind::RefundOnError(maybe_args) => {
+            let result: Result<Option<TransactionExecutionResult>, engine::EngineStateError> =
+                maybe_args
+                    .clone()
+                    .map(|args| {
+                        let mut handler = crate::promise::Noop;
+                        let engine_state = engine::get_state(&io)?;
+                        let result =
+                            engine::refund_on_error(io, &env, engine_state, args, &mut handler);
+                        Ok(TransactionExecutionResult::Submit(result))
+                    })
+                    .transpose();
+
+            (near_receipt_id, result?)
+        }
+
+        TransactionKind::SetConnectorData(args) => {
+            let mut connector_io = io;
+            connector::set_contract_data(&mut connector_io, args.clone())?;
+
+            (near_receipt_id, None)
+        }
+
+        TransactionKind::NewConnector(args) => {
+            connector::EthConnectorContract::create_contract(
+                io,
+                env.current_account_id,
+                args.clone(),
+            )?;
+
+            (near_receipt_id, None)
+        }
+        TransactionKind::Unknown => (near_receipt_id, None),
+    };
+
+    let diff = io.get_transaction_diff();
+
+    Ok((tx_hash, diff, result))
 }
 
 #[derive(Debug)]

--- a/engine-standalone-storage/src/sync/types.rs
+++ b/engine-standalone-storage/src/sync/types.rs
@@ -2,6 +2,8 @@ use aurora_engine::parameters;
 use aurora_engine_transactions::EthTransactionKind;
 use aurora_engine_types::account_id::AccountId;
 use aurora_engine_types::{types, H256};
+use borsh::{BorshDeserialize, BorshSerialize};
+use std::borrow::Cow;
 
 /// Type describing the format of messages sent to the storage layer for keeping
 /// it in sync with the blockchain.
@@ -18,7 +20,7 @@ pub struct BlockMessage {
     pub metadata: crate::BlockMetadata,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TransactionMessage {
     /// Hash of the block which included this transaction
     pub block_hash: H256,
@@ -39,7 +41,22 @@ pub struct TransactionMessage {
     pub transaction: TransactionKind,
 }
 
-#[derive(Debug, Clone)]
+impl TransactionMessage {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let borshable: BorshableTransactionMessage = self.into();
+        borshable.try_to_vec().unwrap()
+    }
+
+    pub fn try_from_slice(bytes: &[u8]) -> Result<Self, std::io::Error> {
+        let borshable = BorshableTransactionMessage::try_from_slice(bytes)?;
+        Self::try_from(borshable).map_err(|e| {
+            let message = e.as_str();
+            std::io::Error::new(std::io::ErrorKind::Other, message)
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[allow(clippy::large_enum_variant)]
 pub enum TransactionKind {
     /// Raw Ethereum transaction submitted to the engine
@@ -81,4 +98,165 @@ pub enum TransactionKind {
     SetConnectorData(parameters::SetContractDataCallArgs),
     /// Initialize eth-connector
     NewConnector(parameters::InitCallArgs),
+    /// Sentinel kind for cases where a NEAR receipt caused a
+    /// change in Aurora state, but we failed to parse the Action.
+    Unknown,
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct BorshableTransactionMessage<'a> {
+    /// Hash of the block which included this transaction
+    pub block_hash: [u8; 32],
+    /// Receipt ID of the receipt that was actually executed on NEAR
+    pub near_receipt_id: [u8; 32],
+    /// If multiple Aurora transactions are included in the same block,
+    /// this index gives the order in which they should be executed.
+    pub position: u16,
+    /// True if the transaction executed successfully on the blockchain, false otherwise.
+    pub succeeded: bool,
+    /// NEAR account that signed the transaction
+    pub signer: Cow<'a, AccountId>,
+    /// NEAR account that called the Aurora engine contract
+    pub caller: Cow<'a, AccountId>,
+    /// Amount of NEAR token attached to the transaction
+    pub attached_near: u128,
+    /// Details of the transaction that was executed
+    pub transaction: BorshableTransactionKind<'a>,
+}
+
+impl<'a> From<&'a TransactionMessage> for BorshableTransactionMessage<'a> {
+    fn from(t: &'a TransactionMessage) -> Self {
+        Self {
+            block_hash: t.block_hash.0,
+            near_receipt_id: t.near_receipt_id.0,
+            position: t.position,
+            succeeded: t.succeeded,
+            signer: Cow::Borrowed(&t.signer),
+            caller: Cow::Borrowed(&t.caller),
+            attached_near: t.attached_near,
+            transaction: (&t.transaction).into(),
+        }
+    }
+}
+
+impl<'a> TryFrom<BorshableTransactionMessage<'a>> for TransactionMessage {
+    type Error = aurora_engine_transactions::ParseTransactionError;
+
+    fn try_from(t: BorshableTransactionMessage<'a>) -> Result<Self, Self::Error> {
+        Ok(Self {
+            block_hash: H256(t.block_hash),
+            near_receipt_id: H256(t.near_receipt_id),
+            position: t.position,
+            succeeded: t.succeeded,
+            signer: t.signer.into_owned(),
+            caller: t.caller.into_owned(),
+            attached_near: t.attached_near,
+            transaction: t.transaction.try_into()?,
+        })
+    }
+}
+
+/// Same as `TransactionKind`, but with `Submit` variant replaced with raw bytes
+/// so that it can derive the Borsh traits. All non-copy elements are `Cow` also
+/// so that this type can be cheaply created from a `TransactionKind` reference.
+#[derive(BorshDeserialize, BorshSerialize, Clone)]
+enum BorshableTransactionKind<'a> {
+    Submit(Cow<'a, Vec<u8>>),
+    Call(Cow<'a, parameters::CallArgs>),
+    Deploy(Cow<'a, Vec<u8>>),
+    DeployErc20(Cow<'a, parameters::DeployErc20TokenArgs>),
+    FtOnTransfer(Cow<'a, parameters::NEP141FtOnTransferArgs>),
+    Deposit(Cow<'a, Vec<u8>>),
+    FtTransferCall(Cow<'a, parameters::TransferCallCallArgs>),
+    FinishDeposit(Cow<'a, parameters::FinishDepositCallArgs>),
+    ResolveTransfer(
+        Cow<'a, parameters::ResolveTransferCallArgs>,
+        Cow<'a, types::PromiseResult>,
+    ),
+    FtTransfer(Cow<'a, parameters::TransferCallArgs>),
+    Withdraw(Cow<'a, aurora_engine_types::parameters::WithdrawCallArgs>),
+    StorageDeposit(Cow<'a, parameters::StorageDepositCallArgs>),
+    StorageUnregister(Option<bool>),
+    StorageWithdraw(Cow<'a, parameters::StorageWithdrawCallArgs>),
+    SetPausedFlags(Cow<'a, parameters::PauseEthConnectorCallArgs>),
+    RegisterRelayer(Cow<'a, types::Address>),
+    RefundOnError(Cow<'a, Option<aurora_engine_types::parameters::RefundCallArgs>>),
+    SetConnectorData(Cow<'a, parameters::SetContractDataCallArgs>),
+    NewConnector(Cow<'a, parameters::InitCallArgs>),
+    Unknown,
+}
+
+impl<'a> From<&'a TransactionKind> for BorshableTransactionKind<'a> {
+    fn from(t: &'a TransactionKind) -> Self {
+        match t {
+            TransactionKind::Submit(eth_tx) => {
+                let tx_bytes = eth_tx.into();
+                Self::Submit(Cow::Owned(tx_bytes))
+            }
+            TransactionKind::Call(x) => Self::Call(Cow::Borrowed(x)),
+            TransactionKind::Deploy(x) => Self::Deploy(Cow::Borrowed(x)),
+            TransactionKind::DeployErc20(x) => Self::DeployErc20(Cow::Borrowed(x)),
+            TransactionKind::FtOnTransfer(x) => Self::FtOnTransfer(Cow::Borrowed(x)),
+            TransactionKind::Deposit(x) => Self::Deposit(Cow::Borrowed(x)),
+            TransactionKind::FtTransferCall(x) => Self::FtTransferCall(Cow::Borrowed(x)),
+            TransactionKind::FinishDeposit(x) => Self::FinishDeposit(Cow::Borrowed(x)),
+            TransactionKind::ResolveTransfer(x, y) => {
+                Self::ResolveTransfer(Cow::Borrowed(x), Cow::Borrowed(y))
+            }
+            TransactionKind::FtTransfer(x) => Self::FtTransfer(Cow::Borrowed(x)),
+            TransactionKind::Withdraw(x) => Self::Withdraw(Cow::Borrowed(x)),
+            TransactionKind::StorageDeposit(x) => Self::StorageDeposit(Cow::Borrowed(x)),
+            TransactionKind::StorageUnregister(x) => Self::StorageUnregister(*x),
+            TransactionKind::StorageWithdraw(x) => Self::StorageWithdraw(Cow::Borrowed(x)),
+            TransactionKind::SetPausedFlags(x) => Self::SetPausedFlags(Cow::Borrowed(x)),
+            TransactionKind::RegisterRelayer(x) => Self::RegisterRelayer(Cow::Borrowed(x)),
+            TransactionKind::RefundOnError(x) => Self::RefundOnError(Cow::Borrowed(x)),
+            TransactionKind::SetConnectorData(x) => Self::SetConnectorData(Cow::Borrowed(x)),
+            TransactionKind::NewConnector(x) => Self::NewConnector(Cow::Borrowed(x)),
+            TransactionKind::Unknown => Self::Unknown,
+        }
+    }
+}
+
+impl<'a> TryFrom<BorshableTransactionKind<'a>> for TransactionKind {
+    type Error = aurora_engine_transactions::ParseTransactionError;
+
+    fn try_from(t: BorshableTransactionKind<'a>) -> Result<Self, Self::Error> {
+        match t {
+            BorshableTransactionKind::Submit(tx_bytes) => {
+                // `BorshableTransactionKind` is an internal type, so we will
+                // assume the conversion is infallible. If the conversion were to
+                // fail then something has gone very wrong.
+                let eth_tx = tx_bytes.as_slice().try_into()?;
+                Ok(Self::Submit(eth_tx))
+            }
+            BorshableTransactionKind::Call(x) => Ok(Self::Call(x.into_owned())),
+            BorshableTransactionKind::Deploy(x) => Ok(Self::Deploy(x.into_owned())),
+            BorshableTransactionKind::DeployErc20(x) => Ok(Self::DeployErc20(x.into_owned())),
+            BorshableTransactionKind::FtOnTransfer(x) => Ok(Self::FtOnTransfer(x.into_owned())),
+            BorshableTransactionKind::Deposit(x) => Ok(Self::Deposit(x.into_owned())),
+            BorshableTransactionKind::FtTransferCall(x) => Ok(Self::FtTransferCall(x.into_owned())),
+            BorshableTransactionKind::FinishDeposit(x) => Ok(Self::FinishDeposit(x.into_owned())),
+            BorshableTransactionKind::ResolveTransfer(x, y) => {
+                Ok(Self::ResolveTransfer(x.into_owned(), y.into_owned()))
+            }
+            BorshableTransactionKind::FtTransfer(x) => Ok(Self::FtTransfer(x.into_owned())),
+            BorshableTransactionKind::Withdraw(x) => Ok(Self::Withdraw(x.into_owned())),
+            BorshableTransactionKind::StorageDeposit(x) => Ok(Self::StorageDeposit(x.into_owned())),
+            BorshableTransactionKind::StorageUnregister(x) => Ok(Self::StorageUnregister(x)),
+            BorshableTransactionKind::StorageWithdraw(x) => {
+                Ok(Self::StorageWithdraw(x.into_owned()))
+            }
+            BorshableTransactionKind::SetPausedFlags(x) => Ok(Self::SetPausedFlags(x.into_owned())),
+            BorshableTransactionKind::RegisterRelayer(x) => {
+                Ok(Self::RegisterRelayer(x.into_owned()))
+            }
+            BorshableTransactionKind::RefundOnError(x) => Ok(Self::RefundOnError(x.into_owned())),
+            BorshableTransactionKind::SetConnectorData(x) => {
+                Ok(Self::SetConnectorData(x.into_owned()))
+            }
+            BorshableTransactionKind::NewConnector(x) => Ok(Self::NewConnector(x.into_owned())),
+            BorshableTransactionKind::Unknown => Ok(Self::Unknown),
+        }
+    }
 }

--- a/engine-tests/src/test_utils/standalone/mod.rs
+++ b/engine-tests/src/test_utils/standalone/mod.rs
@@ -5,8 +5,13 @@ use aurora_engine_transactions::legacy::{LegacyEthSignedTransaction, Transaction
 use aurora_engine_types::types::{Address, NearGas, Wei};
 use aurora_engine_types::{H256, U256};
 use borsh::BorshDeserialize;
-use engine_standalone_storage::engine_state;
-use engine_standalone_storage::{BlockMetadata, Diff, Storage};
+use engine_standalone_storage::{
+    sync::{
+        self,
+        types::{TransactionKind, TransactionMessage},
+    },
+    BlockMetadata, Diff, Storage,
+};
 use secp256k1::SecretKey;
 use tempfile::TempDir;
 
@@ -34,9 +39,19 @@ impl StandaloneRunner {
         let storage = &mut self.storage;
         let env = &mut self.env;
         env.block_height += 1;
-        let io = Self::get_engine_io(storage, env, 0, H256([0u8; 32]));
-        mocks::init_evm(io.engine_io, env, chain_id);
-        io.finish().commit(storage, &mut self.cumulative_diff);
+        let transaction_hash = H256::zero();
+        let tx_msg = Self::template_tx_msg(storage, &env, 0, transaction_hash);
+        let result = storage.with_engine_access(env.block_height, 0, &[], |io| {
+            mocks::init_evm(io, env, chain_id);
+        });
+        let outcome = sync::TransactionIncludedOutcome {
+            hash: transaction_hash,
+            info: tx_msg,
+            diff: result.diff,
+            maybe_result: None,
+        };
+        self.cumulative_diff.append(outcome.diff.clone());
+        test_utils::standalone::storage::commit(storage, &outcome);
     }
 
     pub fn mint_account(
@@ -59,11 +74,19 @@ impl StandaloneRunner {
         };
 
         env.block_height += 1;
-        let io = Self::get_engine_io(storage, env, 0, transaction_hash);
+        let tx_msg = Self::template_tx_msg(storage, &env, 0, transaction_hash);
 
-        mocks::mint_evm_account(address, balance, nonce, code, io.engine_io, env);
-
-        io.finish().commit(storage, &mut self.cumulative_diff);
+        let result = storage.with_engine_access(env.block_height, 0, &[], |io| {
+            mocks::mint_evm_account(address, balance, nonce, code, io, env)
+        });
+        let outcome = sync::TransactionIncludedOutcome {
+            hash: transaction_hash,
+            info: tx_msg,
+            diff: result.diff,
+            maybe_result: None,
+        };
+        self.cumulative_diff.append(outcome.diff.clone());
+        test_utils::standalone::storage::commit(storage, &outcome);
     }
 
     pub fn transfer_with_signer(
@@ -88,7 +111,6 @@ impl StandaloneRunner {
         account: &SecretKey,
         transaction: TransactionLegacy,
     ) -> Result<SubmitResult, engine::EngineError> {
-        self.env.predecessor_account_id = "some-account.near".parse().unwrap();
         let storage = &mut self.storage;
         let env = &mut self.env;
         env.block_height += 1;
@@ -128,30 +150,29 @@ impl StandaloneRunner {
         signed_tx: &LegacyEthSignedTransaction,
         block_height: u64,
         transaction_position: u16,
-    ) -> Result<TransactionComplete, engine::EngineError> {
+    ) -> Result<sync::TransactionIncludedOutcome, engine::EngineError> {
         let storage = &mut self.storage;
         let env = &mut self.env;
 
         env.block_height = block_height;
         let transaction_bytes = rlp::encode(signed_tx).to_vec();
         let transaction_hash = aurora_engine_sdk::keccak(&transaction_bytes);
-        let relayer_address = Self::relayer_address(env);
 
-        let io = Self::get_engine_io(storage, env, transaction_position, transaction_hash);
-        let engine_state = engine::get_state(&io.engine_io).unwrap();
-        let mut handler = mocks::promise::PromiseTracker::default();
+        let mut tx_msg = Self::template_tx_msg(storage, &env, 0, transaction_hash);
+        tx_msg.position = transaction_position;
+        tx_msg.transaction =
+            TransactionKind::Submit(transaction_bytes.as_slice().try_into().unwrap());
+        let outcome = sync::execute_transaction_message(storage, tx_msg).unwrap();
 
-        engine::submit(
-            io.engine_io,
-            env,
-            &transaction_bytes,
-            engine_state,
-            env.current_account_id(),
-            relayer_address,
-            &mut handler,
-        )?;
+        match outcome.maybe_result.as_ref().unwrap() {
+            sync::TransactionExecutionResult::Submit(result) => match result.as_ref() {
+                Err(e) => return Err(e.clone()),
+                Ok(_) => (),
+            },
+            _ => unreachable!(),
+        };
 
-        Ok(io.finish())
+        Ok(outcome)
     }
 
     pub fn submit_raw(
@@ -180,26 +201,29 @@ impl StandaloneRunner {
             )
         } else if method_name == test_utils::CALL {
             let call_args = CallArgs::try_from_slice(&ctx.input).unwrap();
-            let mut handler = mocks::promise::PromiseTracker::default();
             let transaction_hash = aurora_engine_sdk::keccak(&ctx.input);
-            let io = Self::get_engine_io(storage, &env, 0, transaction_hash);
-            let origin = aurora_engine_sdk::types::near_account_to_evm_address(
-                env.predecessor_account_id.as_bytes(),
-            );
-            let mut engine =
-                engine::Engine::new(origin, env.current_account_id(), io.engine_io, &env).unwrap();
-            let result = engine.call_with_args(call_args, &mut handler)?;
-            io.finish().commit(storage, &mut self.cumulative_diff);
-            Ok(result)
+            let mut tx_msg = Self::template_tx_msg(storage, &env, 0, transaction_hash);
+            tx_msg.transaction = TransactionKind::Call(call_args);
+
+            let outcome = sync::execute_transaction_message(storage, tx_msg).unwrap();
+            self.cumulative_diff.append(outcome.diff.clone());
+            test_utils::standalone::storage::commit(storage, &outcome);
+
+            unwrap_result(outcome)
         } else if method_name == test_utils::DEPLOY_ERC20 {
             let deploy_args = DeployErc20TokenArgs::try_from_slice(&ctx.input).unwrap();
-            let mut handler = mocks::promise::PromiseTracker::default();
             let transaction_hash = aurora_engine_sdk::keccak(&ctx.input);
-            let io = Self::get_engine_io(storage, &env, 0, transaction_hash);
-            let address = engine::deploy_erc20_token(deploy_args, io.engine_io, &env, &mut handler)
-                .map_err(mocks::unsafe_to_string)
-                .unwrap();
-            io.finish().commit(storage, &mut self.cumulative_diff);
+            let mut tx_msg = Self::template_tx_msg(storage, &env, 0, transaction_hash);
+            tx_msg.transaction = TransactionKind::DeployErc20(deploy_args);
+
+            let outcome = sync::execute_transaction_message(storage, tx_msg).unwrap();
+            self.cumulative_diff.append(outcome.diff.clone());
+            test_utils::standalone::storage::commit(storage, &outcome);
+
+            let address = match outcome.maybe_result.unwrap() {
+                sync::TransactionExecutionResult::DeployErc20(address) => address,
+                _ => unreachable!(),
+            };
             Ok(SubmitResult::new(
                 TransactionStatus::Succeed(address.raw().as_ref().to_vec()),
                 0,
@@ -240,12 +264,12 @@ impl StandaloneRunner {
         self.storage_dir.close().unwrap();
     }
 
-    fn get_engine_io<'db>(
-        storage: &'db mut Storage,
+    fn template_tx_msg(
+        storage: &mut Storage,
         env: &env::Fixed,
         transaction_position: u16,
         transaction_hash: H256,
-    ) -> TransactionIO<'db> {
+    ) -> TransactionMessage {
         let block_hash = mocks::compute_block_hash(env.block_height);
         let block_metadata = BlockMetadata {
             timestamp: env.block_timestamp,
@@ -254,13 +278,15 @@ impl StandaloneRunner {
         storage
             .set_block_data(block_hash, env.block_height, block_metadata)
             .unwrap();
-        let io =
-            storage.access_engine_storage_at_position(env.block_height, transaction_position, &[]);
-        TransactionIO {
-            engine_io: io,
+        TransactionMessage {
             block_hash,
-            transaction_position,
-            transaction_hash,
+            near_receipt_id: transaction_hash,
+            position: transaction_position,
+            succeeded: true,
+            signer: env.signer_account_id(),
+            caller: env.predecessor_account_id(),
+            attached_near: env.attached_deposit,
+            transaction: TransactionKind::Unknown,
         }
     }
 
@@ -271,28 +297,26 @@ impl StandaloneRunner {
         env: &mut env::Fixed,
         cumulative_diff: &mut Diff,
     ) -> Result<SubmitResult, engine::EngineError> {
-        let relayer_address = Self::relayer_address(env);
         let transaction_hash = aurora_engine_sdk::keccak(&transaction_bytes);
-        let io = Self::get_engine_io(storage, env, transaction_position, transaction_hash);
-        let engine_state = engine::get_state(&io.engine_io).unwrap();
-        let mut handler = mocks::promise::PromiseTracker::default();
+        let mut tx_msg =
+            Self::template_tx_msg(storage, env, transaction_position, transaction_hash);
+        tx_msg.transaction = TransactionKind::Submit(transaction_bytes.try_into().unwrap());
 
-        let result = engine::submit(
-            io.engine_io,
-            env,
-            &transaction_bytes,
-            engine_state,
-            env.current_account_id(),
-            relayer_address,
-            &mut handler,
-        )?;
-        io.finish().commit(storage, cumulative_diff);
+        let outcome = sync::execute_transaction_message(storage, tx_msg).unwrap();
+        cumulative_diff.append(outcome.diff.clone());
+        test_utils::standalone::storage::commit(storage, &outcome);
 
-        Ok(result)
+        unwrap_result(outcome)
     }
+}
 
-    fn relayer_address(env: &env::Fixed) -> Address {
-        aurora_engine_sdk::types::near_account_to_evm_address(env.predecessor_account_id.as_bytes())
+fn unwrap_result(
+    outcome: sync::TransactionIncludedOutcome,
+) -> Result<SubmitResult, engine::EngineError> {
+    match outcome.maybe_result.unwrap() {
+        sync::TransactionExecutionResult::Submit(result) => result,
+        sync::TransactionExecutionResult::Promise(_) => panic!("Unexpected promise."),
+        sync::TransactionExecutionResult::DeployErc20(_) => panic!("Unexpected DeployErc20."),
     }
 }
 
@@ -308,46 +332,5 @@ impl Default for StandaloneRunner {
             chain_id,
             cumulative_diff: Diff::default(),
         }
-    }
-}
-
-struct TransactionIO<'db> {
-    engine_io: engine_state::EngineStateAccess<'db, 'db, 'db>,
-    block_hash: H256,
-    transaction_position: u16,
-    transaction_hash: H256,
-}
-
-impl<'db> TransactionIO<'db> {
-    // Drops `self.engine_io` which releases the borrow on the storage instance used to create it.
-    // This allows the same storage instance to be passed to the `TransactionComplete::commit` function.
-    fn finish(self) -> TransactionComplete {
-        TransactionComplete {
-            diff: self.engine_io.get_transaction_diff(),
-            block_hash: self.block_hash,
-            transaction_position: self.transaction_position,
-            transaction_hash: self.transaction_hash,
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TransactionComplete {
-    pub diff: Diff,
-    pub block_hash: H256,
-    pub transaction_position: u16,
-    pub transaction_hash: H256,
-}
-
-impl TransactionComplete {
-    pub fn commit(self, storage: &mut Storage, cumulative_diff: &mut Diff) {
-        cumulative_diff.append(self.diff.clone());
-        storage::commit(
-            storage,
-            self.diff,
-            self.block_hash,
-            self.transaction_position,
-            self.transaction_hash,
-        );
     }
 }

--- a/engine-tests/src/test_utils/standalone/storage.rs
+++ b/engine-tests/src/test_utils/standalone/storage.rs
@@ -1,5 +1,9 @@
 use aurora_engine_types::H256;
-use engine_standalone_storage::{self, Storage};
+use engine_standalone_storage::{
+    self,
+    sync::types::{TransactionKind, TransactionMessage},
+    Storage,
+};
 use tempfile::TempDir;
 
 pub fn commit(
@@ -9,12 +13,18 @@ pub fn commit(
     transaction_position: u16,
     transaction_hash: H256,
 ) {
-    let tx_included = engine_standalone_storage::TransactionIncluded {
+    let tx_msg = TransactionMessage {
         block_hash,
+        near_receipt_id: H256::zero(),
         position: transaction_position,
+        succeeded: true,
+        signer: "placeholder.near".parse().unwrap(),
+        caller: "placeholder.near".parse().unwrap(),
+        attached_near: 0,
+        transaction: TransactionKind::Unknown,
     };
     storage
-        .set_transaction_included(transaction_hash, &tx_included, &diff)
+        .set_transaction_included(transaction_hash, &tx_msg, &diff)
         .unwrap();
 }
 

--- a/engine-tests/src/test_utils/standalone/storage.rs
+++ b/engine-tests/src/test_utils/standalone/storage.rs
@@ -1,30 +1,9 @@
-use aurora_engine_types::H256;
-use engine_standalone_storage::{
-    self,
-    sync::types::{TransactionKind, TransactionMessage},
-    Storage,
-};
+use engine_standalone_storage::{self, sync::TransactionIncludedOutcome, Storage};
 use tempfile::TempDir;
 
-pub fn commit(
-    storage: &mut Storage,
-    diff: engine_standalone_storage::Diff,
-    block_hash: H256,
-    transaction_position: u16,
-    transaction_hash: H256,
-) {
-    let tx_msg = TransactionMessage {
-        block_hash,
-        near_receipt_id: H256::zero(),
-        position: transaction_position,
-        succeeded: true,
-        signer: "placeholder.near".parse().unwrap(),
-        caller: "placeholder.near".parse().unwrap(),
-        attached_near: 0,
-        transaction: TransactionKind::Unknown,
-    };
+pub fn commit(storage: &mut Storage, outcome: &TransactionIncludedOutcome) {
     storage
-        .set_transaction_included(transaction_hash, &tx_msg, &diff)
+        .set_transaction_included(outcome.hash, &outcome.info, &outcome.diff)
         .unwrap();
 }
 

--- a/engine-tests/src/tests/account_id_precompiles.rs
+++ b/engine-tests/src/tests/account_id_precompiles.rs
@@ -58,9 +58,9 @@ fn test_account_id_precompiles() {
         .as_mut()
         .unwrap()
         .env
-        .current_account_id = account_id.parse().unwrap();
+        .predecessor_account_id = account_id.parse().unwrap();
     let nonce = signer.use_nonce();
-    let tx = contract.call_method_without_args("currentAccountId", nonce.into());
+    let tx = contract.call_method_without_args("predecessorAccountId", nonce.into());
     let result = runner
         .standalone_runner
         .as_mut()

--- a/engine-tests/src/tests/standalone/storage.rs
+++ b/engine-tests/src/tests/standalone/storage.rs
@@ -89,8 +89,7 @@ fn test_replay_transaction() {
                         .execute_transaction_at_position(tx, block_height, position as u16)
                         .unwrap();
 
-                    diff.clone()
-                        .commit(&mut runner.storage, &mut runner.cumulative_diff);
+                    test_utils::standalone::storage::commit(&mut runner.storage, &diff);
 
                     assert_eq!(
                         runner.get_balance(&address),

--- a/engine-tests/src/tests/standalone/tracing.rs
+++ b/engine-tests/src/tests/standalone/tracing.rs
@@ -63,13 +63,22 @@ fn test_evm_tracing_with_storage() {
         .storage
         .set_block_data(block_hash, block_height, block_metadata)
         .unwrap();
-    let tx = test_utils::standalone::TransactionComplete {
+    let tx = engine_standalone_storage::sync::TransactionIncludedOutcome {
+        hash: H256::zero(),
+        info: engine_standalone_storage::sync::types::TransactionMessage {
+            block_hash,
+            near_receipt_id: H256::zero(),
+            position: 0,
+            succeeded: true,
+            signer: "system".parse().unwrap(),
+            caller: "system".parse().unwrap(),
+            attached_near: 0,
+            transaction: engine_standalone_storage::sync::types::TransactionKind::Unknown,
+        },
         diff,
-        block_hash,
-        transaction_position: 0,
-        transaction_hash: H256::zero(),
+        maybe_result: None,
     };
-    tx.commit(&mut runner.storage, &mut runner.cumulative_diff);
+    test_utils::standalone::storage::commit(&mut runner.storage, &tx);
 
     // Replay transaction depositing some ETH to get WETH (for the first time)
     // tx: https://etherscan.io/tx/0x79f7f8f9b3ad98f29a3df5cbed1556397089701c3ce007c2844605849dfb0ad4

--- a/engine-transactions/src/lib.rs
+++ b/engine-transactions/src/lib.rs
@@ -167,6 +167,16 @@ pub enum ParseTransactionError {
     RlpDecodeError(DecoderError),
 }
 
+impl ParseTransactionError {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::UnknownTransactionType => "ERR_UNKNOWN_TX_TYPE",
+            Self::ReservedSentinel => "ERR_RESERVED_LEADING_TX_BYTE",
+            Self::RlpDecodeError(_) => "ERR_TX_RLP_DECODE",
+        }
+    }
+}
+
 impl From<DecoderError> for ParseTransactionError {
     fn from(e: DecoderError) -> Self {
         Self::RlpDecodeError(e)
@@ -175,11 +185,7 @@ impl From<DecoderError> for ParseTransactionError {
 
 impl AsRef<[u8]> for ParseTransactionError {
     fn as_ref(&self) -> &[u8] {
-        match self {
-            Self::UnknownTransactionType => b"ERR_UNKNOWN_TX_TYPE",
-            Self::ReservedSentinel => b"ERR_RESERVED_LEADING_TX_BYTE",
-            Self::RlpDecodeError(_) => b"ERR_TX_RLP_DECODE",
-        }
+        self.as_str().as_bytes()
     }
 }
 

--- a/engine-types/src/parameters.rs
+++ b/engine-types/src/parameters.rs
@@ -51,14 +51,14 @@ pub struct PromiseBatchAction {
 }
 
 /// withdraw NEAR eth-connector call args
-#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
 pub struct WithdrawCallArgs {
     pub recipient_address: Address,
     pub amount: NEP141Wei,
 }
 
 /// withdraw NEAR eth-connector call args
-#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
 pub struct RefundCallArgs {
     pub recipient_address: Address,
     pub erc20_address: Option<Address>,

--- a/engine-types/src/parameters.rs
+++ b/engine-types/src/parameters.rs
@@ -11,7 +11,7 @@ pub enum PromiseArgs {
 }
 
 #[must_use]
-#[derive(Debug, BorshSerialize, BorshDeserialize, Clone)]
+#[derive(Debug, BorshSerialize, BorshDeserialize, Clone, PartialEq, Eq)]
 pub struct PromiseCreateArgs {
     pub target_account_id: AccountId,
     pub method: String,
@@ -21,7 +21,7 @@ pub struct PromiseCreateArgs {
 }
 
 #[must_use]
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, BorshSerialize, BorshDeserialize, Clone, PartialEq, Eq)]
 pub struct PromiseWithCallbackArgs {
     pub base: PromiseCreateArgs,
     pub callback: PromiseCreateArgs,

--- a/engine-types/src/types/mod.rs
+++ b/engine-types/src/types/mod.rs
@@ -1,4 +1,5 @@
 use crate::{str, vec, String, Vec, U256};
+use borsh::{BorshDeserialize, BorshSerialize};
 
 pub mod address;
 pub mod balance;
@@ -62,7 +63,7 @@ pub struct StorageBalanceBounds {
 }
 
 /// promise results structure
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum PromiseResult {
     NotReady,
     Successful(Vec<u8>),

--- a/engine/src/fungible_token.rs
+++ b/engine/src/fungible_token.rs
@@ -57,7 +57,7 @@ pub struct FungibleTokenOps<I: IO> {
 
 /// Fungible token Reference hash type.
 /// Used for FungibleTokenMetadata
-#[derive(Debug, BorshDeserialize, BorshSerialize, Clone)]
+#[derive(Debug, BorshDeserialize, BorshSerialize, Clone, PartialEq, Eq)]
 pub struct FungibleReferenceHash([u8; 32]);
 
 impl FungibleReferenceHash {
@@ -73,7 +73,7 @@ impl AsRef<[u8]> for FungibleReferenceHash {
     }
 }
 
-#[derive(Debug, BorshDeserialize, BorshSerialize, Clone)]
+#[derive(Debug, BorshDeserialize, BorshSerialize, Clone, PartialEq, Eq)]
 pub struct FungibleTokenMetadata {
     pub spec: String,
     pub name: String,

--- a/engine/src/parameters.rs
+++ b/engine/src/parameters.rs
@@ -40,7 +40,7 @@ pub struct MetaCallArgs {
 }
 
 /// Borsh-encoded log for use in a `SubmitResult`.
-#[derive(Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ResultLog {
     pub address: Address,
     pub topics: Vec<RawU256>,
@@ -63,7 +63,7 @@ impl From<Log> for ResultLog {
 }
 
 /// The status of a transaction.
-#[derive(Debug, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
 pub enum TransactionStatus {
     Succeed(Vec<u8>),
     Revert(Vec<u8>),
@@ -105,7 +105,7 @@ impl AsRef<[u8]> for TransactionStatus {
 
 /// Borsh-encoded parameters for the `call`, `call_with_args`, `deploy_code`,
 /// and `deploy_with_input` methods.
-#[derive(Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct SubmitResult {
     version: u8,
     pub status: TransactionStatus,

--- a/engine/src/parameters.rs
+++ b/engine/src/parameters.rs
@@ -234,7 +234,7 @@ pub struct BeginBlockArgs {
 
 /// Borsh-encoded parameters for the `ft_transfer_call` function
 /// for regular NEP-141 tokens.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
 pub struct NEP141FtOnTransferArgs {
     pub sender_id: AccountId,
     /// Balance can be for Eth on Near and for Eth to Aurora
@@ -311,7 +311,7 @@ impl StorageBalance {
 }
 
 /// ft_resolve_transfer eth-connector call args
-#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
 pub struct ResolveTransferCallArgs {
     pub sender_id: AccountId,
     pub amount: NEP141Wei,
@@ -319,7 +319,7 @@ pub struct ResolveTransferCallArgs {
 }
 
 /// Finish deposit NEAR eth-connector call args
-#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
 pub struct FinishDepositCallArgs {
     pub new_owner_id: AccountId,
     pub amount: NEP141Wei,
@@ -347,7 +347,7 @@ pub struct FinishDepositEthCallArgs {
 }
 
 /// Eth-connector initial args
-#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
 pub struct InitCallArgs {
     pub prover_account: AccountId,
     pub eth_custodian_address: String,
@@ -358,7 +358,7 @@ pub struct InitCallArgs {
 pub type SetContractDataCallArgs = InitCallArgs;
 
 /// transfer eth-connector call args
-#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
 pub struct TransferCallCallArgs {
     pub receiver_id: AccountId,
     pub amount: NEP141Wei,
@@ -399,7 +399,7 @@ impl TryFrom<JsonValue> for StorageBalanceOfCallArgs {
 }
 
 /// storage_deposit eth-connector call args
-#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
 pub struct StorageDepositCallArgs {
     pub account_id: Option<AccountId>,
     pub registration_only: Option<bool>,
@@ -417,7 +417,7 @@ impl From<JsonValue> for StorageDepositCallArgs {
 }
 
 /// storage_withdraw eth-connector call args
-#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
 pub struct StorageWithdrawCallArgs {
     pub amount: Option<Yocto>,
 }
@@ -431,7 +431,7 @@ impl From<JsonValue> for StorageWithdrawCallArgs {
 }
 
 /// transfer args for json invocation
-#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
 pub struct TransferCallArgs {
     pub receiver_id: AccountId,
     pub amount: NEP141Wei,
@@ -476,7 +476,7 @@ pub struct RegisterRelayerCallArgs {
     pub address: Address,
 }
 
-#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
 pub struct PauseEthConnectorCallArgs {
     pub paused_mask: PausedMask,
 }


### PR DESCRIPTION
To enable the debug tracing API where the only input is the transaction hash, the standalone engine must persist the transaction data (ie the bytes given as input to the engine), and the transaction context (NEAR data like `predecessor_id`). This is introduced in this PR. Additionally, this PR introduces a read-only execution function. This is useful for debug tracing as well because we do not want to modify the standalone engine's DB when running trace requests.

The diff for this PR is fairly large, but most of the changes are not interesting. For example the `Borshable*` structs are just necessary boiler plate because there are not `borsh` instances for the ethereum types (and I thought it made sense to be consistent in the serialization format used in the engine's DB, so using a serialization format that is supported by the ethereum types didn't seem like a good option). And in `engine-standalone-storage/src/sync/mod.rs` the majority of the diff is simply moving some code around to avoid duplication between the read-only and committing execution modes (this should be more obvious if you tell GitHub to ignore whitespace when displaying the diff).