### PR TITLE
Fix(engine): Correctly account for changes in total supply of ETH on Aurora

### DIFF
--- a/engine-tests/src/test_utils/mod.rs
+++ b/engine-tests/src/test_utils/mod.rs
@@ -292,6 +292,8 @@ impl AuroraRunner {
                 .unwrap_or_default();
             current_ft.total_eth_supply_on_near =
                 current_ft.total_eth_supply_on_near + NEP141Wei::new(init_balance.raw().as_u128());
+            current_ft.total_eth_supply_on_aurora = current_ft.total_eth_supply_on_aurora
+                + NEP141Wei::new(init_balance.raw().as_u128());
             current_ft
         };
 
@@ -315,7 +317,9 @@ impl AuroraRunner {
         );
 
         trie.insert(balance_key.to_vec(), balance_value.to_vec());
-        trie.insert(nonce_key.to_vec(), nonce_value.to_vec());
+        if !init_nonce.is_zero() {
+            trie.insert(nonce_key.to_vec(), nonce_value.to_vec());
+        }
         trie.insert(ft_key, ft_value.try_to_vec().unwrap());
         trie.insert(proof_key, vec![0]);
         trie.insert(

--- a/engine-tests/src/test_utils/one_inch/mod.rs
+++ b/engine-tests/src/test_utils/one_inch/mod.rs
@@ -15,7 +15,17 @@ pub(crate) fn download_and_compile_solidity_sources(
         // if multiple tests running in parallel saw `contracts_dir` does not exist).
         download_once.call_once(|| {
             let url = format!("https://github.com/1inch/{}", repo_name);
-            git2::Repository::clone(&url, &sources_dir).unwrap();
+            let repo = git2::Repository::clone(&url, &sources_dir).unwrap();
+            if repo_name == "limit-order-protocol" {
+                // We need to checkout a specific commit because the code in the current `master`
+                // cannot be used with our version of `ethereum-types`, it gives the following error:
+                // Error("unknown variant `error`, expected one of `constructor`, `function`, `event`, `fallback`, `receive`", line: 9, column: 21)
+                let commit_hash =
+                    git2::Oid::from_str("49ab85b3c39d916711495596a1bf811848437896").unwrap();
+                repo.set_head_detached(commit_hash).unwrap();
+                let mut opts = git2::build::CheckoutBuilder::new();
+                repo.checkout_head(Some(opts.force())).unwrap();
+            }
         });
     }
 

--- a/engine-tests/src/tests/one_inch.rs
+++ b/engine-tests/src/tests/one_inch.rs
@@ -39,7 +39,7 @@ fn test_1inch_liquidity_protocol() {
     let (result, profile, pool) =
         helper.create_pool(&pool_factory, token_a.0.address, token_b.0.address);
     assert!(result.gas_used >= 4_500_000); // more than 4.5M EVM gas used
-    assert_gas_bound(profile.all_gas(), 22);
+    assert_gas_bound(profile.all_gas(), 21);
 
     // Approve giving ERC-20 tokens to the pool
     helper.approve_erc20_tokens(&token_a, pool.address());
@@ -58,7 +58,7 @@ fn test_1inch_liquidity_protocol() {
         },
     );
     assert!(result.gas_used >= 302_000); // more than 302k EVM gas used
-    assert_gas_bound(profile.all_gas(), 25);
+    assert_gas_bound(profile.all_gas(), 24);
 
     // Same here
     helper.runner.context.block_timestamp += 10_000_000 * 1_000_000_000;
@@ -73,7 +73,7 @@ fn test_1inch_liquidity_protocol() {
         },
     );
     assert!(result.gas_used >= 210_000); // more than 210k EVM gas used
-    assert_gas_bound(profile.all_gas(), 27);
+    assert_gas_bound(profile.all_gas(), 25);
 
     let (result, profile) = helper.pool_withdraw(
         &pool,
@@ -84,7 +84,7 @@ fn test_1inch_liquidity_protocol() {
         },
     );
     assert!(result.gas_used >= 150_000); // more than 150k EVM gas used
-    assert_gas_bound(profile.all_gas(), 23);
+    assert_gas_bound(profile.all_gas(), 21);
 }
 
 #[test]

--- a/engine-tests/src/tests/repro.rs
+++ b/engine-tests/src/tests/repro.rs
@@ -27,7 +27,7 @@ fn repro_GdASJ3KESs() {
         block_timestamp: 1645717564644206730,
         input_path: "src/tests/res/input_GdASJ3KESs.hex",
         evm_gas_used: 706713,
-        near_gas_used: 138,
+        near_gas_used: 133,
     });
 }
 
