### PR TITLE
Fix(engine): revert Chain ID requirement

### DIFF
--- a/engine-tests/src/tests/erc20_connector.rs
+++ b/engine-tests/src/tests/erc20_connector.rs
@@ -184,9 +184,7 @@ impl test_utils::AuroraRunner {
             ],
         );
 
-        let chain_id = Some(self.chain_id);
-        let input =
-            create_eth_transaction(Some(token.into()), Wei::zero(), input, chain_id, &sender);
+        let input = create_eth_transaction(Some(token.into()), Wei::zero(), input, None, &sender);
 
         let result = self.evm_submit(input, origin); // create_eth_transaction()
         result.check_ok();

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -909,10 +909,6 @@ pub fn submit<I: IO + Copy, E: Env, P: PromiseHandler>(
         if U256::from(chain_id) != U256::from(state.chain_id) {
             return Err(EngineErrorKind::InvalidChainId.into());
         }
-    } else {
-        // Do not allow missing chain_id in production
-        #[cfg(not(feature = "evm_bully"))]
-        return Err(EngineErrorKind::InvalidChainId.into());
     }
 
     // Retrieve the signer of the transaction:


### PR DESCRIPTION
Reverts: #432.

At the time, given future infrastructure direction and the fact that nobody had used legacy transactions, it had made sense to require a chain ID. However given issue #519, there are other EIPs [which do in fact require legacy transactions](https://eips.ethereum.org/EIPS/eip-1820).

This reverts the Chain ID requirement and unblocks the user at the described issue.