### PR TITLE
Fix(engine): Return correct value for get_bridge_prover function

### DIFF
--- a/engine/src/connector.rs
+++ b/engine/src/connector.rs
@@ -619,6 +619,10 @@ impl<I: IO + Copy> EthConnectorContract<I> {
             .return_output(&self.ft.get_accounts_counter().to_le_bytes());
     }
 
+    pub fn get_bridge_prover(&self) -> &AccountId {
+        &self.contract.prover_account
+    }
+
     /// Save eth-connector fungible token contract data
     fn save_ft_contract(&mut self) {
         self.io.write_borsh(

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -143,8 +143,8 @@ mod contract {
     #[no_mangle]
     pub extern "C" fn get_bridge_prover() {
         let mut io = Runtime;
-        let state = engine::get_state(&io).sdk_unwrap();
-        io.return_output(state.bridge_prover_id.as_bytes());
+        let connector = EthConnectorContract::init_instance(io).sdk_unwrap();
+        io.return_output(connector.get_bridge_prover().as_bytes());
     }
 
     /// Get chain id for this contract.


### PR DESCRIPTION
The intent of the `get_bridge_prover` function is to return the account ID the engine uses to verify proofs coming from the bridge (used in transferring assets from Ethereum to NEAR). The account ID is stored in the eth-connector. In this PR, we fix the `get_bridge_prover` function to return the value from the eth-connector. I think this means the value in the engine state is unused, but it would be a bit of a pain to remove it (requires state migration to delete a field), so it is probably not worth the hassle.