### PR TITLE
Pausable precompiles

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,18 +18,20 @@ jobs:
         run: |
           cache-util restore cargo_git cargo_registry sccache yarn_cache
           cache-util restore aurora-engine-target@generic@${{ hashFiles('**/Cargo.lock') }}:target
-      - name: List directories
-        run: ls -la target/wasm32-unknown-unknown/release && ls -la
       - name: Build contracts
         run: cargo make build-contracts
       - name: Test contracts
         run: cargo make test-contracts
       - name: Build mainnet test WASM
         run: cargo make --profile mainnet build-test
+      - name: List mainnet WASM directory and root directory
+        run: ls -la target/wasm32-unknown-unknown/release && ls -la
       - name: Test mainnet
         run: cargo make --profile mainnet test-workspace
       - name: Build testnet test WASM
         run: cargo make --profile testnet build-test
+      - name: List testnet WASM directory and root directory
+        run: ls -la target/wasm32-unknown-unknown/release && ls -la
       - name: Test testnet
         run: cargo make --profile testnet test-workspace
       - name: Save cache

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,7 @@ dependencies = [
  "aurora-engine-transactions",
  "aurora-engine-types",
  "base64 0.13.0",
+ "bitflags",
  "borsh",
  "byte-slice-cast",
  "ethabi",
@@ -117,6 +118,7 @@ dependencies = [
  "rlp",
  "serde",
  "serde_json",
+ "test-case",
  "wee_alloc",
 ]
 
@@ -179,6 +181,7 @@ dependencies = [
  "near-primitives-core",
  "near-sdk",
  "near-sdk-sim",
+ "near-vm-errors",
  "near-vm-logic",
  "near-vm-runner",
  "rand 0.8.5",
@@ -3855,6 +3858,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "test-case"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07aea929e9488998b64adc414c29fe5620398f01c2e3f58164122b17e567a6d5"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c95968eedc6fc4f5c21920e0f4264f78ec5e4c56bb394f319becc1a5830b3e54"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/engine-precompiles/src/alt_bn256.rs
+++ b/engine-precompiles/src/alt_bn256.rs
@@ -167,10 +167,11 @@ fn read_point(input: &[u8], pos: usize) -> Result<bn::G1, ExitError> {
     })
 }
 
