### PR TITLE
chore: remove dynamic memory allocation while creating precompile flags

### DIFF
--- a/engine/src/pausables.rs
+++ b/engine/src/pausables.rs
@@ -117,10 +117,7 @@ impl<I: IO> EnginePrecompilesPauser<I> {
             None => PrecompileFlags::empty(),
             Some(bytes) => {
                 const U32_SIZE: usize = core::mem::size_of::<u32>();
-
-                if bytes.len() < U32_SIZE {
-                    return PrecompileFlags::empty();
-                }
+                assert_eq!(bytes.len(), U32_SIZE, "ERR_CORRUPTED_PAUSE_FLAGS");
 
                 let mut buffer = [0u8; U32_SIZE];
                 bytes.copy_to_slice(&mut buffer);

--- a/engine/src/pausables.rs
+++ b/engine/src/pausables.rs
@@ -116,17 +116,16 @@ impl<I: IO> EnginePrecompilesPauser<I> {
         match self.io.read_storage(&Self::storage_key()) {
             None => PrecompileFlags::empty(),
             Some(bytes) => {
-                let int_length = core::mem::size_of::<u32>();
-                let input = bytes.to_vec();
+                const U32_SIZE: usize = core::mem::size_of::<u32>();
 
-                if input.len() < int_length {
+                if bytes.len() < U32_SIZE {
                     return PrecompileFlags::empty();
                 }
 
-                let (int_bytes, _) = input.split_at(int_length);
-                PrecompileFlags::from_bits_truncate(u32::from_le_bytes(
-                    int_bytes.try_into().unwrap(),
-                ))
+                let mut buffer = [0u8; U32_SIZE];
+                bytes.copy_to_slice(&mut buffer);
+
+                PrecompileFlags::from_bits_truncate(u32::from_le_bytes(buffer))
             }
         }
     }

--- a/engine/src/pausables.rs
+++ b/engine/src/pausables.rs
@@ -117,7 +117,7 @@ impl<I: IO> EnginePrecompilesPauser<I> {
             None => PrecompileFlags::empty(),
             Some(bytes) => {
                 const U32_SIZE: usize = core::mem::size_of::<u32>();
-                assert_eq!(bytes.len(), U32_SIZE, "ERR_CORRUPTED_PAUSE_FLAGS");
+                assert_eq!(bytes.len(), U32_SIZE, "PrecompileFlags value is corrupted");
 
                 let mut buffer = [0u8; U32_SIZE];
                 bytes.copy_to_slice(&mut buffer);

--- a/engine/src/pausables.rs
+++ b/engine/src/pausables.rs
@@ -234,15 +234,13 @@ mod tests {
     }
 
     #[test]
+    #[should_panic]
     fn test_no_precompile_is_paused_if_storage_contains_too_few_bytes() {
         let key = EnginePrecompilesPauser::<StoragePointer>::storage_key();
         let storage = RwLock::new(Storage::default());
         let mut io = StoragePointer(&storage);
         io.write_storage(key.as_slice(), &[7u8]);
         let pauser = EnginePrecompilesPauser::from_io(io);
-
-        let expected_paused = PrecompileFlags::empty();
-        let actual_paused = pauser.paused();
-        assert_eq!(expected_paused, actual_paused);
+        let _paused = pauser.paused(); // panic here !!!
     }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Here are some helpful tips:

* Always create branches on and target the `develop` branch.
* Run all the tests locally and ensure that they are passing.
* Run `make format` to ensure that the code is formatted.
* Run `make check` to ensure that all checks passed successfully.
* Small commits and contributions that attempt one single goal is preferable.
* If the idea changes or adds anything functional which will affect users, an 
AIP discussion is required first on the Aurora forum: 
https://forum.aurora.dev/discussions/AIPs%20(Aurora%20Improvement%20Proposals).
* Avoid breaking the public API (namely in engine/src/lib.rs) unless required.
* If your PR is a WIP, ensure that you enable "draft" mode.
* Your first PRs won't use the CI automatically unless a maintainer starts.
If this is not your first PR, please do NOT abuse the CI resources.

Checklist:
- [ ] I have performed a self-review of my code
- [ ] I have documented my code, particularly in the hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to prove my fix or new feature is effective and works
- [ ] Any dependent changes have been merged
- [ ] The PR is targeting the `develop` branch and not `master`
- [ ] I have pre-squashed my commits into a single commit and rebased.
-->

## Description

The PR adds tiny optimisation by removing unnecessary dynamic memory allocation while creating precompile flags from storage value. 
