### PR TITLE
Fix: Missing Gas Costs in exitToNear and exitToEthereum Precompiles

### DIFF
--- a/engine-precompiles/src/native.rs
+++ b/engine-precompiles/src/native.rs
@@ -404,7 +404,7 @@ impl<I: IO> Precompile for ExitToNear<I> {
         Ok(PrecompileOutput {
             logs: vec![promise_log, exit_event_log],
             cost: gas_cost,
-            output: Default::default()
+            output: Default::default(),
         })
     }
 }
@@ -577,7 +577,7 @@ impl<I: IO> Precompile for ExitToEthereum<I> {
         Ok(PrecompileOutput {
             logs: vec![promise_log, exit_event_log],
             cost: gas_cost,
-            output: Default::default()
+            output: Default::default(),
         })
     }
 }

--- a/engine-precompiles/src/native.rs
+++ b/engine-precompiles/src/native.rs
@@ -404,7 +404,7 @@ impl<I: IO> Precompile for ExitToNear<I> {
         Ok(PrecompileOutput {
             logs: vec![promise_log, exit_event_log],
             cost: gas_cost,
-            output: Default::default(),
+            output: Vec::new(),
         })
     }
 }
@@ -577,7 +577,7 @@ impl<I: IO> Precompile for ExitToEthereum<I> {
         Ok(PrecompileOutput {
             logs: vec![promise_log, exit_event_log],
             cost: gas_cost,
-            output: Default::default(),
+            output: Vec::new(),
         })
     }
 }

--- a/engine-precompiles/src/native.rs
+++ b/engine-precompiles/src/native.rs
@@ -402,6 +402,7 @@ impl<I: IO> Precompile for ExitToNear<I> {
 
         Ok(PrecompileOutput {
             logs: vec![promise_log, exit_event_log],
+            cost: Self::required_gas(),
             ..Default::default()
         })
     }
@@ -573,6 +574,7 @@ impl<I: IO> Precompile for ExitToEthereum<I> {
 
         Ok(PrecompileOutput {
             logs: vec![promise_log, exit_event_log],
+            cost: Self::required_gas(),
             ..Default::default()
         })
     }

--- a/engine-precompiles/src/native.rs
+++ b/engine-precompiles/src/native.rs
@@ -400,10 +400,11 @@ impl<I: IO> Precompile for ExitToNear<I> {
             data: exit_event_log.data,
         };
 
+        let gas_cost = Self::required_gas(input)?;
         Ok(PrecompileOutput {
             logs: vec![promise_log, exit_event_log],
-            cost: Self::required_gas(),
-            ..Default::default()
+            cost: gas_cost,
+            output: Default::default()
         })
     }
 }
@@ -572,10 +573,11 @@ impl<I: IO> Precompile for ExitToEthereum<I> {
             data: exit_event_log.data,
         };
 
+        let gas_cost = Self::required_gas(input)?;
         Ok(PrecompileOutput {
             logs: vec![promise_log, exit_event_log],
-            cost: Self::required_gas(),
-            ..Default::default()
+            cost: gas_cost,
+            output: Default::default()
         })
     }
 }


### PR DESCRIPTION
Calling the `exitToNear` and `exitToEthereum` precompiles will not add any gas costs as it will use a default value of 0 for the `cost` field.
