### PR TITLE
fix: handle the return value of `exports::storage_remove()`

### DIFF
--- a/engine-sdk/src/near_runtime.rs
+++ b/engine-sdk/src/near_runtime.rs
@@ -57,15 +57,19 @@ impl Runtime {
             // Use register 0 as the destination for the promise.
             let promise_id = exports::promise_batch_create(u64::MAX as _, 0);
             // Remove code from storage and store it in register 1.
-            exports::storage_remove(code_key.len() as _, code_key.as_ptr() as _, 1);
-            exports::promise_batch_action_deploy_contract(promise_id, u64::MAX, 1);
-            Self::promise_batch_action_function_call(
-                promise_id,
-                b"state_migration",
-                &[],
-                0,
-                Self::GAS_FOR_STATE_MIGRATION.as_u64(),
-            )
+            match exports::storage_remove(code_key.len() as _, code_key.as_ptr() as _, 1) {
+                1 => {
+                    exports::promise_batch_action_deploy_contract(promise_id, u64::MAX, 1);
+                    Self::promise_batch_action_function_call(
+                        promise_id,
+                        b"state_migration",
+                        &[],
+                        0,
+                        Self::GAS_FOR_STATE_MIGRATION.as_u64(),
+                    )
+                }
+                _ => unreachable!("INVALID_CODE_KEY"),
+            };
         }
     }
 


### PR DESCRIPTION
## Description

The function `self_deploy()` does not validate the return value of `exports::storage_remove()` which might return `0` in case of an empty `code_key`. 
