### PR TITLE
Fix: resolve clippy warnings and errors

### DIFF
--- a/engine-precompiles/src/lib.rs
+++ b/engine-precompiles/src/lib.rs
@@ -502,7 +502,7 @@ mod tests {
         struct MockPrecompile;
 
         impl Precompile for MockPrecompile {
-            fn required_gas(input: &[u8]) -> Result<EthGas, ExitError>
+            fn required_gas(_input: &[u8]) -> Result<EthGas, ExitError>
             where
                 Self: Sized,
             {
@@ -511,10 +511,10 @@ mod tests {
 
             fn run(
                 &self,
-                input: &[u8],
-                target_gas: Option<EthGas>,
-                context: &Context,
-                is_static: bool,
+                _input: &[u8],
+                _target_gas: Option<EthGas>,
+                _context: &Context,
+                _is_static: bool,
             ) -> EvmPrecompileResult {
                 Ok(PrecompileOutput::default())
             }
@@ -533,17 +533,17 @@ mod tests {
         impl PrecompileHandle for MockPrecompileHandle {
             fn call(
                 &mut self,
-                to: H160,
-                transfer: Option<Transfer>,
-                input: Vec<u8>,
-                gas_limit: Option<u64>,
-                is_static: bool,
-                context: &Context,
+                _to: H160,
+                _transfer: Option<Transfer>,
+                _input: Vec<u8>,
+                _gas_limit: Option<u64>,
+                _is_static: bool,
+                _context: &Context,
             ) -> (ExitReason, Vec<u8>) {
                 unimplemented!()
             }
 
-            fn record_cost(&mut self, cost: u64) -> Result<(), ExitError> {
+            fn record_cost(&mut self, _cost: u64) -> Result<(), ExitError> {
                 unimplemented!()
             }
 
@@ -553,9 +553,9 @@ mod tests {
 
             fn log(
                 &mut self,
-                address: H160,
-                topics: Vec<aurora_engine_types::H256>,
-                data: Vec<u8>,
+                _address: H160,
+                _topics: Vec<aurora_engine_types::H256>,
+                _data: Vec<u8>,
             ) -> Result<(), ExitError> {
                 unimplemented!()
             }

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -2130,7 +2130,8 @@ mod tests {
             attached_balance: Default::default(),
             attached_gas: Default::default(),
         };
-        let actual_id = schedule_promise(&mut promise_tracker, &args);
+        // This is safe because it's just a test
+        let actual_id = unsafe { schedule_promise(&mut promise_tracker, &args) };
         let actual_scheduled_promises = promise_tracker.scheduled_promises;
         let expected_scheduled_promises = {
             let mut map = HashMap::new();
@@ -2155,7 +2156,8 @@ mod tests {
             attached_gas: Default::default(),
         };
         let base_id = PromiseId::new(6);
-        let actual_id = schedule_promise_callback(&mut promise_tracker, base_id, &args);
+        // This is safe because it's just a test
+        let actual_id = unsafe { schedule_promise_callback(&mut promise_tracker, base_id, &args) };
         let actual_scheduled_promises = promise_tracker.scheduled_promises;
         let expected_scheduled_promises = {
             let mut map = HashMap::new();


### PR DESCRIPTION
Recent PR merges didn't play nice together and broke the CI build. This PR fixes it. No functionality is changed, only clippy warnings and rust compilation errors are resolved.