### PR TITLE
chore: replace RwLock for RefCell in storage for tests

### DIFF
--- a/engine-test-doubles/src/io.rs
+++ b/engine-test-doubles/src/io.rs
@@ -1,6 +1,6 @@
 use aurora_engine_sdk::io::{StorageIntermediate, IO};
+use std::cell::RefCell;
 use std::collections::HashMap;
-use std::sync::RwLock;
 
 pub struct Value(Vec<u8>);
 
@@ -27,37 +27,32 @@ pub struct Storage {
 
 /// In-memory implementation of [IO].
 #[derive(Debug, Clone, Copy)]
-pub struct StoragePointer<'a>(pub &'a RwLock<Storage>);
+pub struct StoragePointer<'a>(pub &'a RefCell<Storage>);
 
 impl<'a> IO for StoragePointer<'a> {
     type StorageValue = Value;
 
     fn read_input(&self) -> Self::StorageValue {
-        Value(self.0.read().unwrap().input.clone())
+        Value(self.0.borrow().input.clone())
     }
 
     fn return_output(&mut self, value: &[u8]) {
-        let mut storage = self.0.write().unwrap();
+        let mut storage = self.0.borrow_mut();
         storage.output = value.to_vec();
     }
 
     fn read_storage(&self, key: &[u8]) -> Option<Self::StorageValue> {
-        self.0
-            .read()
-            .unwrap()
-            .kv_store
-            .get(key)
-            .map(|v| Value(v.clone()))
+        self.0.borrow().kv_store.get(key).map(|v| Value(v.clone()))
     }
 
     fn storage_has_key(&self, key: &[u8]) -> bool {
-        self.0.read().unwrap().kv_store.contains_key(key)
+        self.0.borrow().kv_store.contains_key(key)
     }
 
     fn write_storage(&mut self, key: &[u8], value: &[u8]) -> Option<Self::StorageValue> {
         let key = key.to_vec();
         let value = value.to_vec();
-        let mut storage = self.0.write().unwrap();
+        let mut storage = self.0.borrow_mut();
         storage.kv_store.insert(key, value).map(Value)
     }
 
@@ -67,12 +62,12 @@ impl<'a> IO for StoragePointer<'a> {
         value: Self::StorageValue,
     ) -> Option<Self::StorageValue> {
         let key = key.to_vec();
-        let mut storage = self.0.write().unwrap();
+        let mut storage = self.0.borrow_mut();
         storage.kv_store.insert(key, value.0).map(Value)
     }
 
     fn remove_storage(&mut self, key: &[u8]) -> Option<Self::StorageValue> {
-        let mut storage = self.0.write().unwrap();
+        let mut storage = self.0.borrow_mut();
         storage.kv_store.remove(key).map(Value)
     }
 }

--- a/engine-tests/src/tests/standalone/sanity.rs
+++ b/engine-tests/src/tests/standalone/sanity.rs
@@ -4,7 +4,7 @@ use aurora_engine_test_doubles::io::{Storage, StoragePointer};
 use aurora_engine_test_doubles::promise::PromiseTracker;
 use aurora_engine_types::types::{Address, Wei};
 use aurora_engine_types::{account_id::AccountId, H160, H256, U256};
