### PR TITLE
chore(state): refactor state into module

### DIFF
--- a/engine-standalone-storage/src/relayer_db/mod.rs
+++ b/engine-standalone-storage/src/relayer_db/mod.rs
@@ -1,4 +1,4 @@
-use aurora_engine::engine;
+use aurora_engine::{engine, state};
 use aurora_engine_sdk::env::{self, Env, DEFAULT_PREPAID_GAS};
 use aurora_engine_transactions::EthTransactionKind;
 use aurora_engine_types::account_id::AccountId;
@@ -63,7 +63,7 @@ where
 pub fn initialize_transactions<I>(
     storage: &mut Storage,
     mut rows: I,
-    engine_state: engine::EngineState,
+    engine_state: state::EngineState,
 ) -> Result<(), error::Error>
 where
     I: FallibleIterator<Item = types::TransactionRow, Error = postgres::Error>,
@@ -159,13 +159,13 @@ where
 }
 
 pub mod error {
-    use aurora_engine::engine;
+    use aurora_engine::{engine, state};
 
     #[derive(Debug)]
     pub enum Error {
         Storage(crate::Error),
         Postgres(postgres::Error),
-        EngineState(engine::EngineStateError),
+        EngineState(state::EngineStateError),
         Engine(engine::EngineError),
     }
 
@@ -181,8 +181,8 @@ pub mod error {
         }
     }
 
