### PR TITLE
Refactor repro tests to have less boilerplate

### DIFF
--- a/engine-tests/src/tests/repro.rs
+++ b/engine-tests/src/tests/repro.rs
@@ -21,42 +21,14 @@ fn repro_GdASJ3KESs() {
     // Note: this snapshot is pruned from the full Engine state on testnet at that block height.
     // The full snapshot is very large, and all that is necessary for this test are the keys used
     // in the transaction. This pruned snapshot contains precisely those keys, and no others.
-    let snapshot = json_snapshot::types::JsonSnapshot::load_from_file(
+    repro_common(
         "src/tests/res/aurora_state_GdASJ3KESs.json",
-    )
-    .unwrap();
-
-    let mut runner = AuroraRunner::default();
-    runner.wasm_config.limit_config.max_gas_burnt = 3_000_000_000_000_000;
-    runner.context.storage_usage = 1_000_000_000;
-    runner.consume_json_snapshot(snapshot.clone());
-    runner.context.block_index = 83596945;
-    runner.context.block_timestamp = 1645717564644206730;
-
-    let tx_hex = std::fs::read_to_string("src/tests/res/input_GdASJ3KESs.hex").unwrap();
-    let tx_bytes = hex::decode(tx_hex.trim()).unwrap();
-
-    let (outcome, error) = runner.call("submit", "relay.aurora", tx_bytes);
-    let outcome = outcome.unwrap();
-    let profile = ExecutionProfile::new(&outcome);
-    if let Some(error) = error {
-        panic!("{:?}", error);
-    }
-    let submit_result =
-        SubmitResult::try_from_slice(&outcome.return_data.as_value().unwrap()).unwrap();
-
-    assert_eq!(submit_result.gas_used, 706713);
-    assert_eq!(173, profile.all_gas() / 1_000_000_000_000);
-
-    // Also validate the SubmitResult in the standalone engine
-    let mut standalone = standalone::StandaloneRunner::default();
-    json_snapshot::initialize_engine_state(&mut standalone.storage, snapshot).unwrap();
-    let standalone_result = standalone.submit_raw("submit", &runner.context).unwrap();
-    assert_eq!(
-        submit_result.try_to_vec().unwrap(),
-        standalone_result.try_to_vec().unwrap()
+        83596945,
+        1645717564644206730,
+        "src/tests/res/input_GdASJ3KESs.hex",
+        706713,
+        173,
     );
-    standalone.close()
 }
 
 /// This test reproduces a transaction from mainnet:
@@ -74,19 +46,34 @@ fn repro_8ru7VEA() {
     // Note: this snapshot is pruned from the full Engine state on mainnet at that block height.
     // The full snapshot is very large, and all that is necessary for this test are the keys used
     // in the transaction. This pruned snapshot contains precisely those keys, and no others.
-    let snapshot = json_snapshot::types::JsonSnapshot::load_from_file(
+    repro_common(
         "src/tests/res/aurora_state_8ru7VEA.json",
-    )
-    .unwrap();
+        62625815,
+        1648829935343349589,
+        "src/tests/res/input_8ru7VEA.hex",
+        1732181,
+        309,
+    );
+}
+
+fn repro_common(
+    snapshot_path: &str,
+    block_index: u64,
+    block_timestamp: u64,
+    input_path: &str,
+    evm_gas_used: u64,
+    near_gas_used: u64,
+) {
+    let snapshot = json_snapshot::types::JsonSnapshot::load_from_file(snapshot_path).unwrap();
 
     let mut runner = AuroraRunner::default();
     runner.wasm_config.limit_config.max_gas_burnt = 3_000_000_000_000_000;
     runner.context.storage_usage = 1_000_000_000;
     runner.consume_json_snapshot(snapshot.clone());
-    runner.context.block_index = 62625815;
-    runner.context.block_timestamp = 1648829935343349589;
+    runner.context.block_index = block_index;
+    runner.context.block_timestamp = block_timestamp;
 
-    let tx_hex = std::fs::read_to_string("src/tests/res/input_8ru7VEA.hex").unwrap();
+    let tx_hex = std::fs::read_to_string(input_path).unwrap();
     let tx_bytes = hex::decode(tx_hex.trim()).unwrap();
 
     let (outcome, error) = runner.call("submit", "relay.aurora", tx_bytes);
@@ -98,8 +85,8 @@ fn repro_8ru7VEA() {
     let submit_result =
         SubmitResult::try_from_slice(&outcome.return_data.as_value().unwrap()).unwrap();
 
-    assert_eq!(submit_result.gas_used, 1732181);
-    assert_eq!(309, profile.all_gas() / 1_000_000_000_000);
+    assert_eq!(submit_result.gas_used, evm_gas_used);
+    assert_eq!(near_gas_used, profile.all_gas() / 1_000_000_000_000);
 
     // Also validate the SubmitResult in the standalone engine
     let mut standalone = standalone::StandaloneRunner::default();

--- a/engine-tests/src/tests/repro.rs
+++ b/engine-tests/src/tests/repro.rs
@@ -21,14 +21,14 @@ fn repro_GdASJ3KESs() {
     // Note: this snapshot is pruned from the full Engine state on testnet at that block height.
     // The full snapshot is very large, and all that is necessary for this test are the keys used
     // in the transaction. This pruned snapshot contains precisely those keys, and no others.
-    repro_common(
-        "src/tests/res/aurora_state_GdASJ3KESs.json",
-        83596945,
-        1645717564644206730,
-        "src/tests/res/input_GdASJ3KESs.hex",
-        706713,
-        173,
-    );
+    repro_common(ReproContext {
+        snapshot_path: "src/tests/res/aurora_state_GdASJ3KESs.json",
+        block_index: 83596945,
+        block_timestamp: 1645717564644206730,
+        input_path: "src/tests/res/input_GdASJ3KESs.hex",
+        evm_gas_used: 706713,
+        near_gas_used: 173,
+    });
 }
 
 /// This test reproduces a transaction from mainnet:
@@ -46,24 +46,26 @@ fn repro_8ru7VEA() {
     // Note: this snapshot is pruned from the full Engine state on mainnet at that block height.
     // The full snapshot is very large, and all that is necessary for this test are the keys used
     // in the transaction. This pruned snapshot contains precisely those keys, and no others.
-    repro_common(
-        "src/tests/res/aurora_state_8ru7VEA.json",
-        62625815,
-        1648829935343349589,
-        "src/tests/res/input_8ru7VEA.hex",
-        1732181,
-        309,
-    );
+    repro_common(ReproContext {
+        snapshot_path: "src/tests/res/aurora_state_8ru7VEA.json",
+        block_index: 62625815,
+        block_timestamp: 1648829935343349589,
+        input_path: "src/tests/res/input_8ru7VEA.hex",
+        evm_gas_used: 1732181,
+        near_gas_used: 309,
+    });
 }
 
-fn repro_common(
-    snapshot_path: &str,
-    block_index: u64,
-    block_timestamp: u64,
-    input_path: &str,
-    evm_gas_used: u64,
-    near_gas_used: u64,
-) {
+fn repro_common<'a>(context: ReproContext<'a>) {
+    let ReproContext {
+        snapshot_path,
+        block_index,
+        block_timestamp,
+        input_path,
+        evm_gas_used,
+        near_gas_used,
+    } = context;
+
     let snapshot = json_snapshot::types::JsonSnapshot::load_from_file(snapshot_path).unwrap();
 
     let mut runner = AuroraRunner::default();
@@ -97,4 +99,13 @@ fn repro_common(
         standalone_result.try_to_vec().unwrap()
     );
     standalone.close()
+}
+
+struct ReproContext<'a> {
+    snapshot_path: &'a str,
+    block_index: u64,
+    block_timestamp: u64,
+    input_path: &'a str,
+    evm_gas_used: u64,
+    near_gas_used: u64,
 }


### PR DESCRIPTION
I'll be adding more tests reproducing gas errors to our tests. This change simply factors out code that will be common to all the tests to make it easier to add the new ones.