### PR TITLE
Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# CODEOWNERS: https://help.github.com/articles/about-codeowners/
+* @joshuajbouw


### PR DESCRIPTION
Adding CODEOWNERS will automatically allow utilizing the related [functionality](https://help.github.com/articles/about-codeowners/). It will also request a review for PRs from the ones who are listed in CODEOWNERS file (currently @joshuajbouw). 
