### PR TITLE
Fix: re-enable deriving serde traits

### DIFF
--- a/engine-tests/Cargo.toml
+++ b/engine-tests/Cargo.toml
@@ -15,12 +15,12 @@ autobenches = false
 [dependencies]
 
 [dev-dependencies]
-aurora-engine = { path = "../engine", default-features = false, features = ["std", "tracing"] }
+aurora-engine = { path = "../engine", default-features = false, features = ["std", "tracing", "impl-serde"] }
 aurora-engine-test-doubles = { path = "../engine-test-doubles", default-features = false }
-aurora-engine-types = { path = "../engine-types", default-features = false, features = ["std"] }
+aurora-engine-types = { path = "../engine-types", default-features = false, features = ["std", "impl-serde"] }
 aurora-engine-sdk = { path = "../engine-sdk", default-features = false, features = ["std"] }
 aurora-engine-precompiles = { path = "../engine-precompiles", default-features = false, features = ["std"] }
-aurora-engine-transactions = { path = "../engine-transactions", default-features = false, features = ["std"] }
+aurora-engine-transactions = { path = "../engine-transactions", default-features = false, features = ["std", "impl-serde"] }
 engine-standalone-storage = { path = "../engine-standalone-storage" }
 engine-standalone-tracing = { path = "../engine-standalone-tracing", default-features = false, features = ["impl-serde"] }
 borsh = { version = "0.9.3", default-features = false }

--- a/engine-tests/src/tests/mod.rs
+++ b/engine-tests/src/tests/mod.rs
@@ -18,6 +18,7 @@ mod random;
 mod repro;
 pub(crate) mod sanity;
 mod self_destruct_state;
+mod serde;
 mod standalone;
 mod standard_precompiles;
 mod state_migration;

--- a/engine-tests/src/tests/serde.rs
+++ b/engine-tests/src/tests/serde.rs
@@ -1,0 +1,43 @@
+//! Tests to ensure we can use serde to serialize various types.
+
+use aurora_engine::{
+    engine::{EngineError, EngineErrorKind},
+    parameters::{ResultLog, SubmitResult, TransactionStatus},
+};
+use aurora_engine_transactions::eip_2930::AccessTuple;
+use aurora_engine_types::{types::Address, H160};
+
+#[test]
+fn test_serde_submit_result() {
+    let result = SubmitResult::new(
+        TransactionStatus::OutOfFund,
+        0,
+        vec![ResultLog {
+            address: Address::default(),
+            topics: Vec::new(),
+            data: Vec::new(),
+        }],
+    );
+    let serialized = serde_json::to_value(result).unwrap();
+    assert!(serialized.is_object());
+}
+
+#[test]
+fn test_serde_engine_error() {
+    let engine_error = EngineError {
+        kind: EngineErrorKind::GasOverflow,
+        gas_used: 0,
+    };
+    let serialized = serde_json::to_value(engine_error).unwrap();
+    assert!(serialized.is_object());
+}
+
+#[test]
+fn test_serde_access_tuple() {
+    let tuple = AccessTuple {
+        address: H160::default(),
+        storage_keys: Vec::new(),
+    };
+    let serialized = serde_json::to_value(tuple).unwrap();
+    assert!(serialized.is_object());
+}

--- a/engine-types/src/parameters/engine.rs
+++ b/engine-types/src/parameters/engine.rs
@@ -6,7 +6,7 @@ use crate::{
 use borsh::{BorshDeserialize, BorshSerialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "impl-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ResultLog {
     pub address: Address,
     pub topics: Vec<RawU256>,
@@ -15,7 +15,7 @@ pub struct ResultLog {
 
 /// The status of a transaction.
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "impl-serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum TransactionStatus {
     Succeed(Vec<u8>),
     Revert(Vec<u8>),
@@ -58,7 +58,7 @@ impl AsRef<[u8]> for TransactionStatus {
 /// Borsh-encoded parameters for the `call`, `call_with_args`, `deploy_code`,
 /// and `deploy_with_input` methods.
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "impl-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SubmitResult {
     version: u8,
     pub status: TransactionStatus,

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -73,7 +73,7 @@ macro_rules! assert_or_finish {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "impl-serde", derive(serde::Serialize))]
 pub struct EngineError {
     pub kind: EngineErrorKind,
     pub gas_used: u64,
@@ -93,7 +93,7 @@ impl AsRef<[u8]> for EngineError {
 
 /// Errors with the EVM engine.
 #[derive(Debug, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "impl-serde", derive(serde::Serialize))]
 pub enum EngineErrorKind {
     /// Normal EVM errors.
     EvmError(ExitError),
@@ -185,7 +185,7 @@ impl ExitIntoResult for ExitReason {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "impl-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BalanceOverflow;
 
 impl AsRef<[u8]> for BalanceOverflow {
@@ -196,7 +196,7 @@ impl AsRef<[u8]> for BalanceOverflow {
 
 /// Errors resulting from trying to pay for gas
 #[derive(Debug, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "impl-serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum GasPaymentError {
     /// Overflow adding ETH to an account balance (should never happen)
     BalanceOverflow(BalanceOverflow),


### PR DESCRIPTION
## Description

In PR #677 we made `serde` required instead of optional in `aurora-engine` and `aurora-engine-types`. This change means the `serde` feature no longer exists and this prevents the serde traits from being derived on several types. In this PR I fix this regression by using the `impl-serde` feature to trigger deriving the traits instead. I also add new tests which will catch this problem in the future.