### PR TITLE
fix: remove sscache from CI

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -36,4 +36,3 @@ jobs:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
-  RUSTC_WRAPPER: sccache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,4 +44,3 @@ jobs:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
-  RUSTC_WRAPPER: sccache


### PR DESCRIPTION
## Description

The CI is currently broken, and according to @strokovok it fails with [sscache](https://lib.rs/crates/sccache). Removing this should get it running again. Right now it is quite unclear why it is hanging here and may be some issue with our own build servers.
