### PR TITLE
Fix(standalone): Do not assume "aurora" account ID

### DIFF
--- a/engine-standalone-storage/src/error.rs
+++ b/engine-standalone-storage/src/error.rs
@@ -10,6 +10,8 @@ pub enum Error {
     TransactionNotFound(TransactionIncluded),
     TransactionHashNotFound(H256),
     Rocksdb(rocksdb::Error),
+    EngineAccountIdNotSet,
+    EngineAccountIdCorrupted,
 }
 
 impl From<rocksdb::Error> for Error {

--- a/engine-tests/src/test_utils/standalone/mod.rs
+++ b/engine-tests/src/test_utils/standalone/mod.rs
@@ -38,6 +38,9 @@ impl StandaloneRunner {
         self.chain_id = chain_id;
         let storage = &mut self.storage;
         let env = &mut self.env;
+        storage
+            .set_engine_account_id(&env.current_account_id)
+            .unwrap();
         env.block_height += 1;
         let transaction_hash = H256::zero();
         let tx_msg = Self::template_tx_msg(storage, &env, 0, transaction_hash);

--- a/engine-tests/src/tests/repro.rs
+++ b/engine-tests/src/tests/repro.rs
@@ -147,6 +147,10 @@ fn repro_common<'a>(context: ReproContext<'a>) {
 
     // Also validate the SubmitResult in the standalone engine
     let mut standalone = standalone::StandaloneRunner::default();
+    standalone
+        .storage
+        .set_engine_account_id(&"aurora".parse().unwrap())
+        .unwrap();
     json_snapshot::initialize_engine_state(&mut standalone.storage, snapshot).unwrap();
     let standalone_result = standalone.submit_raw("submit", &runner.context).unwrap();
     assert_eq!(

--- a/engine-tests/src/tests/standalone/json_snapshot.rs
+++ b/engine-tests/src/tests/standalone/json_snapshot.rs
@@ -46,6 +46,10 @@ fn test_produce_snapshot() {
     .unwrap();
     let mut runner = standalone::StandaloneRunner::default();
     runner.chain_id = 1313161554;
+    runner
+        .storage
+        .set_engine_account_id(&"aurora".parse().unwrap())
+        .unwrap();
     json_snapshot::initialize_engine_state(&mut runner.storage, snapshot.clone()).unwrap();
 
     // add a couple more transactions that write some extra keys


### PR DESCRIPTION
The standalone engine must not assume the account ID of the account executing the transactions is `aurora` so that it can be used with other deployments of the engine on-chain.

There are multiple ways to accomplish this, so here is some rational behind my chosen solution of storing the account ID in the DB directly.

1. The standalone engine DB only holds state for a single engine instance. This could be changed, but this adds additional complexity without adding much value in my opinion. I think it is unlikely that any on-chain instances of the engine will have so little traffic that all of the queries about them could be served by a single standalone instance. If each on-chain instance requires at least one standalone instance off-chain, then there is no reason to be able to have multiple on-chain instance states in the same DB.
2. Given the DB serves only one on-chain instance, it makes sense to include that account ID in the DB itself This allows for validation logic to prevent inconsistencies where a single DB is built first with transactions from one instance, then transactions from a different instance (the resulting DB would not have state matching any on-chain instance). Furthermore, this keeps the API for `consume_message` and `execute_transaction_message` the same because they already required a DB handle to be passed in.
3. As a final note, you may ask why not include the account ID in the `TransactionMessage`. The reason is to avoid having a redundant field. Since each standalone DB is only meant to serve one on-chain instance, that field will always have the same value, and thus does not need to be present.