### PR TITLE
Fix(standalone): include possible execution errors in the TransactionIncludedOutcome 

### DIFF
--- a/engine-tests/src/test_utils/standalone/mod.rs
+++ b/engine-tests/src/test_utils/standalone/mod.rs
@@ -48,7 +48,7 @@ impl StandaloneRunner {
             hash: transaction_hash,
             info: tx_msg,
             diff: result.diff,
-            maybe_result: None,
+            maybe_result: Ok(None),
         };
         self.cumulative_diff.append(outcome.diff.clone());
         test_utils::standalone::storage::commit(storage, &outcome);
@@ -83,7 +83,7 @@ impl StandaloneRunner {
             hash: transaction_hash,
             info: tx_msg,
             diff: result.diff,
-            maybe_result: None,
+            maybe_result: Ok(None),
         };
         self.cumulative_diff.append(outcome.diff.clone());
         test_utils::standalone::storage::commit(storage, &outcome);
@@ -164,7 +164,7 @@ impl StandaloneRunner {
             TransactionKind::Submit(transaction_bytes.as_slice().try_into().unwrap());
         let outcome = sync::execute_transaction_message(storage, tx_msg).unwrap();
 
-        match outcome.maybe_result.as_ref().unwrap() {
+        match outcome.maybe_result.as_ref().unwrap().as_ref().unwrap() {
             sync::TransactionExecutionResult::Submit(result) => match result.as_ref() {
                 Err(e) => return Err(e.clone()),
                 Ok(_) => (),
@@ -220,7 +220,7 @@ impl StandaloneRunner {
             self.cumulative_diff.append(outcome.diff.clone());
             test_utils::standalone::storage::commit(storage, &outcome);
 
-            let address = match outcome.maybe_result.unwrap() {
+            let address = match outcome.maybe_result.unwrap().unwrap() {
                 sync::TransactionExecutionResult::DeployErc20(address) => address,
                 _ => unreachable!(),
             };
@@ -316,7 +316,7 @@ impl StandaloneRunner {
 fn unwrap_result(
     outcome: sync::TransactionIncludedOutcome,
 ) -> Result<SubmitResult, engine::EngineError> {
-    match outcome.maybe_result.unwrap() {
+    match outcome.maybe_result.unwrap().unwrap() {
         sync::TransactionExecutionResult::Submit(result) => result,
         sync::TransactionExecutionResult::Promise(_) => panic!("Unexpected promise."),
         sync::TransactionExecutionResult::DeployErc20(_) => panic!("Unexpected DeployErc20."),

--- a/engine-tests/src/tests/standalone/storage.rs
+++ b/engine-tests/src/tests/standalone/storage.rs
@@ -100,7 +100,7 @@ fn test_replay_transaction() {
                     );
 
                     i += 1;
-                    diff
+                    diff.diff
                 })
                 .collect()
         })
@@ -118,7 +118,8 @@ fn test_replay_transaction() {
         for ((position, tx), diff) in txs {
             let replay_diff = runner
                 .execute_transaction_at_position(tx, block_height, position as u16)
-                .unwrap();
+                .unwrap()
+                .diff;
             assert_eq!(replay_diff, diff);
         }
     }

--- a/engine-tests/src/tests/standalone/sync.rs
+++ b/engine-tests/src/tests/standalone/sync.rs
@@ -65,7 +65,7 @@ fn test_consume_deposit_message() {
         other => panic!("Unexpected outcome {:?}", other),
     };
 
-    let finish_deposit_args = match outcome.maybe_result.unwrap() {
+    let finish_deposit_args = match outcome.maybe_result.unwrap().unwrap() {
         sync::TransactionExecutionResult::Promise(promise_args) => {
             let bytes = promise_args.callback.args;
             aurora_engine::parameters::FinishDepositCallArgs::try_from_slice(&bytes).unwrap()
@@ -96,7 +96,7 @@ fn test_consume_deposit_message() {
         other => panic!("Unexpected outcome {:?}", other),
     };
 
-    let ft_on_transfer_args = match outcome.maybe_result.unwrap() {
+    let ft_on_transfer_args = match outcome.maybe_result.unwrap().unwrap() {
         sync::TransactionExecutionResult::Promise(promise_args) => {
             let bytes = promise_args.base.args;
             let json = aurora_engine::json::parse_json(&bytes).unwrap();

--- a/engine-tests/src/tests/standalone/tracing.rs
+++ b/engine-tests/src/tests/standalone/tracing.rs
@@ -76,7 +76,7 @@ fn test_evm_tracing_with_storage() {
             transaction: engine_standalone_storage::sync::types::TransactionKind::Unknown,
         },
         diff,
-        maybe_result: None,
+        maybe_result: Ok(None),
     };
     test_utils::standalone::storage::commit(&mut runner.storage, &tx);
 


### PR DESCRIPTION
This fixes an issue in the standalone engine where it would not return the full `TransactionIncludedOutcome` object on very old testnet blocks due to the current engine code not being able to read the old storage layout (before we introduced the version prefix). With this change the error will be included in the `TransactionIncludedOutcome` response so that the caller can handle the error in the same way they would handle any other `SubmitResult` error.