### PR TITLE
Chore(docs): Additional documentation for xcc gas values

### DIFF
--- a/engine-precompiles/src/native.rs
+++ b/engine-precompiles/src/native.rs
@@ -30,8 +30,12 @@ mod costs {
     // TODO(#483): Determine the correct amount of gas
     pub(super) const EXIT_TO_ETHEREUM_GAS: EthGas = EthGas::new(0);
 
+    /// Value determined experimentally based on tests and mainnet data. Example:
+    /// https://explorer.mainnet.near.org/transactions/5CD7NrqWpK3H8MAAU4mYEPuuWz9AqR9uJkkZJzw5b8PM#D1b5NVRrAsJKUX2ZGs3poKViu1Rgt4RJZXtTfMgdxH4S
     pub(super) const FT_TRANSFER_GAS: NearGas = NearGas::new(10_000_000_000_000);
 
+    /// Value determined experimentally based on tests.
+    /// (No mainnet data available since this feature is not enabled)
     #[cfg(feature = "error_refund")]
     pub(super) const REFUND_ON_ERROR_GAS: NearGas = NearGas::new(5_000_000_000_000);
 

--- a/engine/src/xcc.rs
+++ b/engine/src/xcc.rs
@@ -13,10 +13,13 @@ pub const ERR_NO_ROUTER_CODE: &str = "ERR_MISSING_XCC_BYTECODE";
 pub const ERR_INVALID_ACCOUNT: &str = "ERR_INVALID_XCC_ACCOUNT";
 pub const ERR_ATTACHED_NEAR: &str = "ERR_ATTACHED_XCC_NEAR";
 pub const CODE_KEY: &[u8] = b"router_code";
+/// Gas costs estimated from simulation tests.
 pub const VERSION_UPDATE_GAS: NearGas = NearGas::new(5_000_000_000_000);
 pub const INITIALIZE_GAS: NearGas = NearGas::new(15_000_000_000_000);
 pub const UNWRAP_AND_REFUND_GAS: NearGas = NearGas::new(25_000_000_000_000);
 pub const WITHDRAW_GAS: NearGas = NearGas::new(30_000_000_000_000);
+/// Solidity selector for the withdrawToNear function
+/// https://www.4byte.directory/signatures/?bytes4_signature=0x6b351848
 pub const WITHDRAW_TO_NEAR_SELECTOR: [u8; 4] = [0x6b, 0x35, 0x18, 0x48];
 
 pub use aurora_engine_precompiles::xcc::state::{

--- a/etc/xcc-router/src/lib.rs
+++ b/etc/xcc-router/src/lib.rs
@@ -20,9 +20,18 @@ enum StorageKey {
 const CURRENT_VERSION: u32 = 1;
 
 const ERR_ILLEGAL_CALLER: &str = "ERR_ILLEGAL_CALLER";
+/// Gas cost estimated from mainnet data. Cost seems to consistently be 3 Tgas, but we add a
+/// little more to be safe. Example:
+/// https://explorer.mainnet.near.org/transactions/3U9SKbGKM3MchLa2hLTNuYLdErcEDneJGbGv1cHZXuvE#HsHabUdJ7DRJcseNa4GQTYwm8KtbB4mqsq2AUssJWWv6
 const WNEAR_WITHDRAW_GAS: Gas = Gas(5_000_000_000_000);
+/// Gas cost estimated from mainnet data. Example:
+/// https://explorer.mainnet.near.org/transactions/5NbZ7SfrodNxeLcSkCmLAEdbZfbkk9cjqz3zSDwktKrk#D7un3c3Nxv7Ee3JpQSKiM97LbwCDFPbMo5iLoijGPXPM
 const WNEAR_REGISTER_GAS: Gas = Gas(5_000_000_000_000);
+/// Gas cost estimated from simulation tests.
 const REFUND_GAS: Gas = Gas(5_000_000_000_000);
+/// Registration amount computed from FT token source code, see
+/// https://github.com/near/near-sdk-rs/blob/master/near-contract-standards/src/fungible_token/core_impl.rs#L50
+/// https://github.com/near/near-sdk-rs/blob/master/near-contract-standards/src/fungible_token/storage_impl.rs#L101
 const WNEAR_REGISTER_AMOUNT: u128 = 1_250_000_000_000_000_000_000;
 /// Must match arora_engine_precompiles::xcc::state::STORAGE_AMOUNT
 const REFUND_AMOUNT: u128 = 2_000_000_000_000_000_000_000_000;


### PR DESCRIPTION
Adds some documentation of where the various gas constants needed for cross-contract calls came from, [as requested by Joshua](https://github.com/aurora-is-near/aurora-engine/pull/560#discussion_r949349596).