### PR TITLE
Feat: change private methods to admin methods

### DIFF
--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -558,7 +558,8 @@ mod contract {
     pub extern "C" fn new_eth_connector() {
         let io = Runtime;
         // Only the owner can initialize the EthConnector
-        io.assert_private_call().sdk_unwrap();
+        let state = engine::get_state(&io).sdk_unwrap();
+        require_owner_only(&state, &io.predecessor_account_id());
 
         let args: InitCallArgs = io.read_input_borsh().sdk_unwrap();
         let owner_id = io.current_account_id();
@@ -570,7 +571,8 @@ mod contract {
     pub extern "C" fn set_eth_connector_contract_data() {
         let mut io = Runtime;
         // Only the owner can set the EthConnector contract data
-        io.assert_private_call().sdk_unwrap();
+        let state = engine::get_state(&io).sdk_unwrap();
+        require_owner_only(&state, &io.predecessor_account_id());
 
         let args: SetContractDataCallArgs = io.read_input_borsh().sdk_unwrap();
         connector::set_contract_data(&mut io, args).sdk_unwrap();
@@ -846,7 +848,9 @@ mod contract {
     #[no_mangle]
     pub extern "C" fn set_paused_flags() {
         let io = Runtime;
-        io.assert_private_call().sdk_unwrap();
+        // Only the owner can initialize the EthConnector
+        let state = engine::get_state(&io).sdk_unwrap();
+        require_owner_only(&state, &io.predecessor_account_id());
 
         let args: PauseEthConnectorCallArgs = io.read_input_borsh().sdk_unwrap();
         EthConnectorContract::init_instance(io)

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -558,7 +558,7 @@ mod contract {
     pub extern "C" fn new_eth_connector() {
         let io = Runtime;
         // Only the owner can initialize the EthConnector
-        let state = engine::get_state(&io).sdk_unwrap();
+        let state = state::get_state(&io).sdk_unwrap();
         require_owner_only(&state, &io.predecessor_account_id());
 
         let args: InitCallArgs = io.read_input_borsh().sdk_unwrap();
@@ -571,7 +571,7 @@ mod contract {
     pub extern "C" fn set_eth_connector_contract_data() {
         let mut io = Runtime;
         // Only the owner can set the EthConnector contract data
-        let state = engine::get_state(&io).sdk_unwrap();
+        let state = state::get_state(&io).sdk_unwrap();
         require_owner_only(&state, &io.predecessor_account_id());
 
         let args: SetContractDataCallArgs = io.read_input_borsh().sdk_unwrap();
@@ -849,7 +849,7 @@ mod contract {
     pub extern "C" fn set_paused_flags() {
         let io = Runtime;
         // Only the owner can initialize the EthConnector
-        let state = engine::get_state(&io).sdk_unwrap();
+        let state = state::get_state(&io).sdk_unwrap();
         require_owner_only(&state, &io.predecessor_account_id());
 
         let args: PauseEthConnectorCallArgs = io.read_input_borsh().sdk_unwrap();


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Here are some helpful tips:

* Always create branches on and target the `develop` branch.
* Run all the tests locally and ensure that they are passing.
* Run `make format` to ensure that the code is formatted.
* Run `make check` to ensure that all checks passed successfully.
* Small commits and contributions that attempt one single goal is preferable.
* If the idea changes or adds anything functional which will affect users, an 
AIP discussion is required first on the Aurora forum: 
https://forum.aurora.dev/discussions/AIPs%20(Aurora%20Improvement%20Proposals).
* Avoid breaking the public API (namely in engine/src/lib.rs) unless required.
* If your PR is a WIP, ensure that you enable "draft" mode.
* Your first PRs won't use the CI automatically unless a maintainer starts.
If this is not your first PR, please do NOT abuse the CI resources.

Checklist:
- [x] I have performed a self-review of my code
- [x] I have documented my code, particularly in the hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to prove my fix or new feature is effective and works
- [x] Any dependent changes have been merged
- [x] The PR is targeting the `develop` branch and not `master`
- [x] I have pre-squashed my commits into a single commit and rebased.
-->

## Description

<!-- 
Provide a general summary of your changes. A clear overview along with an 
in-depth explanation is beneficial.

If this PR closes any issues, be sure to add "closes #<number>" somewhere.
-->

This PR changes the following 3 Aurora Engine's private methods to admin methods for Aurora Silo and DAO migration:

- new_eth_connector
- set_eth_connector_contract_data
- set_paused_flags

Changing these methods required to make an account to deploy then set owner to be the account to deploy like the updated deployment [code](https://github.com/hskang9/aurora-silo-tests/blob/9b3faa82dae0a865095ff4cb57cf41dd6f97185b/src/common.rs#L42). Adding `set_owner` method in the engine is expected after this PR.



## Performance / NEAR gas cost considerations

<!--
Performance regressions are not ideal, though we welcome performance 
improvements. Any PR must be completely mindful of any gas cost increases. The 
CI will fail if the gas costs change at all. Do update these tests to 
accommodate for the new gas changes. It is good to explain 
this change, if necessary.
-->

Performance has not been considered as this is just an access control change. Gas monitoring would be appreciated.

## Testing

<!--
Please describe the tests that you ran to verify your changes.
-->

NEAR Workspace test on testing the methods can be found [here](https://github.com/hskang9/aurora-silo-tests).


## How should this be reviewed

<!--
Include any recommendations of areas to be careful of to ensure that the 
reviewers use extra attention.
-->

Verify compiled engine code in the workspace test repo, Check code in the workspace test, run tests in the repo, and consider gas cost optimization on code changes.

## Additional information

<!--
Include any additional information which you think should be in this PR, such
as prior arts, future extensions, unresolved problems, or a TODO list which 
should be followed up.
-->

This is a part of Aurora DAO migration and Silo milestone.
