### PR TITLE
Fix(connector): Return an error when storage cannot be read instead of panicking

### DIFF
--- a/engine-tests/src/test_utils/standalone/mocks/mod.rs
+++ b/engine-tests/src/test_utils/standalone/mocks/mod.rs
@@ -115,6 +115,7 @@ pub fn mint_evm_account<I: IO + Copy, E: Env>(
     io.remove_storage(&proof_key);
 
     aurora_engine::connector::EthConnectorContract::init_instance(io)
+        .unwrap()
         .finish_deposit(
             aurora_account_id.clone(),
             aurora_account_id.clone(),

--- a/engine/src/connector.rs
+++ b/engine/src/connector.rs
@@ -62,14 +62,14 @@ impl<I: IO + Copy> EthConnectorContract<I> {
     /// Init Eth-connector contract instance.
     /// Load contract data from storage and init I/O handler.
     /// Used as single point of contract access for various contract actions
-    pub fn init_instance(io: I) -> Self {
-        Self {
-            contract: get_contract_data(&io, &EthConnectorStorageId::Contract),
-            ft: get_contract_data::<FungibleToken, I>(&io, &EthConnectorStorageId::FungibleToken)
+    pub fn init_instance(io: I) -> Result<Self, error::StorageReadError> {
+        Ok(Self {
+            contract: get_contract_data(&io, &EthConnectorStorageId::Contract)?,
+            ft: get_contract_data::<FungibleToken, I>(&io, &EthConnectorStorageId::FungibleToken)?
                 .ops(io),
-            paused_mask: get_contract_data(&io, &EthConnectorStorageId::PausedMask),
+            paused_mask: get_contract_data(&io, &EthConnectorStorageId::PausedMask)?,
             io,
-        }
+        })
     }
 
     /// Create contract data - init eth-connector contract specific data.
@@ -687,11 +687,16 @@ fn construct_contract_key(suffix: &EthConnectorStorageId) -> Vec<u8> {
     crate::prelude::bytes_to_key(KeyPrefix::EthConnector, &[*suffix as u8])
 }
 
-fn get_contract_data<T: BorshDeserialize, I: IO>(io: &I, suffix: &EthConnectorStorageId) -> T {
+fn get_contract_data<T: BorshDeserialize, I: IO>(
+    io: &I,
+    suffix: &EthConnectorStorageId,
+) -> Result<T, error::StorageReadError> {
     io.read_storage(&construct_contract_key(suffix))
-        .expect("Failed read storage")
-        .to_value()
-        .unwrap()
+        .ok_or(error::StorageReadError::KeyNotFound)
+        .and_then(|x| {
+            x.to_value()
+                .map_err(|_| error::StorageReadError::BorshDeserialize)
+        })
 }
 
 /// Sets the contract data and returns it back
@@ -734,6 +739,21 @@ pub mod error {
     use crate::{deposit_event, fungible_token};
 
     const PROOF_EXIST: &[u8; 15] = b"ERR_PROOF_EXIST";
+
+    #[cfg_attr(not(target_arch = "wasm32"), derive(Debug))]
+    pub enum StorageReadError {
+        KeyNotFound,
+        BorshDeserialize,
+    }
+
+    impl AsRef<[u8]> for StorageReadError {
+        fn as_ref(&self) -> &[u8] {
+            match self {
+                Self::KeyNotFound => b"ERR_CONNECTOR_STORAGE_KEY_NOT_FOUND",
+                Self::BorshDeserialize => b"ERR_FAILED_DESERIALIZE_CONNECTOR_DATA",
+            }
+        }
+    }
 
     #[cfg_attr(not(target_arch = "wasm32"), derive(Debug))]
     pub enum DepositError {

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -1282,7 +1282,7 @@ pub fn remove_balance<I: IO + Copy>(io: &mut I, address: &Address) {
     EthConnectorContract::init_instance(*io)
         .map(|mut connector| {
             // The `unwrap` is safe here because (a) if the connector
-            // is implemented correctly then the total supply wll never underflow and (b) we are passing
+            // is implemented correctly then the total supply will never underflow and (b) we are passing
             // in the balance directly so there will always be enough balance.
             connector.internal_remove_eth(address, balance).unwrap();
         })

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -340,6 +340,7 @@ mod contract {
 
         if predecessor_account_id == current_account_id {
             EthConnectorContract::init_instance(io)
+                .sdk_unwrap()
                 .ft_on_transfer(&engine, &args)
                 .sdk_unwrap();
         } else {
@@ -522,6 +523,7 @@ mod contract {
         let current_account_id = io.current_account_id();
         let predecessor_account_id = io.predecessor_account_id();
         let result = EthConnectorContract::init_instance(io)
+            .sdk_unwrap()
             .withdraw_eth_from_near(&current_account_id, &predecessor_account_id, args)
             .sdk_unwrap();
         let result_bytes = result.try_to_vec().sdk_expect("ERR_SERIALIZE");
@@ -535,6 +537,7 @@ mod contract {
         let current_account_id = io.current_account_id();
         let predecessor_account_id = io.predecessor_account_id();
         let promise_args = EthConnectorContract::init_instance(io)
+            .sdk_unwrap()
             .deposit(raw_proof, current_account_id, predecessor_account_id)
             .sdk_unwrap();
         let promise_id = io.promise_create_with_callback(&promise_args);
@@ -564,6 +567,7 @@ mod contract {
         let current_account_id = io.current_account_id();
         let predecessor_account_id = io.predecessor_account_id();
         let maybe_promise_args = EthConnectorContract::init_instance(io)
+            .sdk_unwrap()
             .finish_deposit(
                 predecessor_account_id,
                 current_account_id,
@@ -583,7 +587,9 @@ mod contract {
         let mut io = Runtime;
         let args: IsUsedProofCallArgs = io.read_input_borsh().sdk_unwrap();
 
-        let is_used_proof = EthConnectorContract::init_instance(io).is_used_proof(args.proof);
+        let is_used_proof = EthConnectorContract::init_instance(io)
+            .sdk_unwrap()
+            .is_used_proof(args.proof);
         let res = is_used_proof.try_to_vec().unwrap();
         io.return_output(&res[..]);
     }
@@ -591,19 +597,25 @@ mod contract {
     #[no_mangle]
     pub extern "C" fn ft_total_supply() {
         let io = Runtime;
-        EthConnectorContract::init_instance(io).ft_total_eth_supply_on_near();
+        EthConnectorContract::init_instance(io)
+            .sdk_unwrap()
+            .ft_total_eth_supply_on_near();
     }
 
     #[no_mangle]
     pub extern "C" fn ft_total_eth_supply_on_near() {
         let io = Runtime;
-        EthConnectorContract::init_instance(io).ft_total_eth_supply_on_near();
+        EthConnectorContract::init_instance(io)
+            .sdk_unwrap()
+            .ft_total_eth_supply_on_near();
     }
 
     #[no_mangle]
     pub extern "C" fn ft_total_eth_supply_on_aurora() {
         let io = Runtime;
-        EthConnectorContract::init_instance(io).ft_total_eth_supply_on_aurora();
+        EthConnectorContract::init_instance(io)
+            .sdk_unwrap()
+            .ft_total_eth_supply_on_aurora();
     }
 
     #[no_mangle]
@@ -613,7 +625,9 @@ mod contract {
             parse_json(&io.read_input().to_vec()).sdk_unwrap(),
         )
         .sdk_unwrap();
-        EthConnectorContract::init_instance(io).ft_balance_of(args);
+        EthConnectorContract::init_instance(io)
+            .sdk_unwrap()
+            .ft_balance_of(args);
     }
 
     #[no_mangle]
@@ -621,6 +635,7 @@ mod contract {
         let io = Runtime;
         let args: parameters::BalanceOfEthCallArgs = io.read_input().to_value().sdk_unwrap();
         EthConnectorContract::init_instance(io)
+            .sdk_unwrap()
             .ft_balance_of_eth_on_aurora(args)
             .sdk_unwrap();
     }
@@ -635,6 +650,7 @@ mod contract {
         )
         .sdk_unwrap();
         EthConnectorContract::init_instance(io)
+            .sdk_unwrap()
             .ft_transfer(&predecessor_account_id, args)
             .sdk_unwrap();
     }
@@ -651,7 +667,9 @@ mod contract {
         let args: ResolveTransferCallArgs = io.read_input().to_value().sdk_unwrap();
         let promise_result = io.promise_result(0).sdk_unwrap();
 
-        EthConnectorContract::init_instance(io).ft_resolve_transfer(args, promise_result);
+        EthConnectorContract::init_instance(io)
+            .sdk_unwrap()
+            .ft_resolve_transfer(args, promise_result);
     }
 
     #[no_mangle]
@@ -668,6 +686,7 @@ mod contract {
         let current_account_id = io.current_account_id();
         let predecessor_account_id = io.predecessor_account_id();
         let promise_args = EthConnectorContract::init_instance(io)
+            .sdk_unwrap()
             .ft_transfer_call(
                 predecessor_account_id,
                 current_account_id,
@@ -686,6 +705,7 @@ mod contract {
         let predecessor_account_id = io.predecessor_account_id();
         let amount = Yocto::new(io.attached_deposit());
         let maybe_promise = EthConnectorContract::init_instance(io)
+            .sdk_unwrap()
             .storage_deposit(predecessor_account_id, amount, args)
             .sdk_unwrap();
         if let Some(promise) = maybe_promise {
@@ -700,6 +720,7 @@ mod contract {
         let predecessor_account_id = io.predecessor_account_id();
         let force = parse_json(&io.read_input().to_vec()).and_then(|args| args.bool("force").ok());
         let maybe_promise = EthConnectorContract::init_instance(io)
+            .sdk_unwrap()
             .storage_unregister(predecessor_account_id, force)
             .sdk_unwrap();
         if let Some(promise) = maybe_promise {
@@ -715,6 +736,7 @@ mod contract {
             StorageWithdrawCallArgs::from(parse_json(&io.read_input().to_vec()).sdk_unwrap());
         let predecessor_account_id = io.predecessor_account_id();
         EthConnectorContract::init_instance(io)
+            .sdk_unwrap()
             .storage_withdraw(&predecessor_account_id, args)
             .sdk_unwrap()
     }
@@ -726,13 +748,17 @@ mod contract {
             parse_json(&io.read_input().to_vec()).sdk_unwrap(),
         )
         .sdk_unwrap();
-        EthConnectorContract::init_instance(io).storage_balance_of(args)
+        EthConnectorContract::init_instance(io)
+            .sdk_unwrap()
+            .storage_balance_of(args)
     }
 
     #[no_mangle]
     pub extern "C" fn get_paused_flags() {
         let mut io = Runtime;
-        let paused_flags = EthConnectorContract::init_instance(io).get_paused_flags();
+        let paused_flags = EthConnectorContract::init_instance(io)
+            .sdk_unwrap()
+            .get_paused_flags();
         let data = paused_flags.try_to_vec().expect(ERR_FAILED_PARSE);
         io.return_output(&data[..]);
     }
@@ -743,13 +769,17 @@ mod contract {
         io.assert_private_call().sdk_unwrap();
 
         let args: PauseEthConnectorCallArgs = io.read_input_borsh().sdk_unwrap();
-        EthConnectorContract::init_instance(io).set_paused_flags(args);
+        EthConnectorContract::init_instance(io)
+            .sdk_unwrap()
+            .set_paused_flags(args);
     }
 
     #[no_mangle]
     pub extern "C" fn get_accounts_counter() {
         let io = Runtime;
-        EthConnectorContract::init_instance(io).get_accounts_counter();
+        EthConnectorContract::init_instance(io)
+            .sdk_unwrap()
+            .get_accounts_counter();
     }
 
     #[no_mangle]


### PR DESCRIPTION
This prevents an issue in the standalone engine where it can crash on old testnet blocks where the storage layout is different from the current code.