### PR TITLE
Fix(tracing): update to SputnikVM `v0.37.3-aurora`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1318,7 +1318,7 @@ dependencies = [
 [[package]]
 name = "evm"
 version = "0.37.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.37.2-aurora#dc2add0078e06322b930c07eeabcc21a0c04cc35"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.37.3-aurora#ad17d1c242356e25692573a5eea4b50ee80f6de3"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -1338,7 +1338,7 @@ dependencies = [
 [[package]]
 name = "evm-core"
 version = "0.37.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.37.2-aurora#dc2add0078e06322b930c07eeabcc21a0c04cc35"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.37.3-aurora#ad17d1c242356e25692573a5eea4b50ee80f6de3"
 dependencies = [
  "parity-scale-codec",
  "primitive-types 0.12.1",
@@ -1349,7 +1349,7 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.37.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.37.2-aurora#dc2add0078e06322b930c07eeabcc21a0c04cc35"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.37.3-aurora#ad17d1c242356e25692573a5eea4b50ee80f6de3"
 dependencies = [
  "environmental",
  "evm-core",
@@ -1360,7 +1360,7 @@ dependencies = [
 [[package]]
 name = "evm-runtime"
 version = "0.37.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.37.2-aurora#dc2add0078e06322b930c07eeabcc21a0c04cc35"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.37.3-aurora#ad17d1c242356e25692573a5eea4b50ee80f6de3"
 dependencies = [
  "auto_impl",
  "environmental",

--- a/engine-precompiles/Cargo.toml
+++ b/engine-precompiles/Cargo.toml
@@ -17,7 +17,7 @@ aurora-engine-types = { path = "../engine-types", default-features = false }
 aurora-engine-sdk = { path = "../engine-sdk", default-features = false }
 borsh = { version = "0.9.3", default-features = false }
 bn = { version = "0.5.11", package = "zeropool-bn", default-features = false }
-evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.2-aurora", default-features = false }
+evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.3-aurora", default-features = false }
 libsecp256k1 = { version = "0.7.0", default-features = false, features = ["static-context", "hmac"] }
 num = { version = "0.4.0", default-features = false, features = ["alloc"] }
 ripemd = { version = "0.1.1", default-features = false }

--- a/engine-standalone-storage/Cargo.toml
+++ b/engine-standalone-storage/Cargo.toml
@@ -20,7 +20,7 @@ aurora-engine-sdk = { path = "../engine-sdk", default-features = false, features
 aurora-engine-transactions = { path = "../engine-transactions", default-features = false, features = ["std"] }
 aurora-engine-precompiles = { path = "../engine-precompiles", default-features = false, features = ["std"] }
 borsh = { version = "0.9.3" }
-evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.2-aurora", default-features = false }
+evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.3-aurora", default-features = false }
 hex = "0.4.3"
 rocksdb = { version = "0.19.0", default-features = false }
 postgres = "0.19.2"

--- a/engine-standalone-tracing/Cargo.toml
+++ b/engine-standalone-tracing/Cargo.toml
@@ -15,10 +15,10 @@ crate-type = ["lib"]
 
 [dependencies]
 aurora-engine-types = { path = "../engine-types", default-features = false, features = ["std"] }
-evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.2-aurora", default-features = false, features = ["std"] }
-evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.2-aurora", default-features = false, features = ["std", "tracing"] }
-evm-runtime = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.2-aurora", default-features = false, features = ["std", "tracing"] }
-evm-gasometer = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.2-aurora", default-features = false, features = ["std", "tracing"] }
+evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.3-aurora", default-features = false, features = ["std"] }
+evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.3-aurora", default-features = false, features = ["std", "tracing"] }
+evm-runtime = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.3-aurora", default-features = false, features = ["std", "tracing"] }
+evm-gasometer = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.3-aurora", default-features = false, features = ["std", "tracing"] }
 hex = { version = "0.4", default-features = false, features = ["std"] }
 serde = { version = "1", features = ["derive"], optional = true }
 

--- a/engine-standalone-tracing/src/types/call_tracer.rs
+++ b/engine-standalone-tracing/src/types/call_tracer.rs
@@ -5,21 +5,21 @@ use aurora_engine_types::{types::Address, U256};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CallFrame {
-    call_type: CallType,
-    from: Address,
-    to: Option<Address>,
-    value: U256,
-    gas: u64,
-    gas_used: u64,
-    input: Vec<u8>,
-    output: Vec<u8>,
-    error: Option<String>,
-    calls: Vec<CallFrame>,
+    pub call_type: CallType,
+    pub from: Address,
+    pub to: Option<Address>,
+    pub value: U256,
+    pub gas: u64,
+    pub gas_used: u64,
+    pub input: Vec<u8>,
+    pub output: Vec<u8>,
+    pub error: Option<String>,
+    pub calls: Vec<CallFrame>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct CallTracer {
-    call_stack: Vec<CallFrame>,
+    pub call_stack: Vec<CallFrame>,
 }
 
 impl CallTracer {
@@ -163,10 +163,10 @@ impl evm::tracing::EventListener for CallTracer {
             } => {
                 let call_type = if is_static {
                     CallType::StaticCall
-                } else if transfer.is_none() {
-                    CallType::DelegateCall
                 } else if code_address == context.address {
                     CallType::Call
+                } else if transfer.is_none() {
+                    CallType::DelegateCall
                 } else {
                     CallType::CallCode
                 };

--- a/engine-test-doubles/Cargo.toml
+++ b/engine-test-doubles/Cargo.toml
@@ -15,8 +15,8 @@ autobenches = false
 [dependencies]
 aurora-engine-types = { path = "../engine-types", default-features = false, features = ["std"] }
 aurora-engine-sdk = { path = "../engine-sdk" }
-evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.2-aurora", default-features = false, features = ["std", "tracing"] }
-evm-runtime = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.2-aurora", default-features = false, features = ["std", "tracing"] }
-evm-gasometer = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.2-aurora", default-features = false, features = ["std", "tracing"] }
+evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.3-aurora", default-features = false, features = ["std", "tracing"] }
+evm-runtime = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.3-aurora", default-features = false, features = ["std", "tracing"] }
+evm-gasometer = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.3-aurora", default-features = false, features = ["std", "tracing"] }
 
 [dev-dependencies]

--- a/engine-tests/Cargo.toml
+++ b/engine-tests/Cargo.toml
@@ -22,7 +22,7 @@ aurora-engine-sdk = { path = "../engine-sdk", default-features = false, features
 aurora-engine-precompiles = { path = "../engine-precompiles", default-features = false, features = ["std"] }
 aurora-engine-transactions = { path = "../engine-transactions", default-features = false, features = ["std"] }
 engine-standalone-storage = { path = "../engine-standalone-storage" }
-engine-standalone-tracing = { path = "../engine-standalone-tracing" }
+engine-standalone-tracing = { path = "../engine-standalone-tracing", default-features = false, features = ["impl-serde"] }
 borsh = { version = "0.9.3", default-features = false }
 sha3 = { version = "0.10.2", default-features = false }
 evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.3-aurora", default-features = false, features = ["std", "tracing"] }

--- a/engine-tests/Cargo.toml
+++ b/engine-tests/Cargo.toml
@@ -25,9 +25,9 @@ engine-standalone-storage = { path = "../engine-standalone-storage" }
 engine-standalone-tracing = { path = "../engine-standalone-tracing" }
 borsh = { version = "0.9.3", default-features = false }
 sha3 = { version = "0.10.2", default-features = false }
-evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.2-aurora", default-features = false, features = ["std", "tracing"] }
-evm-runtime = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.2-aurora", default-features = false, features = ["std", "tracing"] }
-evm-gasometer = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.2-aurora", default-features = false, features = ["std", "tracing"] }
+evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.3-aurora", default-features = false, features = ["std", "tracing"] }
+evm-runtime = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.3-aurora", default-features = false, features = ["std", "tracing"] }
+evm-gasometer = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.3-aurora", default-features = false, features = ["std", "tracing"] }
 rlp = { version = "0.5.0", default-features = false }
 base64 = "0.13.0"
 bstr = "1.0.1"

--- a/engine-tests/src/test_utils/standalone/mod.rs
+++ b/engine-tests/src/test_utils/standalone/mod.rs
@@ -317,7 +317,7 @@ impl StandaloneRunner {
         self.storage_dir.close().unwrap();
     }
 
-    fn template_tx_msg(
+    pub(crate) fn template_tx_msg(
         storage: &mut Storage,
         env: &env::Fixed,
         transaction_position: u16,

--- a/engine-tests/src/tests/mod.rs
+++ b/engine-tests/src/tests/mod.rs
@@ -22,4 +22,4 @@ mod standalone;
 mod standard_precompiles;
 mod state_migration;
 pub(crate) mod uniswap;
-mod xcc;
+pub(crate) mod xcc;

--- a/engine-tests/src/tests/standalone/call_tracer.rs
+++ b/engine-tests/src/tests/standalone/call_tracer.rs
@@ -1,0 +1,350 @@
+use crate::test_utils::{self, standalone};
+use aurora_engine_types::{
+    parameters::{CrossContractCallArgs, PromiseArgs, PromiseCreateArgs},
+    storage,
+    types::{Address, NearGas, Wei, Yocto},
+    U256,
+};
+use borsh::BorshSerialize;
+use engine_standalone_storage::sync;
+use engine_standalone_tracing::{
+    sputnik,
+    types::call_tracer::{self, CallTracer},
+};
+
+#[test]
+fn test_trace_precompile_direct_call() {
+    let mut runner = standalone::StandaloneRunner::default();
+    let mut signer = test_utils::Signer::random();
+
+    runner.init_evm();
+
+    let tx = aurora_engine_transactions::legacy::TransactionLegacy {
+        nonce: signer.use_nonce().into(),
+        gas_price: U256::zero(),
+        gas_limit: u64::MAX.into(),
+        to: Some(aurora_engine_precompiles::random::RandomSeed::ADDRESS),
+        value: Wei::zero(),
+        data: Vec::new(),
+    };
+
+    let mut listener = CallTracer::default();
+    let standalone_result = sputnik::traced_call(&mut listener, || {
+        runner.submit_transaction(&signer.secret_key, tx).unwrap()
+    });
+    assert!(standalone_result.status.is_ok());
+    assert_eq!(listener.call_stack.len(), 1);
+
+    let trace = listener.call_stack.pop().unwrap();
+
+    let expected_trace = call_tracer::CallFrame {
+        call_type: call_tracer::CallType::Call,
+        from: test_utils::address_from_secret_key(&signer.secret_key),
+        to: Some(aurora_engine_precompiles::random::RandomSeed::ADDRESS),
+        value: U256::zero(),
+        gas: u64::MAX,
+        gas_used: 21000_u64,
+        input: Vec::new(),
+        output: [0u8; 32].to_vec(),
+        error: None,
+        calls: Vec::new(),
+    };
+
+    assert_eq!(trace, expected_trace);
+
+    runner.close();
+}
+
+#[test]
+fn test_trace_contract_single_call() {
+    let mut runner = standalone::StandaloneRunner::default();
+    let mut signer = test_utils::Signer::random();
+    let signer_address = test_utils::address_from_secret_key(&signer.secret_key);
+
+    runner.init_evm();
+
+    let constructor = test_utils::erc20::ERC20Constructor::load();
+    let deploy_tx = constructor.deploy("Test", "TST", signer.use_nonce().into());
+    let deploy_result = runner
+        .submit_transaction(&signer.secret_key, deploy_tx)
+        .unwrap();
+    let contract_address = {
+        let bytes = test_utils::unwrap_success_slice(&deploy_result);
+        Address::try_from_slice(bytes).unwrap()
+    };
+    let contract = test_utils::erc20::ERC20(constructor.0.deployed_at(contract_address));
+
+    let tx = contract.balance_of(signer_address, signer.use_nonce().into());
+    let mut listener = CallTracer::default();
+    let standalone_result = sputnik::traced_call(&mut listener, || {
+        runner
+            .submit_transaction(&signer.secret_key, tx.clone())
+            .unwrap()
+    });
+    assert!(standalone_result.status.is_ok());
+    assert_eq!(listener.call_stack.len(), 1);
+
+    let trace = listener.call_stack.pop().unwrap();
+
+    let expected_trace = call_tracer::CallFrame {
+        call_type: call_tracer::CallType::Call,
+        from: signer_address,
+        to: Some(contract_address),
+        value: U256::zero(),
+        gas: u64::MAX,
+        gas_used: trace.gas_used,
+        input: tx.data,
+        output: [0u8; 32].to_vec(),
+        error: None,
+        calls: Vec::new(),
+    };
+
+    assert_eq!(trace, expected_trace);
+
+    runner.close();
+}
+
+#[test]
+fn test_trace_contract_with_sub_call() {
+    use crate::tests::uniswap::UniswapTestContext;
+    const MINT_AMOUNT: u64 = 1_000_000_000_000;
+    const LIQUIDITY_AMOUNT: u64 = MINT_AMOUNT / 5;
+    const OUTPUT_AMOUNT: u64 = LIQUIDITY_AMOUNT / 100;
+
+    let mut context = UniswapTestContext::new("uniswap");
+    let (token_a, token_b) = context.create_token_pair(MINT_AMOUNT.into());
+    let pool = context.create_pool(&token_a, &token_b);
+
+    let (_result, _profile) =
+        context.add_equal_liquidity(LIQUIDITY_AMOUNT.into(), &token_a, &token_b);
+
+    context.approve_erc20(&token_a, context.swap_router.0.address, U256::MAX);
+    context.approve_erc20(&token_b, context.swap_router.0.address, U256::MAX);
+    let params = context.exact_output_single_params(OUTPUT_AMOUNT.into(), &token_a, &token_b);
+
+    let mut listener = CallTracer::default();
+    let (_amount_in, _profile) = sputnik::traced_call(&mut listener, || {
+        context
+            .runner
+            .submit_with_signer_profiled(&mut context.signer, |nonce| {
+                context.swap_router.exact_output_single(params, nonce)
+            })
+            .unwrap()
+    });
+
+    assert_eq!(listener.call_stack.len(), 1);
+
+    let user_address = test_utils::address_from_secret_key(&context.signer.secret_key);
+    let router_address = context.swap_router.0.address;
+    let pool_address = pool.0.address;
+    let b_address = token_b.0.address;
+    let a_address = token_a.0.address;
+
+    // Call flow:
+    // User -> Router.exactOutputSingle -> Pool.swap -> B.transfer
+    //                                               -> A.balanceOf
+    //                                               -> Router.uniswapV3SwapCallback -> A.transferFrom
+    //                                               -> A.balanceOf
+    let root_call = listener.call_stack.first().unwrap();
+    assert_eq!(root_call.from, user_address);
+    assert_eq!(root_call.to.unwrap(), router_address);
+
+    let call = subcall_lense(root_call, &[0]);
+    assert_eq!(call.from, router_address);
+    assert_eq!(call.to.unwrap(), pool_address);
+
+    let call = subcall_lense(root_call, &[0, 0]);
+    assert_eq!(call.from, pool_address);
+    assert_eq!(call.to.unwrap(), b_address);
+
+    let call = subcall_lense(root_call, &[0, 1]);
+    assert_eq!(call.from, pool_address);
+    assert_eq!(call.to.unwrap(), a_address);
+
+    let call = subcall_lense(root_call, &[0, 2]);
+    assert_eq!(call.from, pool_address);
+    assert_eq!(call.to.unwrap(), router_address);
+
+    let call = subcall_lense(root_call, &[0, 2, 0]);
+    assert_eq!(call.from, router_address);
+    assert_eq!(call.to.unwrap(), a_address);
+
+    let call = subcall_lense(root_call, &[0, 3]);
+    assert_eq!(call.from, pool_address);
+    assert_eq!(call.to.unwrap(), a_address);
+}
+
+#[test]
+fn test_trace_contract_with_precompile_sub_call() {
+    let mut runner = standalone::StandaloneRunner::default();
+    let mut signer = test_utils::Signer::random();
+
+    runner.init_evm();
+
+    let constructor = test_utils::standard_precompiles::PrecompilesConstructor::load();
+    let deploy_tx = constructor.deploy(signer.use_nonce().into());
+    let deploy_result = runner
+        .submit_transaction(&signer.secret_key, deploy_tx)
+        .unwrap();
+    let contract_address = {
+        let bytes = test_utils::unwrap_success_slice(&deploy_result);
+        Address::try_from_slice(bytes).unwrap()
+    };
+    let contract = test_utils::standard_precompiles::PrecompilesContract(
+        constructor.0.deployed_at(contract_address),
+    );
+
+    // This transaction calls the standard precompiles (`ecrecover`, `sha256`, etc) one aft the other.
+    // So the trace is one top-level call with multiple sub-calls (and the sub-calls contain no further sub-calls).
+    let tx = contract.call_method("test_all", signer.use_nonce().into());
+    let mut listener = CallTracer::default();
+    let standalone_result = sputnik::traced_call(&mut listener, || {
+        runner
+            .submit_transaction(&signer.secret_key, tx.clone())
+            .unwrap()
+    });
+    assert!(standalone_result.status.is_ok());
+    assert_eq!(listener.call_stack.len(), 1);
+
+    let trace = listener.call_stack.pop().unwrap();
+    assert_eq!(trace.calls.len(), 8);
+    for call in trace.calls {
+        assert!(call.calls.is_empty());
+    }
+
+    runner.close();
+}
+
+#[test]
+fn test_trace_precompiles_with_subcalls() {
+    // The XCC precompile does internal sub-calls. We will trace an XCC call.
+
+    let mut runner = standalone::StandaloneRunner::default();
+    let mut signer = test_utils::Signer::random();
+    let signer_address = test_utils::address_from_secret_key(&signer.secret_key);
+    let xcc_address = aurora_engine_precompiles::xcc::cross_contract_call::ADDRESS;
+
+    runner.init_evm();
+
+    // Deploy an ERC-20 contract to act as wNEAR. It doesn't actually need to be bridged for
+    // this test because we are not executing any scheduled promises.
+    let constructor = test_utils::erc20::ERC20Constructor::load();
+    let deploy_tx = constructor.deploy("wNEAR", "WNEAR", signer.use_nonce().into());
+    let deploy_result = runner
+        .submit_transaction(&signer.secret_key, deploy_tx)
+        .unwrap();
+    let wnear_address = {
+        let bytes = test_utils::unwrap_success_slice(&deploy_result);
+        Address::try_from_slice(bytes).unwrap()
+    };
+    let wnear = test_utils::erc20::ERC20(constructor.0.deployed_at(wnear_address));
+    let mint_tx = wnear.mint(signer_address, u128::MAX.into(), signer.use_nonce().into());
+    runner
+        .submit_transaction(&signer.secret_key, mint_tx)
+        .unwrap();
+    let approve_tx = wnear.approve(xcc_address, U256::MAX, signer.use_nonce().into());
+    runner
+        .submit_transaction(&signer.secret_key, approve_tx)
+        .unwrap();
+    // Ensure the above ERC-20 token is registered as if it were a bridged token
+    {
+        runner.env.block_height += 1;
+        let storage = &mut runner.storage;
+        let env = &runner.env;
+
+        let mut tx =
+            standalone::StandaloneRunner::template_tx_msg(storage, env, 0, Default::default(), &[]);
+        tx.transaction = sync::types::TransactionKind::DeployErc20(
+            aurora_engine::parameters::DeployErc20TokenArgs {
+                nep141: "wrap.near".parse().unwrap(),
+            },
+        );
+        let mut outcome = sync::execute_transaction_message(storage, tx).unwrap();
+        let key = storage::bytes_to_key(storage::KeyPrefix::Nep141Erc20Map, b"wrap.near");
+        outcome.diff.modify(key, wnear_address.as_bytes().to_vec());
+        let key =
+            storage::bytes_to_key(storage::KeyPrefix::Erc20Nep141Map, wnear_address.as_bytes());
+        outcome.diff.modify(key, b"wrap.near".to_vec());
+        test_utils::standalone::storage::commit(storage, &outcome);
+    }
+
+    // Setup xcc precompile in standalone runner
+    let xcc_router_bytes = crate::tests::xcc::contract_bytes();
+    let factory_update = {
+        runner.env.block_height += 1;
+        runner.env.predecessor_account_id = "aurora".parse().unwrap();
+        runner.env.signer_account_id = "aurora".parse().unwrap();
+        let storage = &mut runner.storage;
+        let env = &runner.env;
+
+        let mut tx =
+            standalone::StandaloneRunner::template_tx_msg(storage, env, 0, Default::default(), &[]);
+        tx.transaction = sync::types::TransactionKind::FactoryUpdate(xcc_router_bytes);
+        tx
+    };
+    let outcome = sync::execute_transaction_message(&runner.storage, factory_update).unwrap();
+    test_utils::standalone::storage::commit(&mut runner.storage, &outcome);
+    let set_wnear_address = {
+        runner.env.block_height += 1;
+        let storage = &mut runner.storage;
+        let env = &runner.env;
+
+        let mut tx =
+            standalone::StandaloneRunner::template_tx_msg(storage, env, 0, Default::default(), &[]);
+        tx.transaction = sync::types::TransactionKind::FactorySetWNearAddress(wnear_address);
+        tx
+    };
+    let outcome = sync::execute_transaction_message(&runner.storage, set_wnear_address).unwrap();
+    test_utils::standalone::storage::commit(&mut runner.storage, &outcome);
+
+    // User calls XCC precompile
+    let promise = PromiseCreateArgs {
+        target_account_id: "some_account.near".parse().unwrap(),
+        method: "whatever".into(),
+        args: Vec::new(),
+        attached_balance: Yocto::new(1),
+        attached_gas: NearGas::new(100_000_000_000_000),
+    };
+    let xcc_args = CrossContractCallArgs::Delayed(PromiseArgs::Create(promise));
+    let tx = aurora_engine_transactions::legacy::TransactionLegacy {
+        nonce: signer.use_nonce().into(),
+        gas_price: U256::zero(),
+        gas_limit: u64::MAX.into(),
+        to: Some(xcc_address),
+        value: Wei::zero(),
+        data: xcc_args.try_to_vec().unwrap(),
+    };
+    let mut listener = CallTracer::default();
+    let standalone_result = sputnik::traced_call(&mut listener, || {
+        runner
+            .submit_transaction(&signer.secret_key, tx.clone())
+            .unwrap()
+    });
+    assert!(standalone_result.status.is_ok());
+    assert_eq!(listener.call_stack.len(), 1);
+
+    let trace = listener.call_stack.pop().unwrap();
+    assert_eq!(trace.calls.len(), 1);
+    let subcall = trace.calls.first().unwrap();
+    assert_eq!(subcall.call_type, call_tracer::CallType::Call);
+    assert_eq!(subcall.from, xcc_address);
+    assert_eq!(subcall.to.unwrap(), wnear_address);
+    assert_eq!(U256::from_big_endian(&subcall.output), U256::one());
+
+    runner.close();
+}
+
+/// A convenience function for pulling out a sub-call from a trace.
+/// The `path` gives the index to pull out of each `calls` array.
+/// For example `path == []` simply returns the given `root`, while
+/// `path == [2, 0]` will return `root.calls[2].calls[0]`.
+fn subcall_lense<'a, 'b>(
+    root: &'a call_tracer::CallFrame,
+    path: &'b [usize],
+) -> &'a call_tracer::CallFrame {
+    let mut result = root;
+    for index in path {
+        result = result.calls.get(*index).unwrap();
+    }
+    result
+}

--- a/engine-tests/src/tests/standalone/mod.rs
+++ b/engine-tests/src/tests/standalone/mod.rs
@@ -1,3 +1,4 @@
+mod call_tracer;
 mod json_snapshot;
 mod sanity;
 mod storage;

--- a/engine-tests/src/tests/xcc.rs
+++ b/engine-tests/src/tests/xcc.rs
@@ -816,7 +816,7 @@ fn approve_erc20(
     assert!(approve_result.status.is_ok());
 }
 
-fn contract_bytes() -> Vec<u8> {
+pub(crate) fn contract_bytes() -> Vec<u8> {
     let base_path = Path::new("../etc").join("xcc-router");
     let output_path = base_path.join("target/wasm32-unknown-unknown/release/xcc_router.wasm");
     test_utils::rust::compile(base_path);

--- a/engine-transactions/Cargo.toml
+++ b/engine-transactions/Cargo.toml
@@ -16,7 +16,7 @@ autobenches = false
 aurora-engine-types = { path = "../engine-types", default-features = false }
 aurora-engine-sdk = { path = "../engine-sdk", default-features = false }
 aurora-engine-precompiles = { path = "../engine-precompiles", default-features = false }
-evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.2-aurora", default-features = false }
+evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.3-aurora", default-features = false }
 rlp = { version = "0.5.0", default-features = false }
 serde = { version = "1", features = ["derive"], optional = true }
 

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -25,7 +25,7 @@ bitflags = { version = "1.3", default-features = false }
 borsh = { version = "0.9.3", default-features = false }
 byte-slice-cast = { version = "1.0", default-features = false }
 ethabi = { version = "18.0", default-features = false }
-evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.2-aurora", default-features = false }
+evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.3-aurora", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 rjson = { git = "https://github.com/aurora-is-near/rjson", rev = "cc3da949", default-features = false, features = ["integer"] }
 rlp = { version = "0.5.0", default-features = false }


### PR DESCRIPTION
## Description

There was a bug introduced in SputnikVM `v0.37.1-aurora` where some `Exit` tracing events were missing, which caused the tracing feature not to work correctly. This was fixed in `v0.37.3-aurora`. In this PR we update to the fixed version and add new tests to prevent such a regression in the future.

## Testing

New tests for tracing.