### PR TITLE
Fix(aurora-engine-transactions): remove hex feaure from std

### DIFF
--- a/engine-transactions/Cargo.toml
+++ b/engine-transactions/Cargo.toml
@@ -24,5 +24,5 @@ serde = { version = "1", features = ["derive"], optional = true }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 
 [features]
-std = ["aurora-engine-types/std", "aurora-engine-sdk/std", "aurora-engine-precompiles/std", "evm/std", "rlp/std", "hex/std"]
+std = ["aurora-engine-types/std", "aurora-engine-sdk/std", "aurora-engine-precompiles/std", "evm/std", "rlp/std"]
 impl-serde = ["aurora-engine-types/impl-serde", "serde"]


### PR DESCRIPTION
I'm getting a compiler error when I try depending on aurora-engine-transactions crate with the `std` feature

```
error: failed to select a version for `aurora-engine-transactions`.
    ... required by this package
versions that meet the requirements `*` are: 1.0.0

this package depends on `aurora-engine-transactions`, with features: `hex` but `aurora-engine-transactions` does not have these features.
```

Looks like when `hex` was [removed as a dependency](https://github.com/aurora-is-near/aurora-engine/pull/571/files#diff-81b0e69f4699d48b8b5f461a5b37437bace7dbdf6fe003993ef0544a778d926aL21), the features also needed to be changed.

This PR fixes the issue.