### PR TITLE
Chore: Remove unused alloc_error_handler feature

### DIFF
--- a/engine-sdk/src/lib.rs
+++ b/engine-sdk/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(alloc_error_handler))]
 
 #[cfg(feature = "contract")]
 use crate::prelude::{Address, Vec, U256};


### PR DESCRIPTION
## Description

Continuing with trying to make `aurora-engine-types` usable as a library for other Near contracts, I am proposing we remove this unstable feature. It doesn't seem to have any impact on the code (everything compiles and tests still pass), and removing it allows the crate to compile with stable rust.