### PR TITLE
Chore(eth-contracts): Update openzeppelin to 4.7.3

### DIFF
--- a/etc/eth-contracts/package.json
+++ b/etc/eth-contracts/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "ERC20 token implementation on EVM mapped from Native NEP-141",
   "dependencies": {
-    "@openzeppelin/contracts": "^4.7.0"
+    "@openzeppelin/contracts": "^4.7.3"
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.6",

--- a/etc/eth-contracts/yarn.lock
+++ b/etc/eth-contracts/yarn.lock
@@ -1114,10 +1114,10 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
-"@openzeppelin/contracts@^4.7.0":
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.7.0.tgz#3092d70ea60e3d1835466266b1d68ad47035a2d5"
-  integrity sha512-52Qb+A1DdOss8QvJrijYYPSf32GUg2pGaG/yCxtaA3cu4jduouTdg4XZSMLW9op54m1jH7J8hoajhHKOPsoJFw==
+"@openzeppelin/contracts@^4.7.3":
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.7.3.tgz#939534757a81f8d69cc854c7692805684ff3111e"
+  integrity sha512-dGRS0agJzu8ybo44pCIf3xBaPQN/65AIXNgK8+4gzKd5kbvlqyxryUYVLJv7fK98Seyd2hDZzVEHSWAh0Bt1Yw==
 
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"


### PR DESCRIPTION
This simply bumps Open Zeppelin contracts to 4.7.3 from 4.7.0.