### PR TITLE
Fix near-blake2 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "aurora-blake2"
+version = "0.9.1"
+source = "git+https://github.com/aurora-is-near/aurora-blake2.git#05a0b5f7a544c527c0118f8afe2f943b3de4bb03"
+dependencies = [
+ "crypto-mac 0.8.0",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
 name = "aurora-bn"
 version = "0.1.0"
 source = "git+https://github.com/aurora-is-near/aurora-bn.git#8f1743884061981cac84388862e2763b2aa09307"
@@ -142,7 +152,6 @@ dependencies = [
  "hex",
  "libsecp256k1",
  "logos",
- "near-blake2",
  "num",
  "primitive-types 0.10.1",
  "rand 0.7.3",
@@ -159,6 +168,7 @@ dependencies = [
 name = "aurora-engine-precompiles"
 version = "1.0.0"
 dependencies = [
+ "aurora-blake2",
  "aurora-bn",
  "aurora-engine-sdk",
  "aurora-engine-types",
@@ -169,7 +179,6 @@ dependencies = [
  "evm-core",
  "hex",
  "libsecp256k1",
- "near-blake2",
  "num",
  "primitive-types 0.10.1",
  "rand 0.7.3",
@@ -2313,16 +2322,6 @@ source = "git+https://github.com/near/nearcore.git?rev=8a377fda0b4ce319385c463f1
 dependencies = [
  "borsh 0.8.2",
  "serde",
-]
-
-[[package]]
-name = "near-blake2"
-version = "0.9.1"
-source = "git+https://github.com/near/near-blake2.git#cebb7df79608a7058017940830d37c37d55d21fe"
-dependencies = [
- "crypto-mac 0.8.0",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
 ]
 
 [[package]]

--- a/engine-precompiles/Cargo.toml
+++ b/engine-precompiles/Cargo.toml
@@ -16,7 +16,7 @@ autobenches = false
 aurora-engine-types = { path = "../engine-types", default-features = false }
 aurora-engine-sdk = { path = "../engine-sdk", default-features = false }
 base64 = { version = "0.13.0", default-features = false, features = ["alloc"] }
-near-blake2 = { git = "https://github.com/near/near-blake2.git", version = "0.9.1", default-features = false }
+aurora-blake2 = { git = "https://github.com/aurora-is-near/aurora-blake2.git", version = "0.9.1", default-features = false }
 borsh = { version = "0.8.2", default-features = false }
 bn = { package = "aurora-bn", git = "https://github.com/aurora-is-near/aurora-bn.git", default-features = false }
 evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", rev = "37448b6cacd98b06282cff5a559684505c29bd2b", default-features = false }
@@ -36,7 +36,7 @@ serde_json = "1"
 rand = "0.7.3"
 
 [features]
-std = ["aurora-engine-types/std", "aurora-engine-sdk/std", "borsh/std", "near-blake2/std", "bn/std", "evm/std", "evm-core/std", "libsecp256k1/std", "ripemd160/std", "sha2/std", "sha3/std", "ethabi/std"]
+std = ["aurora-engine-types/std", "aurora-engine-sdk/std", "borsh/std", "aurora-blake2/std", "bn/std", "evm/std", "evm-core/std", "libsecp256k1/std", "ripemd160/std", "sha2/std", "sha3/std", "ethabi/std"]
 contract = []
 log = []
 error_refund = []

--- a/engine-precompiles/src/blake2.rs
+++ b/engine-precompiles/src/blake2.rs
@@ -94,7 +94,7 @@ impl Precompile for Blake2F {
         }
         let finished = input[212] != 0;
 
-        let output = near_blake2::blake2b_f(rounds, h, m, t, finished).to_vec();
+        let output = aurora_blake2::blake2b_f(rounds, h, m, t, finished).to_vec();
         Ok(PrecompileOutput::without_logs(cost, output).into())
     }
 }

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,6 @@ aurora-engine-sdk = { path = "../engine-sdk", default-features = false }
 aurora-engine-precompiles = { path = "../engine-precompiles", default-features = false }
 aurora-engine-transactions = { path = "../engine-transactions", default-features = false }
 base64 = { version = "0.13.0", default-features = false, features = ["alloc"] }
-near-blake2 = { git = "https://github.com/near/near-blake2.git", version = "0.9.1", default-features = false }
 borsh = { version = "0.8.2", default-features = false }
 bn = { package = "aurora-bn", git = "https://github.com/aurora-is-near/aurora-bn.git", default-features = false }
 evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", rev = "37448b6cacd98b06282cff5a559684505c29bd2b", default-features = false }

--- a/etc/state-migration-test/Cargo.lock
+++ b/etc/state-migration-test/Cargo.lock
@@ -27,6 +27,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4dc07131ffa69b8072d35f5007352af944213cde02545e2103680baed38fcd"
 
 [[package]]
+name = "aurora-blake2"
+version = "0.9.1"
+source = "git+https://github.com/aurora-is-near/aurora-blake2.git#05a0b5f7a544c527c0118f8afe2f943b3de4bb03"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
 name = "aurora-bn"
 version = "0.1.0"
 source = "git+https://github.com/aurora-is-near/aurora-bn.git#8f1743884061981cac84388862e2763b2aa09307"
@@ -53,7 +63,6 @@ dependencies = [
  "hex",
  "libsecp256k1",
  "logos",
- "near-blake2",
  "num",
  "primitive-types",
  "ripemd160",
@@ -67,6 +76,7 @@ dependencies = [
 name = "aurora-engine-precompiles"
 version = "1.0.0"
 dependencies = [
+ "aurora-blake2",
  "aurora-bn",
  "aurora-engine-sdk",
  "aurora-engine-types",
@@ -77,7 +87,6 @@ dependencies = [
  "evm-core",
  "hex",
  "libsecp256k1",
- "near-blake2",
  "num",
  "primitive-types",
  "ripemd160",
@@ -630,16 +639,6 @@ name = "memory_units"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
-
-[[package]]
-name = "near-blake2"
-version = "0.9.1"
-source = "git+https://github.com/near/near-blake2.git#cebb7df79608a7058017940830d37c37d55d21fe"
-dependencies = [
- "crypto-mac",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
-]
 
 [[package]]
 name = "num"


### PR DESCRIPTION
Issue related to `blake2_f` function compatibility.

Related to:
* [EIP-152](https://eips.ethereum.org/EIPS/eip-152)
* [Blake2 RFC-7693](https://datatracker.ietf.org/doc/html/rfc7693#section-3.2)

Realted to *EIP-152* `compress` function should accept parameters: `h, m, t, f`