@@ -52,7 +52,7 @@ fn repro_8ru7VEA() {
         block_timestamp: 1648829935343349589,
         input_path: "src/tests/res/input_8ru7VEA.hex",
         evm_gas_used: 1732181,
-        near_gas_used: 250,
+        near_gas_used: 242,
     });
 }
 
@@ -72,7 +72,7 @@ fn repro_FRcorNv() {
         block_timestamp: 1650960438774745116,
         input_path: "src/tests/res/input_FRcorNv.hex",
         evm_gas_used: 1239721,
-        near_gas_used: 203,
+        near_gas_used: 198,
     });
 }
 
@@ -107,7 +107,7 @@ fn repro_D98vwmi() {
         block_timestamp: 1651753443421003245,
         input_path: "src/tests/res/input_D98vwmi.hex",
         evm_gas_used: 1_035_348,
-        near_gas_used: 205,
+        near_gas_used: 199,
     });
 }
 

--- a/engine-tests/src/tests/res/self_destructor.sol
+++ b/engine-tests/src/tests/res/self_destructor.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+contract SelfDestruct {
+   constructor() payable {}
+
+   function destruct(address benefactor) payable external {
+      selfdestruct(payable(benefactor));
+   }
+
+}

--- a/engine-tests/src/tests/standalone/json_snapshot.rs
+++ b/engine-tests/src/tests/standalone/json_snapshot.rs
@@ -124,7 +124,9 @@ fn test_produce_snapshot() {
             buf
         };
         assert_eq!(computed_snapshot.get(&balance_key).unwrap(), &balance_value);
-        assert_eq!(computed_snapshot.get(&nonce_key).unwrap(), &nonce_value);
+        if nonce != 0 {
+            assert_eq!(computed_snapshot.get(&nonce_key).unwrap(), &nonce_value);
+        }
     }
 
     runner.close();

--- a/engine-tests/src/tests/uniswap.rs
+++ b/engine-tests/src/tests/uniswap.rs
@@ -38,7 +38,7 @@ fn test_uniswap_input_multihop() {
 
     let (_amount_out, _evm_gas, profile) = context.exact_input(&tokens, INPUT_AMOUNT.into());
 
-    assert_eq!(128, profile.all_gas() / 1_000_000_000_000);
+    assert_eq!(123, profile.all_gas() / 1_000_000_000_000);
 }
 
 #[test]
