### PR TITLE
Fix: Use of Panicking Macros and Functions in aurora-engine Code

### DIFF
--- a/engine-sdk/src/near_runtime.rs
+++ b/engine-sdk/src/near_runtime.rs
@@ -76,7 +76,7 @@ impl Runtime {
         match AccountId::try_from(bytes) {
             Ok(account_id) => account_id,
             // the environment must give us a valid Account ID.
-            Err(_) => unreachable!(),
+            Err(_) => unreachable!("Invalid Account ID"),
         }
     }
 

--- a/engine-types/src/storage.rs
+++ b/engine-types/src/storage.rs
@@ -94,7 +94,7 @@ impl From<KeyPrefixU8> for KeyPrefix {
             0x8 => Self::Nep141Erc20Map,
             0x9 => Self::Erc20Nep141Map,
             0xa => Self::CrossContractCall,
-            _ => unreachable!(),
+            _ => unreachable!("Unknown key prefix"),
         }
     }
 }

--- a/engine/src/xcc.rs
+++ b/engine/src/xcc.rs
@@ -105,9 +105,11 @@ pub fn handle_precompile_promise<I, P>(
             });
             // After the deployment we call the contract's initialize function
             let wnear_address = get_wnear_address(io);
-            let wnear_account = crate::engine::nep141_erc20_map(*io)
-                .lookup_right(&crate::engine::ERC20Address(wnear_address))
-                .unwrap();
+            let wnear_account = match crate::engine::nep141_erc20_map(*io)
+                .lookup_right(&crate::engine::ERC20Address(wnear_address)) {
+                    Some(x) => x,
+                    None => panic!("wnear account not found"),
+                };
             let init_args = format!(
                 r#"{{"wnear_account": "{}", "must_register": {}}}"#,
                 wnear_account.0.as_ref(),

--- a/engine/src/xcc.rs
+++ b/engine/src/xcc.rs
@@ -106,10 +106,11 @@ pub fn handle_precompile_promise<I, P>(
             // After the deployment we call the contract's initialize function
             let wnear_address = get_wnear_address(io);
             let wnear_account = match crate::engine::nep141_erc20_map(*io)
-                .lookup_right(&crate::engine::ERC20Address(wnear_address)) {
-                    Some(x) => x,
-                    None => panic!("wnear account not found"),
-                };
+                .lookup_right(&crate::engine::ERC20Address(wnear_address))
+            {
+                Some(x) => x,
+                None => panic!("wnear account not found"),
+            };
             let init_args = format!(
                 r#"{{"wnear_account": "{}", "must_register": {}}}"#,
                 wnear_account.0.as_ref(),


### PR DESCRIPTION
Avoid using `unwrap()` or `expect()` functions in the production code as these may lead to unforeseen panics. Instead,
gracefully handle error conditions and returned `Err` values by propagating them with `?` operator and handling them further up the execution chain.