-pub(super) struct Bn256Add<HF: HardFork>(PhantomData<HF>);
+#[derive(Default)]
+pub struct Bn256Add<HF: HardFork>(PhantomData<HF>);
 
 impl<HF: HardFork> Bn256Add<HF> {
-    pub(super) const ADDRESS: Address = super::make_address(0, 6);
+    pub const ADDRESS: Address = super::make_address(0, 6);
 
     pub fn new() -> Self {
         Self(Default::default())
@@ -269,10 +270,11 @@ impl Precompile for Bn256Add<Istanbul> {
     }
 }
 
-pub(super) struct Bn256Mul<HF: HardFork>(PhantomData<HF>);
+#[derive(Default)]
+pub struct Bn256Mul<HF: HardFork>(PhantomData<HF>);
 
 impl<HF: HardFork> Bn256Mul<HF> {
-    pub(super) const ADDRESS: Address = super::make_address(0, 7);
+    pub const ADDRESS: Address = super::make_address(0, 7);
 
     pub fn new() -> Self {
         Self(Default::default())
@@ -374,10 +376,11 @@ impl Precompile for Bn256Mul<Istanbul> {
     }
 }
 
-pub(super) struct Bn256Pair<HF: HardFork>(PhantomData<HF>);
+#[derive(Default)]
+pub struct Bn256Pair<HF: HardFork>(PhantomData<HF>);
 
 impl<HF: HardFork> Bn256Pair<HF> {
-    pub(super) const ADDRESS: Address = super::make_address(0, 8);
+    pub const ADDRESS: Address = super::make_address(0, 8);
 
     pub fn new() -> Self {
         Self(Default::default())

--- a/engine-precompiles/src/blake2.rs
+++ b/engine-precompiles/src/blake2.rs
@@ -128,10 +128,10 @@ fn f(mut h: [u64; 8], m: [u64; 16], t: [u64; 2], f: bool, rounds: u32) -> Vec<u8
     result
 }
 
-pub(super) struct Blake2F;
+pub struct Blake2F;
 
 impl Blake2F {
-    pub(super) const ADDRESS: Address = crate::make_address(0, 9);
+    pub const ADDRESS: Address = crate::make_address(0, 9);
 }
 
 impl Precompile for Blake2F {

--- a/engine-precompiles/src/hash.rs
+++ b/engine-precompiles/src/hash.rs
@@ -27,7 +27,7 @@ mod consts {
 pub struct SHA256;
 
 impl SHA256 {
-    pub(super) const ADDRESS: Address = super::make_address(0, 2);
+    pub const ADDRESS: Address = super::make_address(0, 2);
 }
 
 impl Precompile for SHA256 {
@@ -91,7 +91,7 @@ impl Precompile for SHA256 {
 pub struct RIPEMD160;
 
 impl RIPEMD160 {
-    pub(super) const ADDRESS: Address = super::make_address(0, 3);
+    pub const ADDRESS: Address = super::make_address(0, 3);
 
     #[cfg(not(feature = "contract"))]
     fn internal_impl(input: &[u8]) -> [u8; 20] {

--- a/engine-precompiles/src/identity.rs
+++ b/engine-precompiles/src/identity.rs
@@ -21,7 +21,7 @@ mod consts {
 pub struct Identity;
 
 impl Identity {
-    pub(super) const ADDRESS: Address = super::make_address(0, 4);
+    pub const ADDRESS: Address = super::make_address(0, 4);
 }
 
 impl Precompile for Identity {

--- a/engine-precompiles/src/modexp.rs
+++ b/engine-precompiles/src/modexp.rs
@@ -6,10 +6,11 @@ use crate::{
 use evm::{Context, ExitError};
 use num::{BigUint, Integer};
 
-pub(super) struct ModExp<HF: HardFork>(PhantomData<HF>);
+#[derive(Default)]
+pub struct ModExp<HF: HardFork>(PhantomData<HF>);
 
 impl<HF: HardFork> ModExp<HF> {
-    pub(super) const ADDRESS: Address = super::make_address(0, 5);
+    pub const ADDRESS: Address = super::make_address(0, 5);
 
     pub fn new() -> Self {
         Self(Default::default())

--- a/engine-precompiles/src/secp256k1.rs
+++ b/engine-precompiles/src/secp256k1.rs
@@ -56,7 +56,7 @@ fn internal_impl(hash: H256, signature: &[u8]) -> Result<Address, ExitError> {
 pub struct ECRecover;
 
 impl ECRecover {
-    pub(super) const ADDRESS: Address = super::make_address(0, 1);
+    pub const ADDRESS: Address = super::make_address(0, 1);
 }
 
 impl Precompile for ECRecover {

--- a/engine-standalone-storage/src/sync/mod.rs
+++ b/engine-standalone-storage/src/sync/mod.rs
@@ -1,3 +1,6 @@
+use aurora_engine::pausables::{
+    EnginePrecompilesPauser, PausedPrecompilesManager, PrecompileFlags,
+};
 use aurora_engine::{connector, engine, parameters::SubmitResult, xcc};
 use aurora_engine_sdk::env::{self, Env, DEFAULT_PREPAID_GAS};
 use aurora_engine_types::{
@@ -388,6 +391,22 @@ fn non_submit_execute<'db>(
         TransactionKind::Unknown => None,
         // Not handled in this function; is handled by the general `execute_transaction` function
         TransactionKind::Submit(_) => unreachable!(),
+        TransactionKind::PausePrecompiles(args) => {
+            let precompiles_to_pause = PrecompileFlags::from_bits_truncate(args.paused_mask);
+
+            let mut pauser = EnginePrecompilesPauser::from_io(io);
+            pauser.pause_precompiles(precompiles_to_pause);
+
+            None
+        }
+        TransactionKind::ResumePrecompiles(args) => {
+            let precompiles_to_resume = PrecompileFlags::from_bits_truncate(args.paused_mask);
+
+            let mut pauser = EnginePrecompilesPauser::from_io(io);
+            pauser.resume_precompiles(precompiles_to_resume);
+
+            None
+        }
     };
 
     Ok(result)

--- a/engine-tests/Cargo.toml
+++ b/engine-tests/Cargo.toml
@@ -31,13 +31,14 @@ rlp = { version = "0.5.0", default-features = false }
 base64 = "0.13.0"
 bstr = "0.2"
 byte-slice-cast = { version = "1.0", default-features = false }
-ethabi = "17.1" 
+ethabi = "17.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 hex = { version = "0.4.3", default-features = false }
 near-sdk = { git = "https://github.com/aurora-is-near/near-sdk-rs.git", rev = "7a3fa3fbff84b712050370d840297df38c925d2d" }
 near-sdk-sim = { git = "https://github.com/aurora-is-near/near-sdk-rs.git", rev = "7a3fa3fbff84b712050370d840297df38c925d2d" }
 near-crypto = { git = "https://github.com/birchmd/nearcore.git", rev = "980bc48dc02878fea1e0dbc5812ae7de49f12dda" }
+near-vm-errors = { git = "https://github.com/birchmd/nearcore.git", rev = "980bc48dc02878fea1e0dbc5812ae7de49f12dda" }
 near-vm-runner = { git = "https://github.com/birchmd/nearcore.git", rev = "980bc48dc02878fea1e0dbc5812ae7de49f12dda", default-features = false, features = [ "wasmer2_vm", "protocol_feature_alt_bn128" ] }
 near-vm-logic = { git = "https://github.com/birchmd/nearcore.git", rev = "980bc48dc02878fea1e0dbc5812ae7de49f12dda", default-features = false, features = [ "protocol_feature_alt_bn128" ] }
 near-primitives-core = { git = "https://github.com/birchmd/nearcore.git", rev = "980bc48dc02878fea1e0dbc5812ae7de49f12dda", features = [ "protocol_feature_alt_bn128" ] }

--- a/engine-tests/src/test_utils/mod.rs
+++ b/engine-tests/src/test_utils/mod.rs
@@ -33,6 +33,9 @@ pub fn origin() -> String {
 pub(crate) const SUBMIT: &str = "submit";
 pub(crate) const CALL: &str = "call";
 pub(crate) const DEPLOY_ERC20: &str = "deploy_erc20_token";
+pub(crate) const PAUSE_PRECOMPILES: &str = "pause_precompiles";
+pub(crate) const PAUSED_PRECOMPILES: &str = "paused_precompiles";
+pub(crate) const RESUME_PRECOMPILES: &str = "resume_precompiles";
 
 pub(crate) mod erc20;
 pub(crate) mod exit_precompile;
@@ -223,7 +226,11 @@ impl AuroraRunner {
 
         if let Some(standalone_runner) = &mut self.standalone_runner {
             if maybe_error.is_none()
-                && (method_name == SUBMIT || method_name == CALL || method_name == DEPLOY_ERC20)
+                && (method_name == SUBMIT
+                    || method_name == CALL
+                    || method_name == DEPLOY_ERC20
+                    || method_name == PAUSE_PRECOMPILES
+                    || method_name == RESUME_PRECOMPILES)
             {
                 standalone_runner
                     .submit_raw(method_name, &self.context, &self.promise_results)
@@ -582,7 +589,7 @@ impl Default for AuroraRunner {
 
 /// Wrapper around `ProfileData` to still include the wasm gas usage
 /// (which was removed in https://github.com/near/nearcore/pull/4438).
-#[derive(Default, Clone)]
+#[derive(Debug, Default, Clone)]
 pub(crate) struct ExecutionProfile {
     pub host_breakdown: ProfileData,
     wasm_gas: u64,

--- a/engine-tests/src/test_utils/standalone/mod.rs
+++ b/engine-tests/src/test_utils/standalone/mod.rs
@@ -1,5 +1,7 @@
 use aurora_engine::engine;
-use aurora_engine::parameters::{CallArgs, DeployErc20TokenArgs, SubmitResult, TransactionStatus};
+use aurora_engine::parameters::{
+    CallArgs, DeployErc20TokenArgs, PausePrecompilesCallArgs, SubmitResult, TransactionStatus,
+};
 use aurora_engine_sdk::env::{self, Env};
 use aurora_engine_transactions::legacy::{LegacyEthSignedTransaction, TransactionLegacy};
 use aurora_engine_types::types::{Address, NearGas, PromiseResult, Wei};
@@ -235,6 +237,44 @@ impl StandaloneRunner {
             };
             Ok(SubmitResult::new(
                 TransactionStatus::Succeed(address.raw().as_ref().to_vec()),
+                0,
+                Vec::new(),
+            ))
+        } else if method_name == test_utils::RESUME_PRECOMPILES {
+            let input = &ctx.input[..];
+            let call_args = PausePrecompilesCallArgs::try_from_slice(input)
+                .expect("Unable to parse input as PausePrecompilesCallArgs");
+
+            let transaction_hash = aurora_engine_sdk::keccak(&ctx.input);
+            let mut tx_msg =
+                Self::template_tx_msg(storage, &env, 0, transaction_hash, promise_results);
+            tx_msg.transaction = TransactionKind::ResumePrecompiles(call_args);
+
+            let outcome = sync::execute_transaction_message(storage, tx_msg).unwrap();
+            self.cumulative_diff.append(outcome.diff.clone());
+            storage::commit(storage, &outcome);
+
+            Ok(SubmitResult::new(
+                TransactionStatus::Succeed(Vec::new()),
+                0,
+                Vec::new(),
+            ))
+        } else if method_name == test_utils::PAUSE_PRECOMPILES {
+            let input = &ctx.input[..];
+            let call_args = PausePrecompilesCallArgs::try_from_slice(input)
+                .expect("Unable to parse input as PausePrecompilesCallArgs");
+
+            let transaction_hash = aurora_engine_sdk::keccak(&ctx.input);
+            let mut tx_msg =
+                Self::template_tx_msg(storage, &env, 0, transaction_hash, promise_results);
+            tx_msg.transaction = TransactionKind::PausePrecompiles(call_args);
+
+            let outcome = sync::execute_transaction_message(storage, tx_msg).unwrap();
+            self.cumulative_diff.append(outcome.diff.clone());
+            storage::commit(storage, &outcome);
+
+            Ok(SubmitResult::new(
+                TransactionStatus::Succeed(Vec::new()),
                 0,
                 Vec::new(),
             ))

--- a/engine-tests/src/tests/mod.rs
+++ b/engine-tests/src/tests/mod.rs
@@ -11,6 +11,7 @@ mod ghsa_3p69_m8gg_fwmf;
 mod meta_parsing;
 mod multisender;
 mod one_inch;
+mod pausable_precompiles;
 mod prepaid_gas_precompile;
 mod promise_results_precompile;
 mod random;

--- a/engine-tests/src/tests/pausable_precompiles.rs
+++ b/engine-tests/src/tests/pausable_precompiles.rs
@@ -1,0 +1,160 @@
+use crate::prelude::{Address, U256};
+use crate::test_utils::exit_precompile::{Tester, TesterConstructor};
+use crate::test_utils::{
+    self, origin, AuroraRunner, Signer, PAUSED_PRECOMPILES, PAUSE_PRECOMPILES, RESUME_PRECOMPILES,
+};
+use aurora_engine::parameters::{PausePrecompilesCallArgs, TransactionStatus};
+use aurora_engine_types::types::Wei;
+use borsh::BorshSerialize;
+use near_vm_errors::{FunctionCallError, HostError};
+use near_vm_runner::VMError;
+
+const EXIT_TO_ETHEREUM_FLAG: u32 = 0b10;
+const CALLED_ACCOUNT_ID: &str = "aurora";
+
+#[test]
+fn test_paused_precompile_is_shown_when_viewing() {
+    let mut runner = test_utils::deploy_evm();
+
+    let call_args = PausePrecompilesCallArgs {
+        paused_mask: EXIT_TO_ETHEREUM_FLAG,
+    };
+
+    let mut input: Vec<u8> = Vec::new();
+    call_args.serialize(&mut input).unwrap();
+
+    let _ = runner.call(PAUSE_PRECOMPILES, CALLED_ACCOUNT_ID, input.clone());
+    let (outcome, error) = runner.call(PAUSED_PRECOMPILES, CALLED_ACCOUNT_ID, Vec::new());
+
+    assert!(error.is_none(), "{:?}", error);
+
+    let output: Vec<u8> = outcome
+        .as_ref()
+        .unwrap()
+        .return_data
+        .clone()
+        .as_value()
+        .unwrap();
+
+    let actual_paused_precompiles = u32::from_le_bytes(output.as_slice().try_into().unwrap());
+    let expected_paused_precompiles = EXIT_TO_ETHEREUM_FLAG;
+
+    assert_eq!(expected_paused_precompiles, actual_paused_precompiles);
+}
+
+#[test]
+fn test_executing_paused_precompile_throws_error() {
+    let (mut runner, mut signer, _, tester) = setup_test();
+
+    let call_args = PausePrecompilesCallArgs {
+        paused_mask: EXIT_TO_ETHEREUM_FLAG,
+    };
+
+    let mut input: Vec<u8> = Vec::new();
+    call_args.serialize(&mut input).unwrap();
+
+    let _ = runner.call(PAUSE_PRECOMPILES, CALLED_ACCOUNT_ID, input.clone());
+    let is_to_near = false;
+    let result = tester.withdraw(&mut runner, &mut signer, is_to_near);
+
+    assert!(result.is_err(), "{:?}", result);
+
+    let error = result.unwrap_err();
+    match &error {
+        VMError::FunctionCallError(fn_error) => match fn_error {
+            FunctionCallError::HostError(err) => match err {
+                HostError::GuestPanic { panic_msg } => assert_eq!(panic_msg, "ERR_PAUSED"),
+                other => panic!("Unexpected host error {:?}", other),
+            },
+            other => panic!("Unexpected function call error {:?}", other),
+        },
+        other => panic!("Unexpected VM error {:?}", other),
+    };
+}
+
+#[test]
+fn test_executing_paused_and_then_resumed_precompile_succeeds() {
+    let (mut runner, mut signer, _, tester) = setup_test();
+
+    let call_args = PausePrecompilesCallArgs {
+        paused_mask: EXIT_TO_ETHEREUM_FLAG,
+    };
+
+    let mut input: Vec<u8> = Vec::new();
+    call_args.serialize(&mut input).unwrap();
+
+    let _ = runner.call(PAUSE_PRECOMPILES, CALLED_ACCOUNT_ID, input.clone());
+    let _ = runner.call(RESUME_PRECOMPILES, CALLED_ACCOUNT_ID, input);
+    let is_to_near = false;
+    let result = tester
+        .withdraw(&mut runner, &mut signer, is_to_near)
+        .unwrap();
+
+    let number = match result.status {
+        TransactionStatus::Succeed(number) => U256::from(number.as_slice()),
+        _ => panic!("Unexpected status {:?}", result),
+    };
+
+    assert_eq!(number, U256::zero());
+}
+
+#[test]
+fn test_resuming_precompile_does_not_throw_error() {
+    let mut runner = test_utils::deploy_evm();
+
+    let call_args = PausePrecompilesCallArgs { paused_mask: 0b1 };
+
+    let mut input: Vec<u8> = Vec::new();
+    call_args.serialize(&mut input).unwrap();
+
+    let (_, error) = runner.call(RESUME_PRECOMPILES, CALLED_ACCOUNT_ID, input);
+
+    assert!(error.is_none(), "{:?}", error);
+}
+
+#[test]
+fn test_pausing_precompile_does_not_throw_error() {
+    let mut runner = test_utils::deploy_evm();
+
+    let call_args = PausePrecompilesCallArgs { paused_mask: 0b1 };
+
+    let mut input: Vec<u8> = Vec::new();
+    call_args.serialize(&mut input).unwrap();
+
+    let (_, error) = runner.call(PAUSE_PRECOMPILES, CALLED_ACCOUNT_ID, input);
+
+    assert!(error.is_none(), "{:?}", error);
+}
+
+fn setup_test() -> (AuroraRunner, Signer, Address, Tester) {
+    const INITIAL_NONCE: u64 = 0;
+
+    let mut runner = test_utils::deploy_evm();
+    let token = runner.deploy_erc20_token(&"tt.testnet".to_string());
+    let mut signer = Signer::random();
+    runner.create_address(
+        test_utils::address_from_secret_key(&signer.secret_key),
+        Wei::from_eth(1.into()).unwrap(),
+        INITIAL_NONCE.into(),
+    );
+
+    let tester_ctr = TesterConstructor::load();
+    let nonce = signer.use_nonce();
+
+    let tester: Tester = runner
+        .deploy_contract(
+            &signer.secret_key,
+            |ctr| ctr.deploy(nonce, token.into()),
+            tester_ctr,
+        )
+        .into();
+
+    runner.mint(
+        token,
+        tester.contract.address.into(),
+        1_000_000_000,
+        origin(),
+    );
+
+    (runner, signer, token, tester)
+}

--- a/engine-tests/src/tests/repro.rs
+++ b/engine-tests/src/tests/repro.rs
@@ -126,7 +126,7 @@ fn repro_Emufid2() {
         block_timestamp: 1662118048636713538,
         input_path: "src/tests/res/input_Emufid2.hex",
         evm_gas_used: 1_156_364,
-        near_gas_used: 327,
+        near_gas_used: 328,
     });
 }
 

--- a/engine-tests/src/tests/standard_precompiles.rs
+++ b/engine-tests/src/tests/standard_precompiles.rs
@@ -54,7 +54,7 @@ fn profile_identity() {
 #[test]
 fn profile_modexp() {
     let profile = precompile_execution_profile("test_modexp");
-    test_utils::assert_gas_bound(profile.all_gas(), 7);
+    test_utils::assert_gas_bound(profile.all_gas(), 8);
 }
 
 #[test]

--- a/engine-types/src/lib.rs
+++ b/engine-types/src/lib.rs
@@ -18,6 +18,7 @@ mod v0 {
         boxed::Box,
         collections::BTreeMap as HashMap,
         collections::BTreeMap,
+        collections::BTreeSet,
         fmt, format, str,
         string::String,
         string::ToString,

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,6 +21,7 @@ aurora-engine-sdk = { path = "../engine-sdk", default-features = false }
 aurora-engine-precompiles = { path = "../engine-precompiles", default-features = false }
 aurora-engine-transactions = { path = "../engine-transactions", default-features = false }
 base64 = { version = "0.13.0", default-features = false, features = ["alloc"] }
+bitflags = { version = "1.3", default-features = false }
 borsh = { version = "0.9.3", default-features = false }
 byte-slice-cast = { version = "1.0", default-features = false }
 ethabi = { version = "17.1", default-features = false }
@@ -36,6 +37,7 @@ wee_alloc = { version = "0.4.5", default-features = false }
 [dev-dependencies]
 serde_json = "1"
 rand = "0.7.3"
+test-case = "2.1"
 
 [features]
 default = ["std"]

--- a/engine/src/parameters.rs
+++ b/engine/src/parameters.rs
@@ -490,6 +490,11 @@ pub struct PauseEthConnectorCallArgs {
     pub paused_mask: PausedMask,
 }
 
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
+pub struct PausePrecompilesCallArgs {
+    pub paused_mask: u32,
+}
+
 pub mod error {
     use crate::json::JsonError;
     use aurora_engine_types::account_id::ParseAccountError;

--- a/engine/src/pausables.rs
+++ b/engine/src/pausables.rs
@@ -1,0 +1,325 @@
+use crate::prelude::{AccountId, Address, BTreeSet, Vec};
+use aurora_engine_precompiles::native::{exit_to_ethereum, exit_to_near};
+use aurora_engine_sdk::io::{StorageIntermediate, IO};
+use aurora_engine_types::storage::{bytes_to_key, KeyPrefix};
+use bitflags::bitflags;
+use borsh::{BorshDeserialize, BorshSerialize};
+
+bitflags! {
+    /// Wraps unsigned integer where each bit identifies a different precompile.
+    #[derive(BorshSerialize, BorshDeserialize, Default)]
+    pub struct PrecompileFlags: u32 {
+        const EXIT_TO_NEAR        = 0b01;
+        const EXIT_TO_ETHEREUM    = 0b10;
+    }
+}
+
+impl PrecompileFlags {
+    pub fn from_address(address: &Address) -> Option<Self> {
+        Some(if address == &exit_to_ethereum::ADDRESS {
+            PrecompileFlags::EXIT_TO_ETHEREUM
+        } else if address == &exit_to_near::ADDRESS {
+            PrecompileFlags::EXIT_TO_NEAR
+        } else {
+            return None;
+        })
+    }
+
+    /// Checks if the precompile belonging to the `address` is marked as paused.
+    pub fn is_paused_by_address(&self, address: &Address) -> bool {
+        match Self::from_address(address) {
+            Some(precompile_flag) => self.contains(precompile_flag),
+            None => false,
+        }
+    }
+}
+
+/// Can check if given account has a permission to pause precompiles.
+pub trait Authorizer {
+    /// Checks if the `account` has the permission to pause precompiles.
+    fn is_authorized(&self, account: &AccountId) -> bool;
+}
+
+/// Can check if a subset of precompiles is currently paused or not.
+pub trait PausedPrecompilesChecker {
+    /// Checks if all of the `precompiles` are paused.
+    ///
+    /// The `precompiles` mask can be a subset and every 1 bit is meant to be checked and every 0 bit is ignored.
+    fn is_paused(&self, precompiles: PrecompileFlags) -> bool;
+
+    /// Returns a set of all paused precompiles in a bitmask, where every 1 bit means paused and every 0 bit means
+    /// the opposite.
+    ///
+    /// To determine which bit belongs to what precompile, you have to match it with appropriate constant, for example
+    /// [`PrecompileFlags::EXIT_TO_NEAR`].
+    ///
+    /// # Example
+    /// ```
+    /// # use aurora_engine::pausables::{PausedPrecompilesChecker, PrecompileFlags};
+    /// # fn check(checker: impl PausedPrecompilesChecker) {
+    /// let flags = checker.paused();
+    ///
+    /// if flags.contains(PrecompileFlags::EXIT_TO_NEAR) {
+    ///     println!("EXIT_TO_NEAR is paused!");
+    /// }
+    /// # }
+    /// ```
+    fn paused(&self) -> PrecompileFlags;
+}
+
+/// Responsible for resuming and pausing of precompiles.
+pub trait PausedPrecompilesManager {
+    /// Resumes all the given `precompiles_to_resume`.
+    ///
+    /// The `precompiles_to_resume` mask can be a subset and every 1 bit is meant to be resumed and every 0 bit is
+    /// ignored.
+    fn resume_precompiles(&mut self, precompiles_to_resume: PrecompileFlags);
+
+    /// Pauses all the given precompiles.
+    ///
+    /// The `precompiles_to_pause` mask can be a subset and every 1 bit is meant to be paused and every 0 bit is
+    /// ignored.
+    fn pause_precompiles(&mut self, precompiles_to_pause: PrecompileFlags);
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Debug, Default, Clone)]
+pub struct EngineAuthorizer {
+    /// List of [AccountId]s with the permission to pause precompiles.
+    pub acl: BTreeSet<AccountId>,
+}
+
+impl EngineAuthorizer {
+    /// Creates new [EngineAuthorizer] and grants permission to pause precompiles for all given `accounts`.
+    pub fn from_accounts(accounts: impl Iterator<Item = AccountId>) -> Self {
+        Self {
+            acl: accounts.collect(),
+        }
+    }
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Debug, Default, Clone)]
+pub struct EnginePrecompilesPauser<I: IO> {
+    /// Storage to read pause flags from and write into.
+    io: I,
+}
+
+impl<I: IO> EnginePrecompilesPauser<I> {
+    /// Key for storing [PrecompileFlags].
+    const PAUSE_FLAGS_KEY: &'static [u8; 11] = b"PAUSE_FLAGS";
+
+    /// Creates new [EnginePrecompilesPauser] instance that reads from and writes into storage accessed using `io`.
+    pub fn from_io(io: I) -> Self {
+        Self { io }
+    }
+
+    fn read_flags_from_storage(&self) -> PrecompileFlags {
+        match self.io.read_storage(&Self::storage_key()) {
+            None => PrecompileFlags::empty(),
+            Some(bytes) => {
+                let int_length = core::mem::size_of::<u32>();
+                let input = bytes.to_vec();
+
+                if input.len() < int_length {
+                    return PrecompileFlags::empty();
+                }
+
+                let (int_bytes, _) = input.split_at(int_length);
+                PrecompileFlags::from_bits_truncate(u32::from_le_bytes(
+                    int_bytes.try_into().unwrap(),
+                ))
+            }
+        }
+    }
+
+    fn write_flags_into_storage(&mut self, pause_flags: PrecompileFlags) {
+        self.io
+            .write_storage(&Self::storage_key(), &pause_flags.bits().to_le_bytes());
+    }
+
+    fn storage_key() -> Vec<u8> {
+        bytes_to_key(KeyPrefix::Config, Self::PAUSE_FLAGS_KEY)
+    }
+}
+
+impl Authorizer for EngineAuthorizer {
+    fn is_authorized(&self, account: &AccountId) -> bool {
+        self.acl.get(account).is_some()
+    }
+}
+
+impl<I: IO> PausedPrecompilesChecker for EnginePrecompilesPauser<I> {
+    fn is_paused(&self, precompiles: PrecompileFlags) -> bool {
+        self.read_flags_from_storage().contains(precompiles)
+    }
+
+    fn paused(&self) -> PrecompileFlags {
+        self.read_flags_from_storage()
+    }
+}
+
+impl<I: IO> PausedPrecompilesManager for EnginePrecompilesPauser<I> {
+    fn resume_precompiles(&mut self, precompiles_to_resume: PrecompileFlags) {
+        let mut pause_flags = self.read_flags_from_storage();
+        pause_flags.remove(precompiles_to_resume);
+        self.write_flags_into_storage(pause_flags);
+    }
+
+    fn pause_precompiles(&mut self, precompiles_to_pause: PrecompileFlags) {
+        let mut pause_flags = self.read_flags_from_storage();
+        pause_flags.insert(precompiles_to_pause);
+        self.write_flags_into_storage(pause_flags);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::iter::once;
+    use test_case::test_case;
+
+    struct MockStorage {
+        key: Vec<u8>,
+        value: Option<MockValue>,
+    }
+
+    impl MockStorage {
+        pub fn new(key: Vec<u8>) -> Self {
+            Self { key, value: None }
+        }
+    }
+
+    impl IO for MockStorage {
+        type StorageValue = MockValue;
+
+        fn read_input(&self) -> Self::StorageValue {
+            unimplemented!()
+        }
+
+        fn return_output(&mut self, _value: &[u8]) {
+            unimplemented!()
+        }
+
+        fn read_storage(&self, key: &[u8]) -> Option<Self::StorageValue> {
+            match self.key.as_slice() == key {
+                true => self.value.as_ref().map(Clone::clone),
+                false => None,
+            }
+        }
+
+        fn storage_has_key(&self, _key: &[u8]) -> bool {
+            unimplemented!()
+        }
+
+        fn write_storage(&mut self, key: &[u8], value: &[u8]) -> Option<Self::StorageValue> {
+            match self.key.as_slice() == key {
+                true => {
+                    let old_value = self.value.as_ref().map(Clone::clone);
+
+                    self.value = Some(MockValue(value.to_vec()));
+
+                    old_value
+                }
+                false => None,
+            }
+        }
+
+        fn write_storage_direct(
+            &mut self,
+            _key: &[u8],
+            _value: Self::StorageValue,
+        ) -> Option<Self::StorageValue> {
+            unimplemented!()
+        }
+
+        fn remove_storage(&mut self, _key: &[u8]) -> Option<Self::StorageValue> {
+            unimplemented!()
+        }
+    }
+
+    #[derive(Clone)]
+    pub struct MockValue(Vec<u8>);
+
+    impl StorageIntermediate for MockValue {
+        fn len(&self) -> usize {
+            self.0.len()
+        }
+
+        fn is_empty(&self) -> bool {
+            self.0.is_empty()
+        }
+
+        fn copy_to_slice(&self, buffer: &mut [u8]) {
+            buffer.copy_from_slice(&self.0)
+        }
+    }
+
+    #[test_case(PrecompileFlags::EXIT_TO_ETHEREUM, exit_to_ethereum::ADDRESS)]
+    #[test_case(PrecompileFlags::EXIT_TO_NEAR, exit_to_near::ADDRESS)]
+    fn test_paused_flag_marks_precompiles_address_as_paused(
+        flags: PrecompileFlags,
+        address: Address,
+    ) {
+        assert!(flags.is_paused_by_address(&address));
+    }
+
+    #[test]
+    fn test_unknown_precompile_address_is_not_marked_as_paused() {
+        let flags = PrecompileFlags::all();
+        let address = Address::zero();
+
+        assert!(!flags.is_paused_by_address(&address));
+    }
+
+    #[test]
+    fn test_pausing_precompile_marks_it_as_paused() {
+        let key = EnginePrecompilesPauser::<MockStorage>::storage_key();
+        let io = MockStorage::new(key);
+        let mut pauser = EnginePrecompilesPauser::from_io(io);
+        let flags = PrecompileFlags::EXIT_TO_NEAR;
+
+        assert!(!pauser.is_paused(flags));
+        pauser.pause_precompiles(flags);
+        assert!(pauser.is_paused(flags));
+    }
+
+    #[test]
+    fn test_resuming_precompile_removes_its_mark_as_paused() {
+        let key = EnginePrecompilesPauser::<MockStorage>::storage_key();
+        let io = MockStorage::new(key);
+        let mut pauser = EnginePrecompilesPauser::from_io(io);
+        let flags = PrecompileFlags::EXIT_TO_NEAR;
+        pauser.pause_precompiles(flags);
+
+        assert!(pauser.is_paused(flags));
+        pauser.resume_precompiles(flags);
+        assert!(!pauser.is_paused(flags));
+    }
+
+    #[test]
+    fn test_granting_permission_to_account_authorizes_it() {
+        let account = AccountId::default();
+        let authorizer = EngineAuthorizer::from_accounts(once(account.clone()));
+
+        assert!(authorizer.is_authorized(&account));
+    }
+
+    #[test]
+    fn test_revoking_permission_from_account_unauthorizes_it() {
+        let account = AccountId::default();
+        let authorizer = EngineAuthorizer::default();
+
+        assert!(!authorizer.is_authorized(&account));
+    }
+
+    #[test]
+    fn test_no_precompile_is_paused_if_storage_contains_too_few_bytes() {
+        let key = EnginePrecompilesPauser::<MockStorage>::storage_key();
+        let mut io = MockStorage::new(key.clone());
+        io.write_storage(key.as_slice(), &[7u8]);
+        let pauser = EnginePrecompilesPauser::from_io(io);
+
+        let expected_paused = PrecompileFlags::empty();
+        let actual_paused = pauser.paused();
+        assert_eq!(expected_paused, actual_paused);
+    }
+}

--- a/etc/state-migration-test/Cargo.lock
+++ b/etc/state-migration-test/Cargo.lock
@@ -39,6 +39,7 @@ dependencies = [
  "aurora-engine-transactions",
  "aurora-engine-types",
  "base64",
+ "bitflags",
  "borsh",
  "byte-slice-cast",
  "ethabi",
@@ -149,6 +150,12 @@ name = "beef"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6736e2428df2ca2848d846c43e88745121a6654696e349ce0054a420815a7409"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"


### PR DESCRIPTION
## Description

Introduces pausable precompiles for stopping the engine when it hits a precompiled function. This is useful for emergency cases.

## Performance / NEAR gas cost considerations

Increases gas cost by a few Tgas because of additional storage read operation to load the few bytes of paused precompiles flags.

## Testing

Every added module is covered by a set of unit tests covering every conceived test scenario.

Then there is a module in `engine-tests` containing a set of functional tests that checks several test scenarios on the wasm binary. For example, there is a test case hitting a paused precompile during a smart contract execution that expects the error `ERR_PAUSED`. 

## How should this be reviewed

You should consider the administrative engine smart contract methods this feature is going to be controlled by. Take a look at test scenarios to get an idea. Separately from that, there is the mechanism of ensuring calling a paused precompile throws an error, which you should observe.

## Additional information

I have some thoughts considering the use-cases/usefulness of the engine smart contract API of this feature:

### Engine smart contract method interface
The current interface is like this:

As an admin I want to pause `modexp`, its associated flag is `0b000000000010000`. To pause it I need to run:

`pause_precompiles(0b000000000010000)`

The cause of the issue that made me pause `modexp` is resolved, now I run:

`resume_precompiles(0b000000000010000)`

Seems pretty inconvenient to need to know the right binary flag. Maybe it would be better to accept a list of stringified versions? So the previous example would run like this:

`pause_precompiles(["MODEXP"])`

`resume_precompiles(["MODEXP"])`

Also, when you hit invalid string, the error message could include a list of all possible precompile strings.

`pause_precompiles(["MODXP"])`

`Invalid precompile "MODXP", pick one or more from this list: "MODEXP", "BLAKE2F", ...`

### Reading the current state from the engine smart contract

The `paused_precompiles` method returns u32, where each 1-bit identifies a paused precompile. Same as above, more human friendly would be to return a list:

`paused_precompiles() -> Vec<String>`

For example, outputs:

`["MODEXP", "BLAKE2F", ...]`