-use std::sync::RwLock;
+use std::cell::RefCell;
 
 #[test]
 fn test_deploy_code() {
@@ -22,7 +22,7 @@ fn test_deploy_code() {
         upgrade_delay_blocks: 0,
     };
     let origin = Address::new(H160([0u8; 20]));
-    let storage = RwLock::new(Storage::default());
+    let storage = RefCell::new(Storage::default());
     let io = StoragePointer(&storage);
     let env = aurora_engine_sdk::env::Fixed {
         signer_account_id: owner_id.clone(),

--- a/engine/src/connector.rs
+++ b/engine/src/connector.rs
@@ -713,7 +713,7 @@ pub fn set_contract_data<I: IO>(
     Ok(contract_data)
 }
 
-/// Return metdata
+/// Return metadata
 pub fn get_metadata<I: IO>(io: &I) -> Option<FungibleTokenMetadata> {
     io.read_storage(&construct_contract_key(
         &EthConnectorStorageId::FungibleTokenMetadata,

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -1745,15 +1745,14 @@ mod tests {
     use aurora_engine_test_doubles::io::{Storage, StoragePointer};
     use aurora_engine_test_doubles::promise::PromiseTracker;
     use aurora_engine_types::types::RawU256;
-    use std::sync::RwLock;
+    use std::cell::RefCell;
 
     #[test]
     fn test_view_call_to_empty_contract_without_input_returns_empty_data() {
         let origin = Address::zero();
         let current_account_id = AccountId::default();
         let env = Fixed::default();
-        let storage = Storage::default();
-        let storage = RwLock::new(storage);
+        let storage = RefCell::new(Storage::default());
         let mut io = StoragePointer(&storage);
         add_balance(&mut io, &origin, Wei::new_u64(22000)).unwrap();
         let engine =
@@ -1779,8 +1778,7 @@ mod tests {
         let origin = Address::zero();
         let current_account_id = AccountId::default();
         let env = Fixed::default();
-        let storage = Storage::default();
-        let storage = RwLock::new(storage);
+        let storage = RefCell::new(Storage::default());
         let io = StoragePointer(&storage);
         let mut engine =
             Engine::new_with_state(EngineState::default(), origin, current_account_id, io, &env);
@@ -1805,8 +1803,7 @@ mod tests {
         let origin = Address::zero();
         let current_account_id = AccountId::default();
         let env = Fixed::default();
-        let storage = Storage::default();
-        let storage = RwLock::new(storage);
+        let storage = RefCell::new(Storage::default());
         let mut io = StoragePointer(&storage);
         add_balance(&mut io, &origin, Wei::new_u64(22000)).unwrap();
         let mut engine =
@@ -1837,8 +1834,7 @@ mod tests {
         let origin = Address::zero();
         let current_account_id = AccountId::default();
         let env = Fixed::default();
-        let storage = Storage::default();
-        let storage = RwLock::new(storage);
+        let storage = RefCell::new(Storage::default());
         let io = StoragePointer(&storage);
         let mut engine =
             Engine::new_with_state(EngineState::default(), origin, current_account_id, io, &env);
@@ -1867,8 +1863,7 @@ mod tests {
         let origin = Address::zero();
         let current_account_id = AccountId::default();
         let env = Fixed::default();
-        let storage = Storage::default();
-        let storage = RwLock::new(storage);
+        let storage = RefCell::new(Storage::default());
         let mut io = StoragePointer(&storage);
         add_balance(&mut io, &origin, Wei::new_u64(22000)).unwrap();
         let mut engine =
@@ -1896,8 +1891,7 @@ mod tests {
         let origin = Address::zero();
         let current_account_id = AccountId::default();
         let env = Fixed::default();
-        let storage = Storage::default();
-        let storage = RwLock::new(storage);
+        let storage = RefCell::new(Storage::default());
         let mut io = StoragePointer(&storage);
         add_balance(&mut io, &origin, Wei::new_u64(22000)).unwrap();
         let mut engine =
@@ -1923,8 +1917,7 @@ mod tests {
         let origin = Address::zero();
         let current_account_id = AccountId::default();
         let env = Fixed::default();
-        let storage = Storage::default();
-        let storage = RwLock::new(storage);
+        let storage = RefCell::new(Storage::default());
         let mut io = StoragePointer(&storage);
         add_balance(&mut io, &origin, Wei::new_u64(22000)).unwrap();
         let mut engine =
@@ -1943,8 +1936,7 @@ mod tests {
         let origin = Address::zero();
         let current_account_id = AccountId::default();
         let env = Fixed::default();
-        let storage = Storage::default();
-        let storage = RwLock::new(storage);
+        let storage = RefCell::new(Storage::default());
         let mut io = StoragePointer(&storage);
         set_balance(&mut io, &origin, &Wei::new_u64(22000));
         let mut engine = Engine::new_with_state(
@@ -1969,9 +1961,9 @@ mod tests {
             .unwrap();
         engine.receive_erc20_tokens(&nep141_token, &args, &current_account_id, &mut handler);
 
-        let storage_read = storage.read().unwrap();
-        let actual_output = std::str::from_utf8(storage_read.output.as_slice()).unwrap();
-        let expected_output = "\"0\"";
+        let storage = storage.borrow();
+        let actual_output = storage.output.as_slice();
+        let expected_output = b"\"0\"";
 
         assert_eq!(expected_output, actual_output);
     }
@@ -1982,8 +1974,7 @@ mod tests {
         let origin = aurora_engine_sdk::types::near_account_to_evm_address(
             env.predecessor_account_id().as_bytes(),
         );
-        let storage = Storage::default();
-        let storage = RwLock::new(storage);
+        let storage = RefCell::new(Storage::default());
         let mut io = StoragePointer(&storage);
         add_balance(&mut io, &origin, Wei::new_u64(22000)).unwrap();
         state::set_state(&mut io, EngineState::default()).unwrap();
@@ -2005,8 +1996,7 @@ mod tests {
         let origin = Address::zero();
         let current_account_id = AccountId::default();
         let env = Fixed::default();
-        let storage = Storage::default();
-        let storage = RwLock::new(storage);
+        let storage = RefCell::new(Storage::default());
         let mut io = StoragePointer(&storage);
         add_balance(&mut io, &origin, Wei::new_u64(22000)).unwrap();
         let mut engine =
@@ -2097,8 +2087,7 @@ mod tests {
         let origin = Address::zero();
         let current_account_id = AccountId::default();
         let env = Fixed::default();
-        let storage = Storage::default();
-        let storage = RwLock::new(storage);
+        let storage = RefCell::new(Storage::default());
         let mut io = StoragePointer(&storage);
         let engine =
             Engine::new_with_state(EngineState::default(), origin, current_account_id, io, &env);
@@ -2117,8 +2106,7 @@ mod tests {
         let origin = Address::zero();
         let current_account_id = AccountId::default();
         let env = Fixed::default();
-        let storage = Storage::default();
-        let storage = RwLock::new(storage);
+        let storage = RefCell::new(Storage::default());
         let mut io = StoragePointer(&storage);
         let expected_state = EngineState::default();
         state::set_state(&mut io, expected_state.clone()).unwrap();
@@ -2132,8 +2120,7 @@ mod tests {
     fn test_refund_transfer_eth_back_from_precompile_address() {
         let recipient_address = make_address(1, 1);
         let env = Fixed::default();
-        let storage = Storage::default();
-        let storage = RwLock::new(storage);
+        let storage = RefCell::new(Storage::default());
         let mut io = StoragePointer(&storage);
         let expected_state = EngineState::default();
         let refund_amount = Wei::new_u64(1000);
@@ -2156,8 +2143,7 @@ mod tests {
     fn test_refund_remint_burned_erc20_tokens() {
         let origin = Address::zero();
         let env = Fixed::default();
-        let storage = Storage::default();
-        let storage = RwLock::new(storage);
+        let storage = RefCell::new(Storage::default());
         let mut io = StoragePointer(&storage);
         let expected_state = EngineState::default();
         state::set_state(&mut io, expected_state.clone()).unwrap();
@@ -2178,8 +2164,7 @@ mod tests {
     #[test]
     fn test_refund_free_effective_gas_does_nothing() {
         let origin = Address::zero();
-        let storage = Storage::default();
-        let storage = RwLock::new(storage);
+        let storage = RefCell::new(Storage::default());
         let mut io = StoragePointer(&storage);
         let expected_state = EngineState::default();
         state::set_state(&mut io, expected_state).unwrap();
@@ -2196,8 +2181,7 @@ mod tests {
     #[test]
     fn test_refund_gas_pays_expected_amount() {
         let origin = Address::zero();
-        let storage = Storage::default();
-        let storage = RwLock::new(storage);
+        let storage = RefCell::new(Storage::default());
         let mut io = StoragePointer(&storage);
         let expected_state = EngineState::default();
         state::set_state(&mut io, expected_state).unwrap();
@@ -2220,8 +2204,7 @@ mod tests {
     #[test]
     fn test_check_nonce_with_increment_succeeds() {
         let origin = Address::zero();
-        let storage = Storage::default();
-        let storage = RwLock::new(storage);
+        let storage = RefCell::new(Storage::default());
         let mut io = StoragePointer(&storage);
 
         increment_nonce(&mut io, &origin);
@@ -2231,16 +2214,13 @@ mod tests {
     #[test]
     fn test_check_nonce_without_increment_fails() {
         let origin = Address::zero();
-        let storage = Storage::default();
-        let storage = RwLock::new(storage);
+        let storage = RefCell::new(Storage::default());
         let mut io = StoragePointer(&storage);
 
         increment_nonce(&mut io, &origin);
         let actual_error_kind = check_nonce(&io, &origin, &U256::from(0u64)).unwrap_err();
-        let actual_error_kind = std::str::from_utf8(actual_error_kind.as_bytes()).unwrap();
-        let expected_error_kind = std::str::from_utf8(errors::ERR_INCORRECT_NONCE).unwrap();
 
-        assert_eq!(expected_error_kind, actual_error_kind);
+        assert_eq!(actual_error_kind.as_bytes(), errors::ERR_INCORRECT_NONCE);
     }
 
     #[test]
@@ -2258,8 +2238,7 @@ mod tests {
 
     #[test]
     fn test_filtering_promises_from_logs_with_none_keeps_all() {
-        let storage = Storage::default();
-        let storage = RwLock::new(storage);
+        let storage = RefCell::new(Storage::default());
         let io = StoragePointer(&storage);
         let current_account_id = AccountId::default();
         let mut handler = Noop;

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -577,7 +577,6 @@ mod contract {
     }
 
     #[no_mangle]
-
     pub extern "C" fn withdraw() {
         let io = Runtime;
         io.assert_one_yocto().sdk_unwrap();

--- a/engine/src/map.rs
+++ b/engine/src/map.rs
@@ -66,9 +66,9 @@ mod tests {
         use aurora_engine_test_doubles::io::{Storage, StoragePointer};
         use aurora_engine_types::account_id::AccountId;
         use aurora_engine_types::types::Address;
-        use std::sync::RwLock;
+        use std::cell::RefCell;
 
-        let storage = RwLock::new(Storage::default());
+        let storage = RefCell::new(Storage::default());
         let storage = StoragePointer(&storage);
         let left_prefix = KeyPrefix::Nep141Erc20Map;
         let right_prefix = KeyPrefix::Erc20Nep141Map;

--- a/engine/src/pausables.rs
+++ b/engine/src/pausables.rs
@@ -171,8 +171,8 @@ impl<I: IO> PausedPrecompilesManager for EnginePrecompilesPauser<I> {
 mod tests {
     use super::*;
     use aurora_engine_test_doubles::io::{Storage, StoragePointer};
+    use std::cell::RefCell;
     use std::iter::once;
-    use std::sync::RwLock;
     use test_case::test_case;
 
     #[test_case(PrecompileFlags::EXIT_TO_ETHEREUM, exit_to_ethereum::ADDRESS)]
@@ -194,7 +194,7 @@ mod tests {
 
     #[test]
     fn test_pausing_precompile_marks_it_as_paused() {
-        let storage = RwLock::new(Storage::default());
+        let storage = RefCell::new(Storage::default());
         let io = StoragePointer(&storage);
         let mut pauser = EnginePrecompilesPauser::from_io(io);
         let flags = PrecompileFlags::EXIT_TO_NEAR;
@@ -206,7 +206,7 @@ mod tests {
 
     #[test]
     fn test_resuming_precompile_removes_its_mark_as_paused() {
-        let storage = RwLock::new(Storage::default());
+        let storage = RefCell::new(Storage::default());
         let io = StoragePointer(&storage);
         let mut pauser = EnginePrecompilesPauser::from_io(io);
         let flags = PrecompileFlags::EXIT_TO_NEAR;
@@ -237,7 +237,7 @@ mod tests {
     #[should_panic]
     fn test_no_precompile_is_paused_if_storage_contains_too_few_bytes() {
         let key = EnginePrecompilesPauser::<StoragePointer>::storage_key();
-        let storage = RwLock::new(Storage::default());
+        let storage = RefCell::new(Storage::default());
         let mut io = StoragePointer(&storage);
         io.write_storage(key.as_slice(), &[7u8]);
         let pauser = EnginePrecompilesPauser::from_io(io);

--- a/engine/src/state.rs
+++ b/engine/src/state.rs
@@ -90,12 +90,11 @@ pub mod error {
 mod tests {
     use super::*;
     use aurora_engine_test_doubles::io::{Storage, StoragePointer};
-    use std::sync::RwLock;
+    use std::cell::RefCell;
 
     #[test]
     fn test_missing_engine_state_is_not_found() {
-        let storage = Storage::default();
-        let storage = RwLock::new(storage);
+        let storage = RefCell::new(Storage::default());
         let io = StoragePointer(&storage);
 
         let actual_error = get_state(&io).unwrap_err();
@@ -107,8 +106,7 @@ mod tests {
 
     #[test]
     fn test_empty_engine_state_is_corrupted() {
-        let storage = Storage::default();
-        let storage = RwLock::new(storage);
+        let storage = RefCell::new(Storage::default());
         let mut io = StoragePointer(&storage);
 
         io.write_storage(&bytes_to_key(KeyPrefix::Config, STATE_KEY), &[]);


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Here are some helpful tips:

* Always create branches on and target the `develop` branch.
* Run all the tests locally and ensure that they are passing.
* Run `make format` to ensure that the code is formatted.
* Run `make check` to ensure that all checks passed successfully.
* Small commits and contributions that attempt one single goal is preferable.
* If the idea changes or adds anything functional which will affect users, an 
AIP discussion is required first on the Aurora forum: 
https://forum.aurora.dev/discussions/AIPs%20(Aurora%20Improvement%20Proposals).
* Avoid breaking the public API (namely in engine/src/lib.rs) unless required.
* If your PR is a WIP, ensure that you enable "draft" mode.
* Your first PRs won't use the CI automatically unless a maintainer starts.
If this is not your first PR, please do NOT abuse the CI resources.

Checklist:
- [ ] I have performed a self-review of my code
- [ ] I have documented my code, particularly in the hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to prove my fix or new feature is effective and works
- [ ] Any dependent changes have been merged
- [ ] The PR is targeting the `develop` branch and not `master`
- [ ] I have pre-squashed my commits into a single commit and rebased.
-->

## Description

The PR just replaces `RwLock` with `RefCell` in a `StoragePointer` struct. It seems that `RefCell` is pretty enough in this case. 

## Performance / NEAR gas cost considerations

The changes touch test code only, so there is no regression.

## Testing

All tests have been passed.

