### PR TITLE
Refactor: Mark functions that create promises on NEAR as unsafe

### DIFF
--- a/engine-standalone-storage/src/promise.rs
+++ b/engine-standalone-storage/src/promise.rs
@@ -29,11 +29,11 @@ impl<'a> PromiseHandler for NoScheduler<'a> {
         Some(result)
     }
 
-    fn promise_create_call(&mut self, _args: &PromiseCreateArgs) -> PromiseId {
+    unsafe fn promise_create_call(&mut self, _args: &PromiseCreateArgs) -> PromiseId {
         PromiseId::new(0)
     }
 
-    fn promise_attach_callback(
+    unsafe fn promise_attach_callback(
         &mut self,
         _base: PromiseId,
         _callback: &PromiseCreateArgs,
@@ -41,7 +41,7 @@ impl<'a> PromiseHandler for NoScheduler<'a> {
         PromiseId::new(0)
     }
 
-    fn promise_create_batch(&mut self, _args: &PromiseBatchAction) -> PromiseId {
+    unsafe fn promise_create_batch(&mut self, _args: &PromiseBatchAction) -> PromiseId {
         PromiseId::new(0)
     }
 

--- a/engine-test-doubles/src/promise.rs
+++ b/engine-test-doubles/src/promise.rs
@@ -42,14 +42,14 @@ impl PromiseHandler for PromiseTracker {
         self.promise_results.get(index as usize).cloned()
     }
 
-    fn promise_create_call(&mut self, args: &PromiseCreateArgs) -> PromiseId {
+    unsafe fn promise_create_call(&mut self, args: &PromiseCreateArgs) -> PromiseId {
         let id = self.take_id();
         self.scheduled_promises
             .insert(id, PromiseArgs::Create(args.clone()));
         PromiseId::new(id)
     }
 
-    fn promise_attach_callback(
+    unsafe fn promise_attach_callback(
         &mut self,
         base: PromiseId,
         callback: &PromiseCreateArgs,
@@ -65,7 +65,7 @@ impl PromiseHandler for PromiseTracker {
         PromiseId::new(id)
     }
 
-    fn promise_create_batch(&mut self, args: &PromiseBatchAction) -> PromiseId {
+    unsafe fn promise_create_batch(&mut self, args: &PromiseBatchAction) -> PromiseId {
         let id = self.take_id();
         self.scheduled_promises
             .insert(id, PromiseArgs::Batch(args.clone()));

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -605,7 +605,10 @@ mod contract {
             .sdk_unwrap()
             .deposit(raw_proof, current_account_id, predecessor_account_id)
             .sdk_unwrap();
-        let promise_id = io.promise_create_with_callback(&promise_args);
+        // Safety: this call is safe because it comes from the eth-connector, not users.
+        // The call is to verify the user-supplied proof for the deposit, with `finish_deposit`
+        // as a callback.
+        let promise_id = unsafe { io.promise_create_with_callback(&promise_args) };
         io.promise_return(promise_id);
     }
 
@@ -642,7 +645,10 @@ mod contract {
             .sdk_unwrap();
 
         if let Some(promise_args) = maybe_promise_args {
-            let promise_id = io.promise_create_with_callback(&promise_args);
+            // Safety: this call is safe because it comes from the eth-connector, not users.
+            // The call will be to the Engine's ft_transfer_call`, which is needed as part
+            // of the bridge flow (if depositing ETH to an Aurora address).
+            let promise_id = unsafe { io.promise_create_with_callback(&promise_args) };
             io.promise_return(promise_id);
         }
     }
@@ -759,7 +765,9 @@ mod contract {
                 io.prepaid_gas(),
             )
             .sdk_unwrap();
-        let promise_id = io.promise_create_with_callback(&promise_args);
+        // Safety: this call is safe. It is required by the NEP-141 spec that `ft_transfer_call`
+        // creates a call to another contract's `ft_on_transfer` method.
+        let promise_id = unsafe { io.promise_create_with_callback(&promise_args) };
         io.promise_return(promise_id);
     }
 
@@ -774,7 +782,9 @@ mod contract {
             .storage_deposit(predecessor_account_id, amount, args)
             .sdk_unwrap();
         if let Some(promise) = maybe_promise {
-            io.promise_create_batch(&promise);
+            // Safety: This call is safe. It is only a transfer back to the user in the case
+            // that they over paid for their deposit.
+            unsafe { io.promise_create_batch(&promise) };
         }
     }
 
@@ -789,7 +799,8 @@ mod contract {
             .storage_unregister(predecessor_account_id, force)
             .sdk_unwrap();
         if let Some(promise) = maybe_promise {
-            io.promise_create_batch(&promise);
+            // Safety: This call is safe. It is only a transfer back to the user for their deposit.
+            unsafe { io.promise_create_batch(&promise) };
         }
     }
 
@@ -943,12 +954,15 @@ mod contract {
             attached_balance: ZERO_ATTACHED_BALANCE,
             attached_gas: GAS_FOR_FINISH,
         };
-        io.promise_create_with_callback(
-            &aurora_engine_types::parameters::PromiseWithCallbackArgs {
-                base: verify_call,
-                callback: finish_call,
-            },
-        );
+        // Safety: this call is safe because it is only used in integration tests.
+        unsafe {
+            io.promise_create_with_callback(
+                &aurora_engine_types::parameters::PromiseWithCallbackArgs {
+                    base: verify_call,
+                    callback: finish_call,
+                },
+            )
+        };
     }
 
     ///


### PR DESCRIPTION
Creating promises on NEAR from the Engine account is dangerous because of the admin privileges it holds. In this PR we mark the functions which create promises as `unsafe` so that the Rust compiler will not let us use them outside of an `unsafe` block. The purpose of this change is to draw attention to new usages of these functions in the future. These functions must always be accompanied by a comment describing why it is safe to make a promise in that instance, and reviewers of the PR which introduces the new usage must verify the comment is accurate. This will hopefully make it more difficult for accidental security vulnerabilities to be introduced in the future.

This PR is purely a refactor; no functionality is changed.