### PR TITLE
Add serde for TraceTransaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1282,6 +1282,7 @@ dependencies = [
  "evm-core",
  "evm-gasometer",
  "evm-runtime",
+ "serde",
 ]
 
 [[package]]

--- a/engine-standalone-storage/src/sync/mod.rs
+++ b/engine-standalone-storage/src/sync/mod.rs
@@ -394,31 +394,37 @@ pub mod error {
             Self::Storage(e)
         }
     }
+
     impl From<engine::EngineStateError> for Error {
         fn from(e: engine::EngineStateError) -> Self {
             Self::EngineState(e)
         }
     }
+
     impl From<engine::EngineError> for Error {
         fn from(e: engine::EngineError) -> Self {
             Self::Engine(e)
         }
     }
+
     impl From<engine::DeployErc20Error> for Error {
         fn from(e: engine::DeployErc20Error) -> Self {
             Self::DeployErc20(e)
         }
     }
+
     impl From<connector::error::FtTransferCallError> for Error {
         fn from(e: connector::error::FtTransferCallError) -> Self {
             Self::FtOnTransfer(e)
         }
     }
+
     impl From<connector::error::DepositError> for Error {
         fn from(e: connector::error::DepositError) -> Self {
             Self::Deposit(e)
         }
     }
+
     impl From<connector::error::FinishDepositError> for Error {
         fn from(e: connector::error::FinishDepositError) -> Self {
             Self::FinishDeposit(e)

--- a/engine-standalone-tracing/Cargo.toml
+++ b/engine-standalone-tracing/Cargo.toml
@@ -21,8 +21,10 @@ evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", rev = "374
 evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", rev = "37448b6cacd98b06282cff5a559684505c29bd2b", default-features = false, features = ["std", "tracing"] }
 evm-runtime = { git = "https://github.com/aurora-is-near/sputnikvm.git", rev = "37448b6cacd98b06282cff5a559684505c29bd2b", default-features = false, features = ["std", "tracing"] }
 evm-gasometer = { git = "https://github.com/aurora-is-near/sputnikvm.git", rev = "37448b6cacd98b06282cff5a559684505c29bd2b", default-features = false, features = ["std", "tracing"] }
+serde = { version = "1", features = ["derive"], optional = true }
 
 [features]
 default = []
 mainnet = []
 testnet = []
+impl-serde = ["aurora-engine-types/impl-serde", "serde"]

--- a/engine-standalone-tracing/src/types.rs
+++ b/engine-standalone-tracing/src/types.rs
@@ -313,6 +313,7 @@ impl StepTransactionTrace {
 
 // Custom serde serialization for opcode, given it is not provided upstream
 // See here for custom serde serialization: https://serde.rs/custom-serialization.html
+#[cfg(feature = "serde")]
 mod opcode_serde {
     pub fn serialize<S>(opcode: &evm_core::Opcode, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/engine-types/src/types/gas.rs
+++ b/engine-types/src/types/gas.rs
@@ -1,6 +1,8 @@
 use crate::fmt::Formatter;
 use crate::{Add, Display, Div, Mul, Sub};
 use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 #[derive(
     Default, BorshSerialize, BorshDeserialize, Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd,
@@ -35,6 +37,7 @@ impl NearGas {
 }
 
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 /// Ethereum gas type which wraps an underlying u64.
 pub struct EthGas(u64);
 


### PR DESCRIPTION
This is required for borealis-engine as the base branch.

It was really unfortunate that OpCode didn't provide serde, even if it is just a single `u8`. I implemented custom de/serialization methods. If you have any simpler way, let me know.