### PR TITLE
[PoC] Native short cuts experiment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1204,7 +1204,7 @@ dependencies = [
 [[package]]
 name = "evm"
 version = "0.35.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.36.0-aurora#7dfbeb535e7105a7531a4e6c559f0f5d45f20014"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?rev=cb9286b87eb868e921a25f9af74dc9a9f720b39e#cb9286b87eb868e921a25f9af74dc9a9f720b39e"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -1224,7 +1224,7 @@ dependencies = [
 [[package]]
 name = "evm-core"
 version = "0.35.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.36.0-aurora#7dfbeb535e7105a7531a4e6c559f0f5d45f20014"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?rev=cb9286b87eb868e921a25f9af74dc9a9f720b39e#cb9286b87eb868e921a25f9af74dc9a9f720b39e"
 dependencies = [
  "parity-scale-codec 3.1.5",
  "primitive-types 0.11.1",
@@ -1235,7 +1235,7 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.35.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.36.0-aurora#7dfbeb535e7105a7531a4e6c559f0f5d45f20014"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?rev=cb9286b87eb868e921a25f9af74dc9a9f720b39e#cb9286b87eb868e921a25f9af74dc9a9f720b39e"
 dependencies = [
  "environmental",
  "evm-core",
@@ -1246,7 +1246,7 @@ dependencies = [
 [[package]]
 name = "evm-runtime"
 version = "0.35.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.36.0-aurora#7dfbeb535e7105a7531a4e6c559f0f5d45f20014"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?rev=cb9286b87eb868e921a25f9af74dc9a9f720b39e#cb9286b87eb868e921a25f9af74dc9a9f720b39e"
 dependencies = [
  "auto_impl",
  "environmental",

--- a/engine-precompiles/Cargo.toml
+++ b/engine-precompiles/Cargo.toml
@@ -17,7 +17,7 @@ aurora-engine-types = { path = "../engine-types", default-features = false }
 aurora-engine-sdk = { path = "../engine-sdk", default-features = false }
 borsh = { version = "0.9.3", default-features = false }
 bn = { version = "0.5.11", package = "zeropool-bn", default-features = false }
-evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.36.0-aurora", default-features = false }
+evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", rev = "cb9286b87eb868e921a25f9af74dc9a9f720b39e", default-features = false }
 libsecp256k1 = { version = "0.7.0", default-features = false, features = ["static-context", "hmac"] }
 num = { version = "0.4.0", default-features = false, features = ["alloc"] }
 ripemd = { version = "0.1.1", default-features = false }

--- a/engine-precompiles/src/erc20.rs
+++ b/engine-precompiles/src/erc20.rs
@@ -1,0 +1,428 @@
+//! This is not a single precompile, but rather a "precompile template".
+//! In particular, this is meant to replace the implementation of any ERC-20 contract
+//! with an equivalent implementation in pure Rust. This will then be compiled to
+//! wasm, and executed in the NEAR runtime directly, as opposed to the Solidity code
+//! compiled to EVM which then runs in the EVM interpreter on top of wasm.
+//! Therefore, this should be significantly more efficient than the EVM version.
+
+use crate::{HandleBasedPrecompile, PrecompileOutput};
+use aurora_engine_types::{types::EthGas, String, Vec, H160, H256, U256};
+use evm::backend::Backend;
+use evm::executor::stack::{PrecompileFailure, PrecompileHandle, StackState};
+use evm::ExitRevert;
+
+mod consts {
+    pub(super) const TRANSFER_FROM_ARGS: &[ethabi::ParamType] = &[
+        ethabi::ParamType::Address,
+        ethabi::ParamType::Address,
+        ethabi::ParamType::Uint(256),
+    ];
+    pub(super) const BALANCE_OF_ARGS: &[ethabi::ParamType] = &[ethabi::ParamType::Address];
+    pub(super) const TRANSFER_ARGS: &[ethabi::ParamType] =
+        &[ethabi::ParamType::Address, ethabi::ParamType::Uint(256)];
+    pub(super) const ALLOWANCE_ARGS: &[ethabi::ParamType] =
+        &[ethabi::ParamType::Address, ethabi::ParamType::Address];
+    pub(super) const APPROVE_ARGS: &[ethabi::ParamType] =
+        &[ethabi::ParamType::Address, ethabi::ParamType::Uint(256)];
+    pub(super) const APPROVE_SELECTOR: &[u8] = &[0x09, 0x5e, 0xa7, 0xb3];
+    pub(super) const BALANCE_OF_SELECTOR: &[u8] = &[0x70, 0xa0, 0x82, 0x31];
+    pub(super) const TOTAL_SUPPLY_SELECTOR: &[u8] = &[0x18, 0x16, 0x0d, 0xdd];
+    pub(super) const TRANSFER_SELECTOR: &[u8] = &[0xa9, 0x05, 0x9c, 0xbb];
+    pub(super) const ALLOWANCE_SELECTOR: &[u8] = &[0xdd, 0x62, 0xed, 0x3e];
+    pub(super) const TRANSFER_FROM_SELECTOR: &[u8] = &[0x23, 0xb8, 0x72, 0xdd];
+    pub(super) const NAME_SELECTOR: &[u8] = &[0x06, 0xfd, 0xde, 0x03];
+    pub(super) const SYMBOL_SELECTOR: &[u8] = &[0x95, 0xd8, 0x9b, 0x41];
+    pub(super) const DECIMALS_SELECTOR: &[u8] = &[0x31, 0x3c, 0xe5, 0x67];
+}
+
+pub struct Erc20;
+
+impl<'config> Erc20 {
+    fn name(
+        &self,
+        handle: &mut impl PrecompileHandle<'config>,
+    ) -> Result<PrecompileOutput, PrecompileFailure> {
+        let name_key = slot(5);
+        let address = handle.context().address;
+        let name = read_as_string(handle.state_mut(), address, name_key);
+
+        // TODO: cost?
+        let cost = EthGas::new(0);
+        Ok(PrecompileOutput {
+            cost,
+            output: ethabi::encode(&[ethabi::Token::String(name)]),
+            logs: Vec::new(),
+        })
+    }
+
+    fn symbol(
+        &self,
+        handle: &mut impl PrecompileHandle<'config>,
+    ) -> Result<PrecompileOutput, PrecompileFailure> {
+        let symbol_key = slot(6);
+        let address = handle.context().address;
+        let symbol = read_as_string(handle.state_mut(), address, symbol_key);
+
+        // TODO: cost?
+        let cost = EthGas::new(0);
+        Ok(PrecompileOutput {
+            cost,
+            output: ethabi::encode(&[ethabi::Token::String(symbol)]),
+            logs: Vec::new(),
+        })
+    }
+
+    fn total_supply(
+        &self,
+        handle: &mut impl PrecompileHandle<'config>,
+    ) -> Result<PrecompileOutput, PrecompileFailure> {
+        let total_supply_key = slot(4);
+        let address = handle.context().address;
+        let total_supply = read_as_u256(handle.state_mut(), address, total_supply_key);
+
+        // TODO: cost?
+        let cost = EthGas::new(0);
+        Ok(PrecompileOutput {
+            cost,
+            output: ethabi::encode(&[ethabi::Token::Uint(total_supply)]),
+            logs: Vec::new(),
+        })
+    }
+
+    fn balance_of(
+        &self,
+        handle: &mut impl PrecompileHandle<'config>,
+        owner: &H160,
+    ) -> Result<PrecompileOutput, PrecompileFailure> {
+        let address = handle.context().address;
+        let state = handle.state_mut();
+        let balance_key = Self::create_balance_storage_key(owner);
+        let balance = read_as_u256(state, address, balance_key);
+
+        // TODO: cost?
+        let cost = EthGas::new(0);
+        Ok(PrecompileOutput {
+            cost,
+            output: ethabi::encode(&[ethabi::Token::Uint(balance)]),
+            logs: Vec::new(),
+        })
+    }
+
+    fn transfer(
+        &self,
+        handle: &mut impl PrecompileHandle<'config>,
+        to: &H160,
+        amount: U256,
+    ) -> Result<PrecompileOutput, PrecompileFailure> {
+        let (erc20_address, from) = {
+            let ctx = handle.context();
+            (ctx.address, ctx.caller)
+        };
+        let state = handle.state_mut();
+
+        let balance_key = Self::create_balance_storage_key(&from);
+        let current_balance = read_as_u256(state, erc20_address, balance_key);
+        if current_balance < amount {
+            // TODO: proper error message
+            return Err(PrecompileFailure::Revert {
+                exit_status: ExitRevert::Reverted,
+                output: Vec::new(),
+            });
+        }
+
+        write_u256(state, erc20_address, balance_key, current_balance - amount);
+        let balance_key = Self::create_balance_storage_key(to);
+        // TODO: is this saturating add or checked add?
+        write_u256(
+            state,
+            erc20_address,
+            balance_key,
+            read_as_u256(state, erc20_address, balance_key).saturating_add(amount),
+        );
+
+        // TODO: cost?
+        let cost = EthGas::new(0);
+        Ok(PrecompileOutput {
+            cost,
+            output: ethabi::encode(&[ethabi::Token::Bool(true)]),
+            // TODO: proper event output
+            logs: Vec::new(),
+        })
+    }
+
+    fn allowance(
+        &self,
+        handle: &mut impl PrecompileHandle<'config>,
+        owner: &H160,
+        spender: &H160,
+    ) -> Result<PrecompileOutput, PrecompileFailure> {
+        let address = handle.context().address;
+        let state = handle.state_mut();
+        let allowance_key = Self::create_allowance_storage_key(owner, spender);
+        let allowance = read_as_u256(state, address, allowance_key);
+
+        // TODO: cost?
+        let cost = EthGas::new(0);
+        Ok(PrecompileOutput {
+            cost,
+            output: ethabi::encode(&[ethabi::Token::Uint(allowance)]),
+            logs: Vec::new(),
+        })
+    }
+
+    fn approve(
+        &self,
+        handle: &mut impl PrecompileHandle<'config>,
+        spender: &H160,
+        amount: U256,
+    ) -> Result<PrecompileOutput, PrecompileFailure> {
+        let (erc20_address, owner) = {
+            let ctx = handle.context();
+            (ctx.address, ctx.caller)
+        };
+        let state = handle.state_mut();
+
+        let allowance_key = Self::create_allowance_storage_key(&owner, spender);
+        // TODO: is this saturating add or checked add?
+        write_u256(
+            state,
+            erc20_address,
+            allowance_key,
+            read_as_u256(state, erc20_address, allowance_key).saturating_add(amount),
+        );
+
+        // TODO: cost?
+        let cost = EthGas::new(0);
+        Ok(PrecompileOutput {
+            cost,
+            output: ethabi::encode(&[ethabi::Token::Bool(true)]),
+            // TODO: proper event output
+            logs: Vec::new(),
+        })
+    }
+
+    fn transfer_from(
+        &self,
+        handle: &mut impl PrecompileHandle<'config>,
+        from: &H160,
+        to: &H160,
+        amount: U256,
+    ) -> Result<PrecompileOutput, PrecompileFailure> {
+        let (erc20_address, spender) = {
+            let ctx = handle.context();
+            (ctx.address, ctx.caller)
+        };
+        let state = handle.state_mut();
+
+        let allowance_key = Self::create_allowance_storage_key(from, &spender);
+        let current_allowance = read_as_u256(state, erc20_address, allowance_key);
+        if current_allowance < amount {
+            // TODO: proper error message
+            return Err(PrecompileFailure::Revert {
+                exit_status: ExitRevert::Reverted,
+                output: Vec::new(),
+            });
+        }
+
+        let balance_key = Self::create_balance_storage_key(from);
+        let current_balance = read_as_u256(state, erc20_address, balance_key);
+        if current_balance < amount {
+            // TODO: proper error message
+            return Err(PrecompileFailure::Revert {
+                exit_status: ExitRevert::Reverted,
+                output: Vec::new(),
+            });
+        }
+
+        if current_allowance != U256::MAX {
+            write_u256(
+                state,
+                erc20_address,
+                allowance_key,
+                current_allowance - amount,
+            );
+        }
+        write_u256(state, erc20_address, balance_key, current_balance - amount);
+        let balance_key = Self::create_balance_storage_key(to);
+        // TODO: is this saturating add or checked add?
+        write_u256(
+            state,
+            erc20_address,
+            balance_key,
+            read_as_u256(state, erc20_address, balance_key).saturating_add(amount),
+        );
+
+        // TODO: cost?
+        let cost = EthGas::new(0);
+        Ok(PrecompileOutput {
+            cost,
+            output: ethabi::encode(&[ethabi::Token::Bool(true)]),
+            // TODO: proper event output
+            logs: Vec::new(),
+        })
+    }
+
+    fn create_balance_storage_key(owner: &H160) -> H256 {
+        let mut bytes = Vec::with_capacity(64);
+        bytes.extend_from_slice(&[0u8; 12]);
+        bytes.extend_from_slice(owner.as_bytes());
+        bytes.extend_from_slice(&[0u8; 31]);
+        bytes.push(2); // balance mapping is in "slot 2"
+
+        aurora_engine_sdk::keccak(&bytes)
+    }
+
+    fn create_allowance_storage_key(owner: &H160, spender: &H160) -> H256 {
+        let mut bytes = Vec::with_capacity(64);
+        bytes.extend_from_slice(&[0u8; 12]);
+        bytes.extend_from_slice(owner.as_bytes());
+        bytes.extend_from_slice(&[0u8; 31]);
+        bytes.push(3); // allowance mapping is in "slot 3"
+
+        let hash1 = aurora_engine_sdk::keccak(&bytes);
+
+        bytes.clear();
+        bytes.extend_from_slice(&[0u8; 12]);
+        bytes.extend_from_slice(spender.as_bytes());
+        bytes.extend_from_slice(hash1.as_bytes());
+
+        aurora_engine_sdk::keccak(&bytes)
+    }
+}
+
+const fn slot(n: u8) -> H256 {
+    let mut tmp = [0u8; 32];
+    tmp[31] = n;
+    H256(tmp)
+}
+
+fn read_as_string<S: Backend>(state: &S, address: H160, key: H256) -> String {
+    let value = state.storage(address, key);
+
+    if value.0[31] % 2 == 1 {
+        panic!("Long format strings not implemented");
+    }
+
+    let length = usize::from(value.0[31] / 2);
+    let bytes = &value.as_bytes()[0..length];
+    // TODO: is lossy conversion fine here?
+    String::from_utf8_lossy(bytes).into()
+}
+
+fn read_as_u256<S: Backend>(state: &S, address: H160, key: H256) -> U256 {
+    U256::from_big_endian(state.storage(address, key).as_bytes())
+}
+
+fn write_u256<'a, S: StackState<'a>>(state: &mut S, address: H160, key: H256, value: U256) {
+    let mut bytes = [0u8; 32];
+    value.to_big_endian(&mut bytes);
+    state.set_storage(address, key, H256(bytes))
+}
+
+impl<'config> HandleBasedPrecompile<'config> for Erc20 {
+    fn run_with_handle(
+        &self,
+        handle: &mut impl PrecompileHandle<'config>,
+    ) -> Result<PrecompileOutput, PrecompileFailure> {
+        let input = handle.input();
+
+        if input.len() < 4 {
+            return Err(PrecompileFailure::Revert {
+                exit_status: ExitRevert::Reverted,
+                output: Vec::new(),
+            });
+        }
+
+        let selector = &input[0..4];
+        match selector {
+            consts::NAME_SELECTOR => self.name(handle),
+            consts::SYMBOL_SELECTOR => self.symbol(handle),
+            consts::DECIMALS_SELECTOR => {
+                // TODO: cost
+                Ok(PrecompileOutput::without_logs(
+                    EthGas::new(0),
+                    ethabi::encode(&[ethabi::Token::Uint(18.into())]),
+                ))
+            }
+            consts::TOTAL_SUPPLY_SELECTOR => self.total_supply(handle),
+            consts::BALANCE_OF_SELECTOR => {
+                let parsed_args =
+                    ethabi::decode(consts::BALANCE_OF_ARGS, &input[4..]).map_err(|_| {
+                        PrecompileFailure::Revert {
+                            exit_status: ExitRevert::Reverted,
+                            output: Vec::new(),
+                        }
+                    })?;
+                let owner = as_address(&parsed_args[0]).unwrap();
+                self.balance_of(handle, owner)
+            }
+            consts::TRANSFER_SELECTOR => {
+                let parsed_args =
+                    ethabi::decode(consts::TRANSFER_ARGS, &input[4..]).map_err(|_| {
+                        PrecompileFailure::Revert {
+                            exit_status: ExitRevert::Reverted,
+                            output: Vec::new(),
+                        }
+                    })?;
+                let to = as_address(&parsed_args[0]).unwrap(); // unwrap is because of the types passed to `decode` above
+                let amount = *as_uint(&parsed_args[1]).unwrap();
+                self.transfer(handle, to, amount)
+            }
+            consts::ALLOWANCE_SELECTOR => {
+                let parsed_args =
+                    ethabi::decode(consts::ALLOWANCE_ARGS, &input[4..]).map_err(|_| {
+                        PrecompileFailure::Revert {
+                            exit_status: ExitRevert::Reverted,
+                            output: Vec::new(),
+                        }
+                    })?;
+                let owner = as_address(&parsed_args[0]).unwrap();
+                let spender = as_address(&parsed_args[1]).unwrap();
+                self.allowance(handle, owner, spender)
+            }
+            consts::APPROVE_SELECTOR => {
+                let parsed_args =
+                    ethabi::decode(consts::APPROVE_ARGS, &input[4..]).map_err(|_| {
+                        PrecompileFailure::Revert {
+                            exit_status: ExitRevert::Reverted,
+                            output: Vec::new(),
+                        }
+                    })?;
+                let spender = as_address(&parsed_args[0]).unwrap(); // unwrap is because of the types passed to `decode` above
+                let amount = *as_uint(&parsed_args[1]).unwrap();
+                self.approve(handle, spender, amount)
+            }
+            consts::TRANSFER_FROM_SELECTOR => {
+                let parsed_args =
+                    ethabi::decode(consts::TRANSFER_FROM_ARGS, &input[4..]).map_err(|_| {
+                        PrecompileFailure::Revert {
+                            exit_status: ExitRevert::Reverted,
+                            output: Vec::new(),
+                        }
+                    })?;
+                let from = as_address(&parsed_args[0]).unwrap(); // unwrap is because of the types passed to `decode` above
+                let to = as_address(&parsed_args[1]).unwrap();
+                let amount = *as_uint(&parsed_args[2]).unwrap();
+                self.transfer_from(handle, from, to, amount)
+            }
+            _ => Err(PrecompileFailure::Revert {
+                exit_status: ExitRevert::Reverted,
+                output: Vec::new(),
+            }),
+        }
+    }
+}
+
+fn as_address(token: &ethabi::Token) -> Option<&H160> {
+    match token {
+        ethabi::Token::Address(a) => Some(a),
+        _ => None,
+    }
+}
+
+fn as_uint(token: &ethabi::Token) -> Option<&U256> {
+    match token {
+        ethabi::Token::Uint(x) => Some(x),
+        _ => None,
+    }
+}

--- a/engine-precompiles/src/xcc.rs
+++ b/engine-precompiles/src/xcc.rs
@@ -88,10 +88,10 @@ pub mod cross_contract_call {
         crate::make_h256(0x72657175697265645f6e656172, 0x72657175697265645f6e656172);
 }
 
-impl<I: IO> HandleBasedPrecompile for CrossContractCall<I> {
+impl<'config, I: IO> HandleBasedPrecompile<'config> for CrossContractCall<I> {
     fn run_with_handle(
         &self,
-        handle: &mut impl PrecompileHandle,
+        handle: &mut impl PrecompileHandle<'config>,
     ) -> Result<PrecompileOutput, PrecompileFailure> {
         let input = handle.input();
         let target_gas = handle.gas_limit().map(EthGas::new);

--- a/engine-standalone-storage/Cargo.toml
+++ b/engine-standalone-storage/Cargo.toml
@@ -20,7 +20,7 @@ aurora-engine-sdk = { path = "../engine-sdk", default-features = false, features
 aurora-engine-transactions = { path = "../engine-transactions", default-features = false, features = ["std"] }
 aurora-engine-precompiles = { path = "../engine-precompiles", default-features = false, features = ["std"] }
 borsh = { version = "0.9.3" }
-evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.36.0-aurora", default-features = false }
+evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", rev = "cb9286b87eb868e921a25f9af74dc9a9f720b39e", default-features = false }
 hex = "0.4.3"
 rocksdb = { version = "0.18.0", default-features = false }
 postgres = "0.19.2"

--- a/engine-standalone-tracing/Cargo.toml
+++ b/engine-standalone-tracing/Cargo.toml
@@ -15,10 +15,10 @@ crate-type = ["lib"]
 
 [dependencies]
 aurora-engine-types = { path = "../engine-types", default-features = false, features = ["std"] }
-evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.36.0-aurora", default-features = false, features = ["std"] }
-evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.36.0-aurora", default-features = false, features = ["std", "tracing"] }
-evm-runtime = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.36.0-aurora", default-features = false, features = ["std", "tracing"] }
-evm-gasometer = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.36.0-aurora", default-features = false, features = ["std", "tracing"] }
+evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", rev = "cb9286b87eb868e921a25f9af74dc9a9f720b39e", default-features = false, features = ["std"] }
+evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", rev = "cb9286b87eb868e921a25f9af74dc9a9f720b39e", default-features = false, features = ["std", "tracing"] }
+evm-runtime = { git = "https://github.com/aurora-is-near/sputnikvm.git", rev = "cb9286b87eb868e921a25f9af74dc9a9f720b39e", default-features = false, features = ["std", "tracing"] }
+evm-gasometer = { git = "https://github.com/aurora-is-near/sputnikvm.git", rev = "cb9286b87eb868e921a25f9af74dc9a9f720b39e", default-features = false, features = ["std", "tracing"] }
 hex = { version = "0.4", default-features = false, features = ["std"] }
 serde = { version = "1", features = ["derive"], optional = true }
 

--- a/engine-tests/Cargo.toml
+++ b/engine-tests/Cargo.toml
@@ -24,9 +24,9 @@ engine-standalone-storage = { path = "../engine-standalone-storage" }
 engine-standalone-tracing = { path = "../engine-standalone-tracing" }
 borsh = { version = "0.9.3", default-features = false }
 sha3 = { version = "0.10.2", default-features = false }
-evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.36.0-aurora", default-features = false, features = ["std", "tracing"] }
-evm-runtime = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.36.0-aurora", default-features = false, features = ["std", "tracing"] }
-evm-gasometer = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.36.0-aurora", default-features = false, features = ["std", "tracing"] }
+evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", rev = "cb9286b87eb868e921a25f9af74dc9a9f720b39e", default-features = false, features = ["std", "tracing"] }
+evm-runtime = { git = "https://github.com/aurora-is-near/sputnikvm.git", rev = "cb9286b87eb868e921a25f9af74dc9a9f720b39e", default-features = false, features = ["std", "tracing"] }
+evm-gasometer = { git = "https://github.com/aurora-is-near/sputnikvm.git", rev = "cb9286b87eb868e921a25f9af74dc9a9f720b39e", default-features = false, features = ["std", "tracing"] }
 rlp = { version = "0.5.0", default-features = false }
 base64 = "0.13.0"
 bstr = "0.2"

--- a/engine-tests/src/tests/standard_precompiles.rs
+++ b/engine-tests/src/tests/standard_precompiles.rs
@@ -54,7 +54,7 @@ fn profile_identity() {
 #[test]
 fn profile_modexp() {
     let profile = precompile_execution_profile("test_modexp");
-    test_utils::assert_gas_bound(profile.all_gas(), 7);
+    test_utils::assert_gas_bound(profile.all_gas(), 8);
 }
 
 #[test]

--- a/engine-tests/src/tests/uniswap.rs
+++ b/engine-tests/src/tests/uniswap.rs
@@ -60,7 +60,7 @@ fn test_uniswap_exact_output() {
 
     let (_amount_in, profile) =
         context.exact_output_single(&token_a, &token_b, OUTPUT_AMOUNT.into());
-    test_utils::assert_gas_bound(profile.all_gas(), 17);
+    test_utils::assert_gas_bound(profile.all_gas(), 16);
     let wasm_fraction = 100 * profile.wasm_gas() / profile.all_gas();
     assert!(
         45 <= wasm_fraction && wasm_fraction <= 55,

--- a/engine-tests/src/tests/uniswap.rs
+++ b/engine-tests/src/tests/uniswap.rs
@@ -50,7 +50,7 @@ fn test_uniswap_exact_output() {
 
     let (_result, profile) =
         context.add_equal_liquidity(LIQUIDITY_AMOUNT.into(), &token_a, &token_b);
-    test_utils::assert_gas_bound(profile.all_gas(), 33);
+    test_utils::assert_gas_bound(profile.all_gas(), 31);
     let wasm_fraction = 100 * profile.wasm_gas() / profile.all_gas();
     assert!(
         40 <= wasm_fraction && wasm_fraction <= 50,
@@ -60,7 +60,7 @@ fn test_uniswap_exact_output() {
 
     let (_amount_in, profile) =
         context.exact_output_single(&token_a, &token_b, OUTPUT_AMOUNT.into());
-    test_utils::assert_gas_bound(profile.all_gas(), 18);
+    test_utils::assert_gas_bound(profile.all_gas(), 17);
     let wasm_fraction = 100 * profile.wasm_gas() / profile.all_gas();
     assert!(
         45 <= wasm_fraction && wasm_fraction <= 55,

--- a/engine-transactions/Cargo.toml
+++ b/engine-transactions/Cargo.toml
@@ -16,7 +16,7 @@ autobenches = false
 aurora-engine-types = { path = "../engine-types", default-features = false }
 aurora-engine-sdk = { path = "../engine-sdk", default-features = false }
 aurora-engine-precompiles = { path = "../engine-precompiles", default-features = false }
-evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.36.0-aurora", default-features = false }
+evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", rev = "cb9286b87eb868e921a25f9af74dc9a9f720b39e", default-features = false }
 rlp = { version = "0.5.0", default-features = false }
 serde = { version = "1", features = ["derive"], optional = true }
 

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -24,7 +24,7 @@ base64 = { version = "0.13.0", default-features = false, features = ["alloc"] }
 borsh = { version = "0.9.3", default-features = false }
 byte-slice-cast = { version = "1.0", default-features = false }
 ethabi = { version = "17.1", default-features = false }
-evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.36.0-aurora", default-features = false }
+evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", rev = "cb9286b87eb868e921a25f9af74dc9a9f720b39e", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 rjson = { git = "https://github.com/aurora-is-near/rjson", rev = "cc3da949", default-features = false, features = ["integer"] }
 rlp = { version = "0.5.0", default-features = false }

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -27,6 +27,7 @@ pub mod errors;
 pub mod fungible_token;
 pub mod json;
 pub mod log_entry;
+pub mod native_contracts;
 mod prelude;
 pub mod xcc;
 
@@ -199,6 +200,18 @@ mod contract {
     ///
     /// MUTATIVE METHODS
     ///
+
+    #[no_mangle]
+    pub extern "C" fn register_native_contract() {
+        let mut io = Runtime;
+        let state = engine::get_state(&io).sdk_unwrap();
+        require_owner_only(&state, &io.predecessor_account_id());
+
+        let input: (Address, crate::native_contracts::ContractType) =
+            io.read_input_borsh().sdk_unwrap();
+        aurora_engine_sdk::log!(&crate::prelude::format!("Register native {:?}", input));
+        crate::native_contracts::insert_native_contract(&mut io, input.0, input.1);
+    }
 
     /// Deploy code into the EVM.
     #[no_mangle]

--- a/engine/src/native_contracts.rs
+++ b/engine/src/native_contracts.rs
@@ -1,0 +1,31 @@
+use aurora_engine_sdk::io::{StorageIntermediate, IO};
+use aurora_engine_types::{
+    storage::{self, KeyPrefix},
+    types::Address,
+    Vec,
+};
+use borsh::{BorshDeserialize, BorshSerialize};
+
+const KEY_BYTES: &[u8] = b"native_contracts";
+
+#[derive(Debug, BorshDeserialize, BorshSerialize)]
+pub enum ContractType {
+    Erc20,
+}
+
+pub fn read_native_contracts<I: IO>(io: &I) -> Vec<(Address, ContractType)> {
+    let key = storage::bytes_to_key(KeyPrefix::Config, KEY_BYTES);
+    io.read_storage(&key)
+        .map(|v| v.to_value().unwrap())
+        .unwrap_or_default()
+}
+
+pub fn insert_native_contract<I: IO>(io: &mut I, address: Address, kind: ContractType) {
+    let key = storage::bytes_to_key(KeyPrefix::Config, KEY_BYTES);
+    let mut current_value: Vec<(Address, ContractType)> = io
+        .read_storage(&key)
+        .map(|v| v.to_value().unwrap())
+        .unwrap_or_default();
+    current_value.push((address, kind));
+    io.write_borsh(&key, &current_value);
+}


### PR DESCRIPTION
## Background

We recently updated our SputnikVM version to include a recent change that makes precompiles able to make direct EVM calls using a `handle` object. This object effectively hooks directly into the EVM runtime, which got me thinking that it would be easy to give the `handle` access to EVM state as well. Then a precompile would be able to do anything a normal contract is able to. Therefore, the precompiles mechanism could be used to make "native short-cuts" we have discussed previously (the idea the we could have performance improvements by skipping over the EVM interpreter through executing equivalent native code directly -- [previous results](https://github.com/aurora-is-near/aurora-engine/pull/463) have shown native code can vastly outperform EVM interpretation).

## Description

In a [separate commit](https://github.com/aurora-is-near/sputnikvm/commit/cb9286b87eb868e921a25f9af74dc9a9f720b39e) I added state access to the `PrecompileHandle` trait in SputnikVM. We could make this into a proper PR if we think this approach is worth pursuing.

In this PR I use this new ability to make a native implementation of the ERC-20 standard which is binary-compatible with the Solidity version (i.e. reads and writes the EVM state in exactly the same way). Additionally, I add some functionality to the engine to dynamically assign addresses to precompiles. This allows deployed ERC-20 contracts to be replaced with a "native short-cut". Then I test out this new feature by short-cutting all the ERC-20 tokens used in our Uniswap tests.

## Performance / NEAR gas cost considerations

The entire purpose of this change is to give us another tool we can use for performance optimizations. In the case of `test_uniswap_input_multihop` (our most expensive uniswap test), we see about a 15% reduction in the amount of NEAR gas used. Honestly I was hoping for a bigger impact given how much effort it is to translate even a simple Solidity contract into a native counterpart. I suspect much of the gas cost still comes from state access and the overhead involved with making calls in the EVM (each call creates a new stack frame inside SputnikVM, which is needed to respect `revert` semantics properly, and this is a fairly computationally expensive operation).

Some tests actually now use a little more NEAR gas with this change due to the additional state read which is required to look for the new dynamic precompiles ("native contracts").

## How should this be reviewed

This PR is a PoC, not intended for production in its current form. As discussed below, there are a number of considerations when it comes to deciding if we want to adopt a feature like this, and if we do adopt it, what contracts we want to give native short-cuts to.

In particular, the reviewer should not focus on the details of the native ERC-20 implementation (for example, I did not implement the events the Solidity contract emits, and I think there are probably some edge case incompatibilities which would need to be ironed out if we wanted this in production). Instead, please focus on the design of the feature as a whole, and the high level ideas of translating a contract from Solidity into this Rust dialect.

## Additional information

The purpose of this PoC is research. The main deliverable from this PR is us deciding if we want to spend more time pursing this kind of feature. What follows are some pros and cons I can think of, but please give your own opinions in your reviews!

### Pros

* Performance improvement for short-cut contracts. 15% on the ERC-20 example is less than I hoped for, but certainly not nothing! And presumably more computationally intensive contracts would have more opportunities for gains.
* Potentially adds Rust to the list of languages you can write Aurora contracts in. I focused on translating a Solidity contract for this PoC because I think that would be the main use-case for this feature in the short-term, however we do not need to tether ourselves to the Solidity ABI. One could write a whole contract from scratch using this approach, and some partners may be interested in doing this. By writing it from scratch there are more opportunities for performances improvements. For example, with the ERC-20 balance/allowance mappings, the slot numbers are 1 byte and the address keys are 20 bytes, so using the keccak hash to make 32-byte keys is not necessary, thus saving some computation if we are willing to break the Solidity ABI.

### Cons

* Translating Solidity contracts creates additional auditing burdens. Effectively this requires re-implementing any contract we want to short-cut in its entirety in Rust. And if we want to upgrade an existing contract, then the Rust implementation needs to be binary-compatible with the Solidity version. Doing this for mission-critical contract (eg the bridged ERC-20 tokens) is dangerous and would require lots of testing and audits to ensure we get it right. Its possible this drawback could be mitigated through an automated transpiler from Solidity to Rust (something along the lines of what @artob has been working on, but at a higher level than the bytecode), however such a tool would be a non-trivial development effort and would itself require auditing.
* Gas cost of transactions not touching one of the short-cut contracts would be more expensive (due to the state read of the new dynamic precompiles list). This drawback could be mitigated if we short-cut all the "hot" contracts that get used the most often. The bridged ERC-20 tokens are one place to start, but we would probably need to get partners (like Trisolaris, Aurigami and Bastion) on board with this approach if we wanted to reach all the most popular contracts.