@@ -49,7 +49,7 @@ fn test_uniswap_exact_output() {
 
     let (_result, profile) =
         context.add_equal_liquidity(LIQUIDITY_AMOUNT.into(), &token_a, &token_b);
-    test_utils::assert_gas_bound(profile.all_gas(), 35);
+    test_utils::assert_gas_bound(profile.all_gas(), 34);
     let wasm_fraction = 100 * profile.wasm_gas() / profile.all_gas();
     assert!(
         40 <= wasm_fraction && wasm_fraction <= 50,
@@ -59,7 +59,7 @@ fn test_uniswap_exact_output() {
 
     let (_amount_in, profile) =
         context.exact_output_single(&token_a, &token_b, OUTPUT_AMOUNT.into());
-    test_utils::assert_gas_bound(profile.all_gas(), 20);
+    test_utils::assert_gas_bound(profile.all_gas(), 18);
     let wasm_fraction = 100 * profile.wasm_gas() / profile.all_gas();
     assert!(
         45 <= wasm_fraction && wasm_fraction <= 55,

--- a/engine/src/accounting.rs
+++ b/engine/src/accounting.rs
@@ -1,0 +1,53 @@
+use aurora_engine_types::U256;
+use core::cmp::Ordering;
+
+/// This struct tracks changes to the supply of a U256 quantity.
+/// It is used in our code to keep track of the total supply of ETH on Aurora.
+/// This struct is intentionally designed to avoid doing subtraction as much as possible
+/// to avoid complexities of signed values and over/underflow.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Accounting {
+    gained: U256,
+    lost: U256,
+}
+
+impl Accounting {
+    pub fn change(&mut self, amount: Change) {
+        match amount.new_value.cmp(&amount.old_value) {
+            Ordering::Greater => {
+                let net_gained = amount.new_value - amount.old_value;
+                self.gained = self.gained.saturating_add(net_gained);
+            }
+            Ordering::Less => {
+                let net_lost = amount.old_value - amount.new_value;
+                self.lost = self.lost.saturating_add(net_lost);
+            }
+            Ordering::Equal => (),
+        }
+    }
+
+    pub fn remove(&mut self, amount: U256) {
+        self.lost = self.lost.saturating_add(amount);
+    }
+
+    pub fn net(&self) -> Net {
+        match self.gained.cmp(&self.lost) {
+            Ordering::Equal => Net::Zero,
+            Ordering::Greater => Net::Gained(self.gained - self.lost),
+            Ordering::Less => Net::Lost(self.lost - self.gained),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Change {
+    pub new_value: U256,
+    pub old_value: U256,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Net {
+    Zero,
+    Gained(U256),
+    Lost(U256),
+}

--- a/engine/src/connector.rs
+++ b/engine/src/connector.rs
@@ -288,10 +288,9 @@ impl<I: IO + Copy> EthConnectorContract<I> {
     /// Internal ETH withdraw ETH logic
     pub(crate) fn internal_remove_eth(
         &mut self,
-        address: &Address,
         amount: Wei,
     ) -> Result<(), fungible_token::error::WithdrawError> {
-        self.burn_eth_on_aurora(address, amount)?;
+        self.burn_eth_on_aurora(amount)?;
         self.save_ft_contract();
         Ok(())
     }
@@ -339,15 +338,9 @@ impl<I: IO + Copy> EthConnectorContract<I> {
     /// Burn ETH tokens
     fn burn_eth_on_aurora(
         &mut self,
-        address: &Address,
         amount: Wei,
     ) -> Result<(), fungible_token::error::WithdrawError> {
-        sdk::log!(&format!(
-            "Burn {} ETH tokens for: {}",
-            amount,
-            address.encode()
-        ));
-        self.ft.internal_withdraw_eth_from_aurora(address, amount)
+        self.ft.internal_withdraw_eth_from_aurora(amount)
     }
 
     /// Withdraw nETH from NEAR accounts

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -1686,7 +1686,7 @@ impl<'env, J: IO + Copy, E: Env> ApplyBackend for Engine<'env, J, E> {
                 // In tests we have convenience functions that can poof addresses with ETH out of nowhere.
                 #[cfg(all(not(feature = "integration-test"), feature = "contract"))]
                 {
-                    unreachable!()
+                    panic!("ERR_INVALID_ETH_SUPPLY_INCREASE");
                 }
             }
         }

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -11,6 +11,7 @@ use aurora_engine_sdk::env::Env;
 use aurora_engine_sdk::io::{StorageIntermediate, IO};
 use aurora_engine_sdk::promise::{PromiseHandler, PromiseId};
 
+use crate::accounting;
 use crate::parameters::{DeployErc20TokenArgs, NewCallArgs, TransactionStatus};
 use crate::prelude::parameters::RefundCallArgs;
 use crate::prelude::precompiles::native::{exit_to_ethereum, exit_to_near};
@@ -1272,17 +1273,6 @@ pub fn set_balance<I: IO>(io: &mut I, address: &Address, balance: &Wei) {
 }
 
 pub fn remove_balance<I: IO + Copy>(io: &mut I, address: &Address) {
-    let balance = get_balance(io, address);
-    // Apply changes for eth-connector. We ignore the `StorageReadError` intentionally since
-    // if we cannot read the storage then there is nothing to remove.
-    EthConnectorContract::init_instance(*io)
-        .map(|mut connector| {
-            // The `unwrap` is safe here because (a) if the connector
-            // is implemented correctly then the total supply will never underflow and (b) we are passing
-            // in the balance directly so there will always be enough balance.
-            connector.internal_remove_eth(address, balance).unwrap();
-        })
-        .ok();
     io.remove_storage(&address_to_key(KeyPrefix::Balance, address));
 }
 
@@ -1594,6 +1584,7 @@ impl<'env, J: IO + Copy, E: Env> ApplyBackend for Engine<'env, J, E> {
     {
         let mut writes_counter: usize = 0;
         let mut code_bytes_written: usize = 0;
+        let mut accounting = accounting::Accounting::default();
         for apply in values {
             match apply {
                 Apply::Modify {
@@ -1603,11 +1594,23 @@ impl<'env, J: IO + Copy, E: Env> ApplyBackend for Engine<'env, J, E> {
                     storage,
                     reset_storage,
                 } => {
+                    let current_basic = self.basic(address);
+                    accounting.change(accounting::Change {
+                        new_value: basic.balance,
+                        old_value: current_basic.balance,
+                    });
+
                     let address = Address::new(address);
                     let generation = get_generation(&self.io, &address);
-                    set_nonce(&mut self.io, &address, &basic.nonce);
-                    set_balance(&mut self.io, &address, &Wei::new(basic.balance));
-                    writes_counter += 2; // 1 for nonce, 1 for balance
+
+                    if current_basic.nonce != basic.nonce {
+                        set_nonce(&mut self.io, &address, &basic.nonce);
+                        writes_counter += 1;
+                    }
+                    if current_basic.balance != basic.balance {
+                        set_balance(&mut self.io, &address, &Wei::new(basic.balance));
+                        writes_counter += 1;
+                    }
 
                     if let Some(code) = code {
                         set_code(&mut self.io, &address, &code);
@@ -1650,10 +1653,40 @@ impl<'env, J: IO + Copy, E: Env> ApplyBackend for Engine<'env, J, E> {
                     }
                 }
                 Apply::Delete { address } => {
+                    let current_basic = self.basic(address);
+                    accounting.remove(current_basic.balance);
+
                     let address = Address::new(address);
                     let generation = get_generation(&self.io, &address);
                     remove_account(&mut self.io, &address, generation);
                     writes_counter += 1;
+                }
+            }
+        }
+        match accounting.net() {
+            // Net loss is possible if `SELFDESTRUCT(self)` calls are made.
+            accounting::Net::Lost(amount) => {
+                sdk::log!(
+                    crate::prelude::format!("Burn {} ETH due to SELFDESTRUCT", amount).as_str()
+                );
+                // Apply changes for eth-connector. We ignore the `StorageReadError` intentionally since
+                // if we cannot read the storage then there is nothing to remove.
+                EthConnectorContract::init_instance(self.io)
+                    .map(|mut connector| {
+                        // The `unwrap` is safe here because (a) if the connector
+                        // is implemented correctly then the total supply will never underflow and (b) we are passing
+                        // in the balance directly so there will always be enough balance.
+                        connector.internal_remove_eth(Wei::new(amount)).unwrap();
+                    })
+                    .ok();
+            }
+            accounting::Net::Zero => (),
+            accounting::Net::Gained(_) => {
+                // It should be impossible to gain ETH using normal EVM operations in production.
+                // In tests we have convenience functions that can poof addresses with ETH out of nowhere.
+                #[cfg(all(not(feature = "integration-test"), feature = "contract"))]
+                {
+                    unreachable!()
                 }
             }
         }

--- a/engine/src/fungible_token.rs
+++ b/engine/src/fungible_token.rs
@@ -217,14 +217,8 @@ impl<I: IO + Copy> FungibleTokenOps<I> {
     /// Withdraw ETH tokens
     pub fn internal_withdraw_eth_from_aurora(
         &mut self,
-        address: &Address,
         amount: Wei,
     ) -> Result<(), error::WithdrawError> {
-        let balance = self.internal_unwrap_balance_of_eth_on_aurora(address);
-        let new_balance = balance
-            .checked_sub(amount)
-            .ok_or(error::WithdrawError::InsufficientFunds)?;
-        engine::set_balance(&mut self.io, address, &new_balance);
         self.total_eth_supply_on_aurora = self
             .total_eth_supply_on_aurora
             .checked_sub(amount)

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -18,6 +18,7 @@ pub mod meta_parsing;
 pub mod parameters;
 pub mod proof;
 
+pub mod accounting;
 pub mod admin_controlled;
 #[cfg_attr(feature = "contract", allow(dead_code))]
 pub mod connector;


### PR DESCRIPTION
This PR fixes a bug where the total supply on Aurora (that is the amount of ETH available in the EVM) was incorrectly lowered if a self-destructed address had a beneficiary other than itself. In that case the funds were simply moved from one address to another without any being lost even though an account was deleted.

The fix is implemented by aggregating the changes to the ETH supply in each item of the `Apply` loop done at the end of an EVM transaction. In the case of a self-destruct with beneficiary, this accounting will see the tokens removed from the deleted account, but added to the beneficiary's account, thus correctly recognizing this as net zero change. If there was no beneficiary (eg the contract specifies itself), then there will be no other `Apply` entry to offset this loss and the accounting will correctly note a net loss of ETH.

A test is included to illustrate this behaviour.

As a side-effect of this change, the `Apply` loop now looks up the values of balance and nonce from before the EVM transaction was executed (this is needed to see the changes in ETH balance used for accounting). Using these old values, the engine can save some NEAR gas because it does not need to write the same value to storage again. This results in a net decrease in the engine's gas usage.

The PR is somewhat large, but most of the changes are in the tests. The main logic changes are in `engine/src/engine.rs` and `engine/src/accounting.rs`.