### PR TITLE
Standalone: forward underlying rocksdb crate features

### DIFF
--- a/engine-standalone-storage/Cargo.toml
+++ b/engine-standalone-storage/Cargo.toml
@@ -20,13 +20,18 @@ aurora-engine-sdk = { path = "../engine-sdk", default-features = false, features
 aurora-engine-transactions = { path = "../engine-transactions", default-features = false, features = ["std"] }
 borsh = { version = "0.8.2" }
 evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", rev = "37448b6cacd98b06282cff5a559684505c29bd2b", default-features = false }
-rocksdb = "0.16.0"
+rocksdb = { version = "0.16.0", default-features = false }
 postgres = "0.19.2"
 serde = "1.0.130"
 serde_json = "1.0.72"
 base64 = "0.13.0"
 
 [features]
-default = []
+default = ["snappy", "lz4", "zstd", "zlib", "bzip2"]
 mainnet = []
 testnet = []
+snappy = ["rocksdb/snappy"]
+lz4 = ["rocksdb/lz4"]
+zstd = ["rocksdb/zstd"]
+zlib = ["rocksdb/zlib"]
+bzip2 = ["rocksdb/bzip2"]

--- a/engine-tests/Cargo.toml
+++ b/engine-tests/Cargo.toml
@@ -18,8 +18,8 @@ aurora-engine-types = { path = "../engine-types", default-features = false, feat
 aurora-engine-sdk = { path = "../engine-sdk", default-features = false, features = ["std"] }
 aurora-engine-precompiles = { path = "../engine-precompiles", default-features = false, features = ["std"] }
 aurora-engine-transactions = { path = "../engine-transactions", default-features = false, features = ["std"] }
-engine-standalone-storage = { path = "../engine-standalone-storage", default-features = false }
-engine-standalone-tracing = { path = "../engine-standalone-tracing", default-features = false }
+engine-standalone-storage = { path = "../engine-standalone-storage" }
+engine-standalone-tracing = { path = "../engine-standalone-tracing" }
 borsh = { version = "0.8.2", default-features = false }
 sha3 = { version = "0.9.1", default-features = false }
 evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", rev = "37448b6cacd98b06282cff5a559684505c29bd2b", default-features = false, features = ["std", "tracing"] }


### PR DESCRIPTION
This allows dependent libraries to turn on/off any of the rocksdb compression features.