### PR TITLE
Fix(xcc): Only update the router contract version in storage if the deploy is successful

### DIFF
--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -351,6 +351,12 @@ mod contract {
     pub extern "C" fn factory_update_address_version() {
         let mut io = Runtime;
         io.assert_private_call().sdk_unwrap();
+        let check_deploy: Result<(), &[u8]> = match io.promise_result(0) {
+            Some(PromiseResult::Successful(_)) => Ok(()),
+            Some(_) => Err(b"ERR_ROUTER_DEPLOY_FAILED"),
+            None => Err(b"ERR_ROUTER_UPDATE_NOT_CALLBACK"),
+        };
+        check_deploy.sdk_unwrap();
         let args: crate::xcc::AddressVersionUpdateArgs = io.read_input_borsh().sdk_unwrap();
         crate::xcc::set_code_version_of_address(&mut io, &args.address, args.version);
     }


### PR DESCRIPTION
## Description

In the xcc flow, we store the current version of each deployed sub-account in the Engine's storage. When a router contract is out of date (or the sub-account does not yet exist) then we must deploy the new version and update the entry in storage. The storage update is done as a callback after the deploy. In this PR we add logic to check the deploy was successful before updating the version in storage.

## Testing

Existing xcc tests are used for testing (the deploy flow is tested because it occurs when creating a sub-account for the first time).