### PR TITLE
Feat(standalone): Handle call to new method of Engine contract

### DIFF
--- a/engine-standalone-storage/src/sync/mod.rs
+++ b/engine-standalone-storage/src/sync/mod.rs
@@ -88,11 +88,11 @@ pub fn execute_transaction_message(
     Ok(outcome)
 }
 
-fn execute_transaction<'db, 'input, 'output>(
+fn execute_transaction<'db>(
     transaction_message: &TransactionMessage,
     block_height: u64,
     block_metadata: &BlockMetadata,
-    io: EngineStateAccess<'db, 'input, 'output>,
+    mut io: EngineStateAccess<'db, 'db, 'db>,
 ) -> Result<(H256, Diff, Option<TransactionExecutionResult>), error::Error> {
     let signer_account_id = transaction_message.signer.clone();
     let predecessor_account_id = transaction_message.caller.clone();
@@ -330,6 +330,11 @@ fn execute_transaction<'db, 'input, 'output>(
                 env.current_account_id,
                 args.clone(),
             )?;
+
+            (near_receipt_id, None)
+        }
+        TransactionKind::NewEngine(args) => {
+            engine::set_state(&mut io, args.clone().into());
 
             (near_receipt_id, None)
         }

--- a/engine-standalone-storage/src/sync/types.rs
+++ b/engine-standalone-storage/src/sync/types.rs
@@ -98,6 +98,8 @@ pub enum TransactionKind {
     SetConnectorData(parameters::SetContractDataCallArgs),
     /// Initialize eth-connector
     NewConnector(parameters::InitCallArgs),
+    /// Initialize Engine
+    NewEngine(parameters::NewCallArgs),
     /// Sentinel kind for cases where a NEAR receipt caused a
     /// change in Aurora state, but we failed to parse the Action.
     Unknown,
@@ -183,6 +185,7 @@ enum BorshableTransactionKind<'a> {
     RefundOnError(Cow<'a, Option<aurora_engine_types::parameters::RefundCallArgs>>),
     SetConnectorData(Cow<'a, parameters::SetContractDataCallArgs>),
     NewConnector(Cow<'a, parameters::InitCallArgs>),
+    NewEngine(Cow<'a, parameters::NewCallArgs>),
     Unknown,
 }
 
@@ -213,6 +216,7 @@ impl<'a> From<&'a TransactionKind> for BorshableTransactionKind<'a> {
             TransactionKind::RefundOnError(x) => Self::RefundOnError(Cow::Borrowed(x)),
             TransactionKind::SetConnectorData(x) => Self::SetConnectorData(Cow::Borrowed(x)),
             TransactionKind::NewConnector(x) => Self::NewConnector(Cow::Borrowed(x)),
+            TransactionKind::NewEngine(x) => Self::NewEngine(Cow::Borrowed(x)),
             TransactionKind::Unknown => Self::Unknown,
         }
     }
@@ -256,6 +260,7 @@ impl<'a> TryFrom<BorshableTransactionKind<'a>> for TransactionKind {
                 Ok(Self::SetConnectorData(x.into_owned()))
             }
             BorshableTransactionKind::NewConnector(x) => Ok(Self::NewConnector(x.into_owned())),
+            BorshableTransactionKind::NewEngine(x) => Ok(Self::NewEngine(x.into_owned())),
             BorshableTransactionKind::Unknown => Ok(Self::Unknown),
         }
     }

--- a/engine/src/parameters.rs
+++ b/engine/src/parameters.rs
@@ -11,7 +11,7 @@ use aurora_engine_types::types::{Fee, NEP141Wei, Yocto};
 use evm::backend::Log;
 
 /// Borsh-encoded parameters for the `new` function.
-#[derive(BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct NewCallArgs {
     /// Chain id, according to the EIP-115 / ethereum-lists spec.
     pub chain_id: RawU256,


### PR DESCRIPTION
I missed `new` when I was adding all the methods that mutate the engine in my [previous PR](https://github.com/aurora-is-near/aurora-engine/pull/478). It is included in this PR. As a fun historical note, [here is the transaction](https://explorer.mainnet.near.org/transactions/DWtjJpXz9sRLvekWTGjQdVbXRaKHhfdFPnHHfwUWQEQZ) where the Engine was first initialized.

This allows the standalone engine to start from an empty storage directory and completely build the engine state from the full transaction history.