### PR TITLE
fix: reachable panic in `receive_erc20_tokens()`

### DIFF
--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -695,7 +695,9 @@ impl<'env, I: IO + Copy, E: Env> Engine<'env, I, E> {
             assert_or_finish!(message.len() >= 40, output_on_fail, self.io);
 
             Address::new(H160(unwrap_res_or_finish!(
-                hex::decode(&message[..40]).unwrap().as_slice().try_into(),
+                unwrap_res_or_finish!(hex::decode(&message[..40]), output_on_fail, self.io)
+                    .as_slice()
+                    .try_into(),
                 output_on_fail,
                 self.io
             )))


### PR DESCRIPTION
## Description
 
Avoid panicking `receive_erc20_tokens()` in`hex::decode()` to propagate any errors.