-    impl From<engine::EngineStateError> for Error {
-        fn from(e: engine::EngineStateError) -> Self {
+    impl From<state::EngineStateError> for Error {
+        fn from(e: state::EngineStateError) -> Self {
             Self::EngineState(e)
         }
     }
@@ -198,7 +198,7 @@ pub mod error {
 mod test {
     use super::FallibleIterator;
     use crate::sync::types::{TransactionKind, TransactionMessage};
-    use aurora_engine::{connector, engine, parameters};
+    use aurora_engine::{connector, parameters, state};
     use aurora_engine_types::H256;
 
     /// Requires a running postgres server to work. A snapshot of the DB can be
@@ -210,7 +210,7 @@ mod test {
     fn test_fill_db() {
         let mut storage = crate::Storage::open("rocks_tmp/").unwrap();
         let mut connection = super::connect_without_tls(&Default::default()).unwrap();
-        let engine_state = engine::EngineState {
+        let engine_state = state::EngineState {
             chain_id: aurora_engine_types::types::u256_to_arr(&1313161555.into()),
             owner_id: "aurora".parse().unwrap(),
             bridge_prover_id: "prover.bridge.near".parse().unwrap(),
@@ -231,7 +231,7 @@ mod test {
                 .unwrap();
             let result = storage.with_engine_access(block_height, 0, &[], |io| {
                 let mut local_io = io;
-                engine::set_state(&mut local_io, engine_state.clone());
+                state::set_state(&mut local_io, engine_state.clone()).unwrap();
                 connector::EthConnectorContract::create_contract(
                     io,
                     engine_state.owner_id.clone(),

--- a/engine-standalone-storage/src/sync/mod.rs
+++ b/engine-standalone-storage/src/sync/mod.rs
@@ -1,7 +1,7 @@
 use aurora_engine::pausables::{
     EnginePrecompilesPauser, PausedPrecompilesManager, PrecompileFlags,
 };
-use aurora_engine::{connector, engine, parameters::SubmitResult, xcc};
+use aurora_engine::{connector, engine, parameters::SubmitResult, state, xcc};
 use aurora_engine_sdk::env::{self, Env, DEFAULT_PREPAID_GAS};
 use aurora_engine_types::{
     account_id::AccountId,
@@ -137,7 +137,7 @@ fn execute_transaction<'db>(
             let transaction_bytes: Vec<u8> = tx.into();
             let tx_hash = aurora_engine_sdk::keccak(&transaction_bytes);
 
-            let result = engine::get_state(&io)
+            let result = state::get_state(&io)
                 .map(|engine_state| {
                     let submit_result = engine::submit(
                         io,
@@ -335,12 +335,12 @@ fn non_submit_execute<'db>(
         }
 
         TransactionKind::RefundOnError(maybe_args) => {
-            let result: Result<Option<TransactionExecutionResult>, engine::EngineStateError> =
+            let result: Result<Option<TransactionExecutionResult>, state::EngineStateError> =
                 maybe_args
                     .clone()
                     .map(|args| {
                         let mut handler = crate::promise::NoScheduler { promise_data };
-                        let engine_state = engine::get_state(&io)?;
+                        let engine_state = state::get_state(&io)?;
                         let result =
                             engine::refund_on_error(io, &env, engine_state, args, &mut handler);
                         Ok(TransactionExecutionResult::Submit(result))
@@ -367,7 +367,7 @@ fn non_submit_execute<'db>(
             None
         }
         TransactionKind::NewEngine(args) => {
-            engine::set_state(&mut io, args.clone().into());
+            state::set_state(&mut io, args.clone().into())?;
 
             None
         }
@@ -434,11 +434,11 @@ pub enum TransactionExecutionResult {
 }
 
 pub mod error {
-    use aurora_engine::{connector, engine, fungible_token};
+    use aurora_engine::{connector, engine, fungible_token, state};
 
     #[derive(Debug)]
     pub enum Error {
-        EngineState(engine::EngineStateError),
+        EngineState(state::EngineStateError),
         Engine(engine::EngineError),
         DeployErc20(engine::DeployErc20Error),
         FtOnTransfer(connector::error::FtTransferCallError),
@@ -452,8 +452,8 @@ pub mod error {
         ConnectorStorage(connector::error::StorageReadError),
     }
 
-    impl From<engine::EngineStateError> for Error {
-        fn from(e: engine::EngineStateError) -> Self {
+    impl From<state::EngineStateError> for Error {
+        fn from(e: state::EngineStateError) -> Self {
             Self::EngineState(e)
         }
     }

--- a/engine-tests/src/test_utils/standalone/mocks/mod.rs
+++ b/engine-tests/src/test_utils/standalone/mocks/mod.rs
@@ -1,9 +1,9 @@
 use crate::test_utils;
-use aurora_engine::engine;
 use aurora_engine::fungible_token::FungibleTokenMetadata;
 use aurora_engine::parameters::{
     FinishDepositCallArgs, InitCallArgs, NEP141FtOnTransferArgs, NewCallArgs,
 };
+use aurora_engine::{engine, state};
 use aurora_engine_sdk::env::{Env, DEFAULT_PREPAID_GAS};
 use aurora_engine_sdk::io::IO;
 use aurora_engine_types::types::{Address, Balance, NEP141Wei, NearGas, Wei};
@@ -56,7 +56,7 @@ pub fn init_evm<I: IO + Copy, E: Env>(mut io: I, env: &E, chain_id: u64) {
         upgrade_delay_blocks: 1,
     };
 
-    engine::set_state(&mut io, new_args.into());
+    state::set_state(&mut io, new_args.into()).unwrap();
 
     let connector_args = InitCallArgs {
         prover_account: test_utils::str_to_account_id("prover.near"),

--- a/engine-tests/src/tests/sanity.rs
+++ b/engine-tests/src/tests/sanity.rs
@@ -139,7 +139,7 @@ fn test_state_format() {
         bridge_prover_id: "prover_mcprovy_face".parse().unwrap(),
         upgrade_delay_blocks: 3,
     };
-    let state: aurora_engine::engine::EngineState = args.into();
+    let state: aurora_engine::state::EngineState = args.into();
     let expected_hex: String = [
         "000000000000000000000000000000000000000000000000000000000000029a",
         "04000000626f7373",

--- a/engine-tests/src/tests/standalone/sanity.rs
+++ b/engine-tests/src/tests/standalone/sanity.rs
@@ -1,4 +1,4 @@
-use aurora_engine::engine;
+use aurora_engine::{engine, state};
 use aurora_engine_sdk::env::DEFAULT_PREPAID_GAS;
 use aurora_engine_test_doubles::io::{Storage, StoragePointer};
 use aurora_engine_test_doubles::promise::PromiseTracker;
@@ -15,7 +15,7 @@ fn test_deploy_code() {
         buf
     };
     let owner_id: AccountId = "aurora".parse().unwrap();
-    let state = engine::EngineState {
+    let state = state::EngineState {
         chain_id,
         owner_id: owner_id.clone(),
         bridge_prover_id: "mr_the_prover".parse().unwrap(),

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -5,15 +5,15 @@ use evm::executor;
 use evm::{Config, CreateScheme, ExitError, ExitFatal, ExitReason};
 
 use crate::connector::EthConnectorContract;
-use crate::errors;
 use crate::map::BijectionMap;
+use crate::{errors, state};
 use aurora_engine_sdk::caching::FullCache;
 use aurora_engine_sdk::env::Env;
 use aurora_engine_sdk::io::{StorageIntermediate, IO};
 use aurora_engine_sdk::promise::{PromiseHandler, PromiseId, ReadOnlyPromiseHandler};
 
 use crate::accounting;
-use crate::parameters::{DeployErc20TokenArgs, NewCallArgs, TransactionStatus};
+use crate::parameters::{DeployErc20TokenArgs, TransactionStatus};
 use crate::pausables::{
     EngineAuthorizer, EnginePrecompilesPauser, PausedPrecompilesChecker, PrecompileFlags,
 };
@@ -24,9 +24,10 @@ use crate::prelude::precompiles::Precompiles;
 use crate::prelude::transactions::{EthTransactionKind, NormalizedEthTransaction};
 use crate::prelude::{
     address_to_key, bytes_to_key, sdk, storage_to_key, u256_to_arr, vec, AccountId, Address,
-    BTreeMap, BorshDeserialize, BorshSerialize, KeyPrefix, PromiseArgs, PromiseCreateArgs,
-    ToString, Vec, Wei, Yocto, ERC20_MINT_SELECTOR, H160, H256, U256,
+    BTreeMap, BorshDeserialize, KeyPrefix, PromiseArgs, PromiseCreateArgs, ToString, Vec, Wei,
+    Yocto, ERC20_MINT_SELECTOR, H160, H256, U256,
 };
+use crate::state::EngineState;
 use aurora_engine_precompiles::PrecompileConstructorContext;
 use core::cell::RefCell;
 use core::iter::once;
@@ -230,7 +231,7 @@ impl From<BalanceOverflow> for GasPaymentError {
 
 #[derive(Debug)]
 pub enum DeployErc20Error {
-    State(EngineStateError),
+    State(state::EngineStateError),
     Failed(TransactionStatus),
     Engine(EngineError),
     Register(RegisterTokenError),
@@ -337,21 +338,6 @@ impl AsRef<[u8]> for RegisterTokenError {
     }
 }
 
-#[derive(Debug)]
-pub enum EngineStateError {
-    NotFound,
-    DeserializationFailed,
-}
-
-impl AsRef<[u8]> for EngineStateError {
-    fn as_ref(&self) -> &[u8] {
-        match self {
-            Self::NotFound => errors::ERR_STATE_NOT_FOUND,
-            Self::DeserializationFailed => errors::ERR_STATE_CORRUPTED,
-        }
-    }
-}
-
 pub struct StackExecutorParams<'a, I, E, H> {
     precompiles: Precompiles<'a, I, E, H>,
     gas_limit: u64,
@@ -387,33 +373,6 @@ pub struct GasPaymentResult {
     pub priority_fee_per_gas: U256,
 }
 
-/// Engine internal state, mostly configuration.
-/// Should not contain anything large or enumerable.
-#[derive(BorshSerialize, BorshDeserialize, Default, Clone, PartialEq, Eq, Debug)]
-pub struct EngineState {
-    /// Chain id, according to the EIP-155 / ethereum-lists spec.
-    pub chain_id: [u8; 32],
-    /// Account which can upgrade this contract.
-    /// Use empty to disable updatability.
-    pub owner_id: AccountId,
-    /// Account of the bridge prover.
-    /// Use empty to not use base token as bridged asset.
-    pub bridge_prover_id: AccountId,
-    /// How many blocks after staging upgrade can deploy it.
-    pub upgrade_delay_blocks: u64,
-}
-
-impl From<NewCallArgs> for EngineState {
-    fn from(args: NewCallArgs) -> Self {
-        EngineState {
-            chain_id: args.chain_id,
-            owner_id: args.owner_id,
-            bridge_prover_id: args.bridge_prover_id,
-            upgrade_delay_blocks: args.upgrade_delay_blocks,
-        }
-    }
-}
-
 pub struct Engine<'env, I: IO, E: Env> {
     state: EngineState,
     origin: Address,
@@ -429,17 +388,15 @@ pub struct Engine<'env, I: IO, E: Env> {
 
 pub(crate) const CONFIG: &Config = &Config::london();
 
-/// Key for storing the state of the engine.
-const STATE_KEY: &[u8; 5] = b"STATE";
-
 impl<'env, I: IO + Copy, E: Env> Engine<'env, I, E> {
     pub fn new(
         origin: Address,
         current_account_id: AccountId,
         io: I,
         env: &'env E,
-    ) -> Result<Self, EngineStateError> {
-        get_state(&io).map(|state| Self::new_with_state(state, origin, current_account_id, io, env))
+    ) -> Result<Self, state::EngineStateError> {
+        state::get_state(&io)
+            .map(|state| Self::new_with_state(state, origin, current_account_id, io, env))
     }
 
     pub fn new_with_state(
@@ -1090,22 +1047,6 @@ pub fn compute_block_hash(chain_id: [u8; 32], block_height: u64, account_id: &[u
     data.extend_from_slice(&block_height.to_be_bytes());
 
     sdk::sha256(&data)
-}
-
-pub fn get_state<I: IO>(io: &I) -> Result<EngineState, EngineStateError> {
-    match io.read_storage(&bytes_to_key(KeyPrefix::Config, STATE_KEY)) {
-        None => Err(EngineStateError::NotFound),
-        Some(bytes) => EngineState::try_from_slice(&bytes.to_vec())
-            .map_err(|_| EngineStateError::DeserializationFailed),
-    }
-}
-
-/// Saves state into the storage.
-pub fn set_state<I: IO>(io: &mut I, state: EngineState) {
-    io.write_storage(
-        &bytes_to_key(KeyPrefix::Config, STATE_KEY),
-        &state.try_to_vec().expect("ERR_SER"),
-    );
 }
 
 pub fn get_authorizer() -> EngineAuthorizer {
@@ -2032,7 +1973,7 @@ mod tests {
         let storage = RwLock::new(storage);
         let mut io = StoragePointer(&storage);
         add_balance(&mut io, &origin, Wei::new_u64(22000)).unwrap();
-        set_state(&mut io, EngineState::default());
+        state::set_state(&mut io, EngineState::default()).unwrap();
 
         let nep141_token = AccountId::new("testcoin").unwrap();
         let mut handler = Noop;
@@ -2167,7 +2108,7 @@ mod tests {
         let storage = RwLock::new(storage);
         let mut io = StoragePointer(&storage);
         let expected_state = EngineState::default();
-        set_state(&mut io, expected_state.clone());
+        state::set_state(&mut io, expected_state.clone()).unwrap();
         let engine = Engine::new(origin, current_account_id, io, &env).unwrap();
         let actual_state = engine.state;
 
@@ -2184,7 +2125,7 @@ mod tests {
         let expected_state = EngineState::default();
         let refund_amount = Wei::new_u64(1000);
         add_balance(&mut io, &exit_to_near::ADDRESS, refund_amount).unwrap();
-        set_state(&mut io, expected_state.clone());
+        state::set_state(&mut io, expected_state.clone()).unwrap();
         let args = RefundCallArgs {
             recipient_address,
             erc20_address: None,
@@ -2206,7 +2147,7 @@ mod tests {
         let storage = RwLock::new(storage);
         let mut io = StoragePointer(&storage);
         let expected_state = EngineState::default();
-        set_state(&mut io, expected_state.clone());
+        state::set_state(&mut io, expected_state.clone()).unwrap();
         let value = Wei::new_u64(1000);
         let args = RefundCallArgs {
             recipient_address: Default::default(),
@@ -2228,7 +2169,7 @@ mod tests {
         let storage = RwLock::new(storage);
         let mut io = StoragePointer(&storage);
         let expected_state = EngineState::default();
-        set_state(&mut io, expected_state);
+        state::set_state(&mut io, expected_state).unwrap();
         let relayer = make_address(1, 1);
         let gas_result = GasPaymentResult {
             prepaid_amount: Default::default(),
@@ -2246,7 +2187,7 @@ mod tests {
         let storage = RwLock::new(storage);
         let mut io = StoragePointer(&storage);
         let expected_state = EngineState::default();
-        set_state(&mut io, expected_state);
+        state::set_state(&mut io, expected_state).unwrap();
         let relayer = make_address(1, 1);
         let gas_result = GasPaymentResult {
             prepaid_amount: Wei::new_u64(8000),
@@ -2300,33 +2241,6 @@ mod tests {
             created_address.encode(),
             "140e8a21d08cbb530929b012581a7c7e696145ef"
         );
-    }
-
-    #[test]
-    fn test_missing_engine_state_is_not_found() {
-        let storage = Storage::default();
-        let storage = RwLock::new(storage);
-        let io = StoragePointer(&storage);
-
-        let actual_error = get_state(&io).unwrap_err();
-        let actual_error = std::str::from_utf8(actual_error.as_ref()).unwrap();
-        let expected_error = std::str::from_utf8(errors::ERR_STATE_NOT_FOUND).unwrap();
-
-        assert_eq!(expected_error, actual_error);
-    }
-
-    #[test]
-    fn test_empty_engine_state_is_corrupted() {
-        let storage = Storage::default();
-        let storage = RwLock::new(storage);
-        let mut io = StoragePointer(&storage);
-
-        io.write_storage(&bytes_to_key(KeyPrefix::Config, STATE_KEY), &[]);
-        let actual_error = get_state(&io).unwrap_err();
-        let actual_error = std::str::from_utf8(actual_error.as_ref()).unwrap();
-        let expected_error = std::str::from_utf8(errors::ERR_STATE_CORRUPTED).unwrap();
-
-        assert_eq!(expected_error, actual_error);
     }
 
     #[test]

--- a/engine/src/state.rs
+++ b/engine/src/state.rs
@@ -1,0 +1,121 @@
+use crate::parameters::NewCallArgs;
+use aurora_engine_sdk::io::{StorageIntermediate, IO};
+use aurora_engine_types::account_id::AccountId;
+use aurora_engine_types::storage::{bytes_to_key, KeyPrefix};
+use borsh::{BorshDeserialize, BorshSerialize};
+
+pub use error::EngineStateError;
+
+/// Key for storing the state of the engine.
+const STATE_KEY: &[u8; 5] = b"STATE";
+
+/// Engine internal state, mostly configuration.
+/// Should not contain anything large or enumerable.
+#[derive(BorshSerialize, BorshDeserialize, Default, Clone, PartialEq, Eq, Debug)]
+pub struct EngineState {
+    /// Chain id, according to the EIP-155 / ethereum-lists spec.
+    pub chain_id: [u8; 32],
+    /// Account which can upgrade this contract.
+    /// Use empty to disable updatability.
+    pub owner_id: AccountId,
+    /// Account of the bridge prover.
+    /// Use empty to not use base token as bridged asset.
+    pub bridge_prover_id: AccountId,
+    /// How many blocks after staging upgrade can deploy it.
+    pub upgrade_delay_blocks: u64,
+}
+
+impl From<NewCallArgs> for EngineState {
+    fn from(args: NewCallArgs) -> Self {
+        EngineState {
+            chain_id: args.chain_id,
+            owner_id: args.owner_id,
+            bridge_prover_id: args.bridge_prover_id,
+            upgrade_delay_blocks: args.upgrade_delay_blocks,
+        }
+    }
+}
+
+/// Gets the state from storage, if it exists otherwise it will error.
+pub fn get_state<I: IO>(io: &I) -> Result<EngineState, error::EngineStateError> {
+    match io.read_storage(&bytes_to_key(KeyPrefix::Config, STATE_KEY)) {
+        None => Err(error::EngineStateError::NotFound),
+        Some(bytes) => EngineState::try_from_slice(&bytes.to_vec())
+            .map_err(|_| error::EngineStateError::DeserializationFailed),
+    }
+}
+
+/// Saves state into the storage. Does not return the previous state.
+pub fn set_state<I: IO>(io: &mut I, state: EngineState) -> Result<(), error::EngineStateError> {
+    io.write_storage(
+        &bytes_to_key(KeyPrefix::Config, STATE_KEY),
+        &state
+            .try_to_vec()
+            .map_err(|_| error::EngineStateError::SerializationFailed)?,
+    );
+
+    Ok(())
+}
+
+/// Engine state error module.
+pub mod error {
+    pub const ERR_STATE_NOT_FOUND: &[u8; 19] = b"ERR_STATE_NOT_FOUND";
+    pub const ERR_STATE_SERIALIZATION_FAILED: &[u8; 26] = b"ERR_STATE_SERIALIZE_FAILED";
+    pub const ERR_STATE_CORRUPTED: &[u8; 19] = b"ERR_STATE_CORRUPTED";
+
+    #[derive(Debug)]
+    /// Engine state error kinds.
+    pub enum EngineStateError {
+        /// The engine state is missing from storage, need to initialize with contract `new` method.
+        NotFound,
+        /// The engine state serialized had failed.
+        SerializationFailed,
+        /// The state of the engine is corrupted, possibly due to failed state migration.
+        DeserializationFailed,
+    }
+
+    impl AsRef<[u8]> for EngineStateError {
+        fn as_ref(&self) -> &[u8] {
+            match self {
+                Self::NotFound => ERR_STATE_NOT_FOUND,
+                Self::SerializationFailed => ERR_STATE_SERIALIZATION_FAILED,
+                Self::DeserializationFailed => ERR_STATE_CORRUPTED,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "std")]
+mod tests {
+    use super::*;
+    use aurora_engine_test_doubles::io::{Storage, StoragePointer};
+    use std::sync::RwLock;
+
+    #[test]
+    fn test_missing_engine_state_is_not_found() {
+        let storage = Storage::default();
+        let storage = RwLock::new(storage);
+        let io = StoragePointer(&storage);
+
+        let actual_error = get_state(&io).unwrap_err();
+        let actual_error = std::str::from_utf8(actual_error.as_ref()).unwrap();
+        let expected_error = std::str::from_utf8(error::ERR_STATE_NOT_FOUND).unwrap();
+
+        assert_eq!(expected_error, actual_error);
+    }
+
+    #[test]
+    fn test_empty_engine_state_is_corrupted() {
+        let storage = Storage::default();
+        let storage = RwLock::new(storage);
+        let mut io = StoragePointer(&storage);
+
+        io.write_storage(&bytes_to_key(KeyPrefix::Config, STATE_KEY), &[]);
+        let actual_error = get_state(&io).unwrap_err();
+        let actual_error = std::str::from_utf8(actual_error.as_ref()).unwrap();
+        let expected_error = std::str::from_utf8(error::ERR_STATE_CORRUPTED).unwrap();
+
+        assert_eq!(expected_error, actual_error);
+    }
+}

--- a/etc/tests/self-contained-5bEgfRQ/src/lib.rs
+++ b/etc/tests/self-contained-5bEgfRQ/src/lib.rs
@@ -39,7 +39,7 @@ pub extern "C" fn run() {
     let state = BTreeMap::try_from_slice(STATE).unwrap();
     let in_mem_io = InMemIO::new(&state, INPUT);
 
-    let engine_state = aurora_engine::engine::get_state(&in_mem_io).unwrap();
+    let engine_state = aurora_engine::state::get_state(&in_mem_io).unwrap();
     let relayer_address = aurora_engine_sdk::types::near_account_to_evm_address(
         local_env.predecessor_account_id.as_bytes(),
     );

--- a/etc/tests/state-migration-test/src/lib.rs
+++ b/etc/tests/state-migration-test/src/lib.rs
@@ -3,7 +3,7 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
-use aurora_engine::engine::{self, EngineState};
+use aurora_engine::state;
 use aurora_engine_sdk::near_runtime::Runtime;
 use aurora_engine_sdk::io::{IO, StorageIntermediate};
 use aurora_engine_types::storage;
@@ -11,14 +11,14 @@ use borsh::{BorshDeserialize, BorshSerialize};
 
 #[derive(BorshDeserialize, BorshSerialize)]
 struct NewFancyState {
-    old_state: EngineState,
+    old_state: state::EngineState,
     some_other_numbers: [u32; 7],
 }
 
 #[no_mangle]
 pub extern "C" fn state_migration() {
     let mut io = Runtime;
-    let old_state = match engine::get_state(&io) {
+    let old_state = match state::get_state(&io) {
         Ok(state) => state,
         Err(e) => aurora_engine_sdk::panic_utf8(e.as_ref()),
     };


### PR DESCRIPTION
## Description

Simply refactors the state into its own module. My motivation is to improve the code quality gradually when required.

## How should this be reviewed

Ensure that the refactor is complete, and nothing that has been missed was missed. That would require looking into the `engine/src/engine.rs` and ensuring all relevant tests and anything to do with the state has been moved.

## Additional information

Descoped from a scope creeping PR https://github.com/aurora-is-near/aurora-engine/pull/662
