### PR TITLE
Fix: deploy_upgrade() Does Not Clear Upgrade Index

### DIFF
--- a/engine-standalone-storage/src/sync/mod.rs
+++ b/engine-standalone-storage/src/sync/mod.rs
@@ -449,7 +449,7 @@ fn non_submit_execute<'db>(
         TransactionKind::SetUpgradeDelayBlocks(args) => {
             let mut prev = state::get_state(&io)?;
 
-            prev.upgrade_delay_blocks = args.clone().upgrade_delay_blocks;
+            prev.upgrade_delay_blocks = args.upgrade_delay_blocks;
             state::set_state(&mut io, &prev)?;
 
             None

--- a/engine-standalone-storage/src/sync/mod.rs
+++ b/engine-standalone-storage/src/sync/mod.rs
@@ -446,6 +446,14 @@ fn non_submit_execute<'db>(
 
             None
         }
+        TransactionKind::SetUpgradeDelayBlocks(args) => {
+            let mut prev = state::get_state(&io)?;
+
+            prev.upgrade_delay_blocks = args.clone().upgrade_delay_blocks;
+            state::set_state(&mut io, &prev)?;
+
+            None
+        }
     };
 
     Ok(result)

--- a/engine-standalone-storage/src/sync/types.rs
+++ b/engine-standalone-storage/src/sync/types.rs
@@ -352,8 +352,8 @@ impl TransactionKind {
             Self::PausePrecompiles(_) => Self::no_evm_execution("pause_precompiles"),
             Self::ResumePrecompiles(_) => Self::no_evm_execution("resume_precompiles"),
             Self::SetOwner(_) => Self::no_evm_execution("set_owner"),
-            Self::SetUpgradeDelayBlocks(_) => Self::no_evm_execution("set_upgrade_delay_blocks"),
             Self::FundXccSubAccound(_) => Self::no_evm_execution("fund_xcc_sub_account"),
+            Self::SetUpgradeDelayBlocks(_) => Self::no_evm_execution("set_upgrade_delay_blocks"),
         }
     }
 
@@ -521,8 +521,8 @@ enum BorshableTransactionKind<'a> {
     Unknown,
     SetOwner(Cow<'a, parameters::SetOwnerArgs>),
     SubmitWithArgs(Cow<'a, parameters::SubmitArgs>),
-    SetUpgradeDelayBlocks(Cow<'a, parameters::SetUpgradeDelayBlocksArgs>),
     FundXccSubAccound(Cow<'a, FundXccArgs>),
+    SetUpgradeDelayBlocks(Cow<'a, parameters::SetUpgradeDelayBlocksArgs>),
 }
 
 impl<'a> From<&'a TransactionKind> for BorshableTransactionKind<'a> {
@@ -565,10 +565,10 @@ impl<'a> From<&'a TransactionKind> for BorshableTransactionKind<'a> {
             TransactionKind::PausePrecompiles(x) => Self::PausePrecompiles(Cow::Borrowed(x)),
             TransactionKind::ResumePrecompiles(x) => Self::ResumePrecompiles(Cow::Borrowed(x)),
             TransactionKind::SetOwner(x) => Self::SetOwner(Cow::Borrowed(x)),
+            TransactionKind::FundXccSubAccound(x) => Self::FundXccSubAccound(Cow::Borrowed(x)),
             TransactionKind::SetUpgradeDelayBlocks(x) => {
                 Self::SetUpgradeDelayBlocks(Cow::Borrowed(x))
             }
-            TransactionKind::FundXccSubAccound(x) => Self::FundXccSubAccound(Cow::Borrowed(x)),
         }
     }
 }
@@ -628,11 +628,12 @@ impl<'a> TryFrom<BorshableTransactionKind<'a>> for TransactionKind {
                 Ok(Self::ResumePrecompiles(x.into_owned()))
             }
             BorshableTransactionKind::SetOwner(x) => Ok(Self::SetOwner(x.into_owned())),
+            BorshableTransactionKind::FundXccSubAccound(x) => {
+                Ok(Self::FundXccSubAccound(x.into_owned()))
+            }
             BorshableTransactionKind::SetUpgradeDelayBlocks(x) => {
                 Ok(Self::SetUpgradeDelayBlocks(x.into_owned()))
             }
-            BorshableTransactionKind::FundXccSubAccound(x) => {
-                Ok(Self::FundXccSubAccound(x.into_owned()))
         }
     }
 }

--- a/engine-standalone-storage/src/sync/types.rs
+++ b/engine-standalone-storage/src/sync/types.rs
@@ -352,11 +352,8 @@ impl TransactionKind {
             Self::PausePrecompiles(_) => Self::no_evm_execution("pause_precompiles"),
             Self::ResumePrecompiles(_) => Self::no_evm_execution("resume_precompiles"),
             Self::SetOwner(_) => Self::no_evm_execution("set_owner"),
-<<<<<<< HEAD
-            Self::FundXccSubAccound(_) => Self::no_evm_execution("fund_xcc_sub_account"),
-=======
             Self::SetUpgradeDelayBlocks(_) => Self::no_evm_execution("set_upgrade_delay_blocks"),
->>>>>>> d579e43 (standalone changes)
+            Self::FundXccSubAccound(_) => Self::no_evm_execution("fund_xcc_sub_account"),
         }
     }
 
@@ -523,8 +520,8 @@ enum BorshableTransactionKind<'a> {
     ResumePrecompiles(Cow<'a, parameters::PausePrecompilesCallArgs>),
     Unknown,
     SetOwner(Cow<'a, parameters::SetOwnerArgs>),
-    SetUpgradeDelayBlocks(Cow<'a, parameters::SetUpgradeDelayBlocksArgs>),
     SubmitWithArgs(Cow<'a, parameters::SubmitArgs>),
+    SetUpgradeDelayBlocks(Cow<'a, parameters::SetUpgradeDelayBlocksArgs>),
     FundXccSubAccound(Cow<'a, FundXccArgs>),
 }
 
@@ -568,13 +565,10 @@ impl<'a> From<&'a TransactionKind> for BorshableTransactionKind<'a> {
             TransactionKind::PausePrecompiles(x) => Self::PausePrecompiles(Cow::Borrowed(x)),
             TransactionKind::ResumePrecompiles(x) => Self::ResumePrecompiles(Cow::Borrowed(x)),
             TransactionKind::SetOwner(x) => Self::SetOwner(Cow::Borrowed(x)),
-<<<<<<< HEAD
-            TransactionKind::FundXccSubAccound(x) => Self::FundXccSubAccound(Cow::Borrowed(x)),
-=======
             TransactionKind::SetUpgradeDelayBlocks(x) => {
                 Self::SetUpgradeDelayBlocks(Cow::Borrowed(x))
             }
->>>>>>> d579e43 (standalone changes)
+            TransactionKind::FundXccSubAccound(x) => Self::FundXccSubAccound(Cow::Borrowed(x)),
         }
     }
 }
@@ -634,14 +628,11 @@ impl<'a> TryFrom<BorshableTransactionKind<'a>> for TransactionKind {
                 Ok(Self::ResumePrecompiles(x.into_owned()))
             }
             BorshableTransactionKind::SetOwner(x) => Ok(Self::SetOwner(x.into_owned())),
-<<<<<<< HEAD
-            BorshableTransactionKind::FundXccSubAccound(x) => {
-                Ok(Self::FundXccSubAccound(x.into_owned()))
-=======
             BorshableTransactionKind::SetUpgradeDelayBlocks(x) => {
                 Ok(Self::SetUpgradeDelayBlocks(x.into_owned()))
->>>>>>> d579e43 (standalone changes)
             }
+            BorshableTransactionKind::FundXccSubAccound(x) => {
+                Ok(Self::FundXccSubAccound(x.into_owned()))
         }
     }
 }

--- a/engine-standalone-storage/src/sync/types.rs
+++ b/engine-standalone-storage/src/sync/types.rs
@@ -111,6 +111,8 @@ pub enum TransactionKind {
     StorageWithdraw(parameters::StorageWithdrawCallArgs),
     /// Admin only method; used to transfer administration
     SetOwner(parameters::SetOwnerArgs),
+    /// Admin only method; used to change upgrade delay blocks
+    SetUpgradeDelayBlocks(parameters::SetUpgradeDelayBlocksArgs),
     /// Admin only method
     SetPausedFlags(parameters::PauseEthConnectorCallArgs),
     /// Ad entry mapping from address to relayer NEAR account
@@ -350,7 +352,11 @@ impl TransactionKind {
             Self::PausePrecompiles(_) => Self::no_evm_execution("pause_precompiles"),
             Self::ResumePrecompiles(_) => Self::no_evm_execution("resume_precompiles"),
             Self::SetOwner(_) => Self::no_evm_execution("set_owner"),
+<<<<<<< HEAD
             Self::FundXccSubAccound(_) => Self::no_evm_execution("fund_xcc_sub_account"),
+=======
+            Self::SetUpgradeDelayBlocks(_) => Self::no_evm_execution("set_upgrade_delay_blocks"),
+>>>>>>> d579e43 (standalone changes)
         }
     }
 
@@ -517,6 +523,7 @@ enum BorshableTransactionKind<'a> {
     ResumePrecompiles(Cow<'a, parameters::PausePrecompilesCallArgs>),
     Unknown,
     SetOwner(Cow<'a, parameters::SetOwnerArgs>),
+    SetUpgradeDelayBlocks(Cow<'a, parameters::SetUpgradeDelayBlocksArgs>),
     SubmitWithArgs(Cow<'a, parameters::SubmitArgs>),
     FundXccSubAccound(Cow<'a, FundXccArgs>),
 }
@@ -561,7 +568,13 @@ impl<'a> From<&'a TransactionKind> for BorshableTransactionKind<'a> {
             TransactionKind::PausePrecompiles(x) => Self::PausePrecompiles(Cow::Borrowed(x)),
             TransactionKind::ResumePrecompiles(x) => Self::ResumePrecompiles(Cow::Borrowed(x)),
             TransactionKind::SetOwner(x) => Self::SetOwner(Cow::Borrowed(x)),
+<<<<<<< HEAD
             TransactionKind::FundXccSubAccound(x) => Self::FundXccSubAccound(Cow::Borrowed(x)),
+=======
+            TransactionKind::SetUpgradeDelayBlocks(x) => {
+                Self::SetUpgradeDelayBlocks(Cow::Borrowed(x))
+            }
+>>>>>>> d579e43 (standalone changes)
         }
     }
 }
@@ -621,8 +634,13 @@ impl<'a> TryFrom<BorshableTransactionKind<'a>> for TransactionKind {
                 Ok(Self::ResumePrecompiles(x.into_owned()))
             }
             BorshableTransactionKind::SetOwner(x) => Ok(Self::SetOwner(x.into_owned())),
+<<<<<<< HEAD
             BorshableTransactionKind::FundXccSubAccound(x) => {
                 Ok(Self::FundXccSubAccound(x.into_owned()))
+=======
+            BorshableTransactionKind::SetUpgradeDelayBlocks(x) => {
+                Ok(Self::SetUpgradeDelayBlocks(x.into_owned()))
+>>>>>>> d579e43 (standalone changes)
             }
         }
     }

--- a/engine-tests/src/test_utils/mod.rs
+++ b/engine-tests/src/test_utils/mod.rs
@@ -35,6 +35,7 @@ pub const PAUSE_PRECOMPILES: &str = "pause_precompiles";
 pub const PAUSED_PRECOMPILES: &str = "paused_precompiles";
 pub const RESUME_PRECOMPILES: &str = "resume_precompiles";
 pub const SET_OWNER: &str = "set_owner";
+pub const SET_UPGRADE_DELAY_BLOCKS: &str = "set_upgrade_delay_blocks";
 
 const CALLER_ACCOUNT_ID: &str = "some-account.near";
 
@@ -233,7 +234,8 @@ impl AuroraRunner {
                     || method_name == DEPLOY_ERC20
                     || method_name == PAUSE_PRECOMPILES
                     || method_name == RESUME_PRECOMPILES
-                    || method_name == SET_OWNER)
+                    || method_name == SET_OWNER
+                    || method_name == SET_UPGRADE_DELAY_BLOCKS)
             {
                 standalone_runner
                     .submit_raw(method_name, &self.context, &self.promise_results)

--- a/engine-tests/src/test_utils/standalone/mod.rs
+++ b/engine-tests/src/test_utils/standalone/mod.rs
@@ -311,7 +311,7 @@ impl StandaloneRunner {
                 Vec::new(),
             ))
         } else if method_name == test_utils::SET_UPGRADE_DELAY_BLOCKS {
-            let input = &ctx.input[..];
+            let input = &ctx.input;
             let call_args = SetUpgradeDelayBlocksArgs::try_from_slice(input)
                 .expect("Unable to parse input as SetUpgradeDelayBlocksArgs");
 

--- a/engine-tests/src/test_utils/standalone/mod.rs
+++ b/engine-tests/src/test_utils/standalone/mod.rs
@@ -1,7 +1,7 @@
 use aurora_engine::engine;
 use aurora_engine::parameters::{
-    CallArgs, DeployErc20TokenArgs, PausePrecompilesCallArgs, SetOwnerArgs, SubmitArgs,
-    SubmitResult, TransactionStatus,
+    CallArgs, DeployErc20TokenArgs, PausePrecompilesCallArgs, SetOwnerArgs,
+    SetUpgradeDelayBlocksArgs, SubmitArgs, SubmitResult, TransactionStatus,
 };
 use aurora_engine_sdk::env::{self, Env};
 use aurora_engine_transactions::legacy::{LegacyEthSignedTransaction, TransactionLegacy};
@@ -300,6 +300,25 @@ impl StandaloneRunner {
             let mut tx_msg =
                 Self::template_tx_msg(storage, &env, 0, transaction_hash, promise_results);
             tx_msg.transaction = TransactionKind::SetOwner(call_args);
+
+            let outcome = sync::execute_transaction_message(storage, tx_msg).unwrap();
+            self.cumulative_diff.append(outcome.diff.clone());
+            storage::commit(storage, &outcome);
+
+            Ok(SubmitResult::new(
+                TransactionStatus::Succeed(Vec::new()),
+                0,
+                Vec::new(),
+            ))
+        } else if method_name == test_utils::SET_UPGRADE_DELAY_BLOCKS {
+            let input = &ctx.input[..];
+            let call_args = SetUpgradeDelayBlocksArgs::try_from_slice(input)
+                .expect("Unable to parse input as SetUpgradeDelayBlocksArgs");
+
+            let transaction_hash = aurora_engine_sdk::keccak(&ctx.input);
+            let mut tx_msg =
+                Self::template_tx_msg(storage, &env, 0, transaction_hash, promise_results);
+            tx_msg.transaction = TransactionKind::SetUpgradeDelayBlocks(call_args);
 
             let outcome = sync::execute_transaction_message(storage, tx_msg).unwrap();
             self.cumulative_diff.append(outcome.diff.clone());

--- a/engine-tests/src/tests/sanity.rs
+++ b/engine-tests/src/tests/sanity.rs
@@ -1156,9 +1156,9 @@ fn test_set_upgrade_delay_blocks() {
     // check if the query goes through the standalone runner
     assert!(outcome.is_some() && error.is_none());
 
-    // check if the owner_id property has changed to 2
+    // check if the upgrade_delay_blocks property has changed to 2
     assert_eq!(
-        b"2",
+        [2, 0, 0, 0, 0, 0, 0, 0],
         outcome.unwrap().return_data.as_value().unwrap().as_slice()
     );
 }

--- a/engine-tests/src/tests/sanity.rs
+++ b/engine-tests/src/tests/sanity.rs
@@ -3,7 +3,9 @@ use crate::prelude::{Wei, ERC20_MINT_SELECTOR};
 use crate::test_utils::{self, str_to_account_id};
 use crate::tests::state_migration;
 use aurora_engine::fungible_token::FungibleTokenMetadata;
-use aurora_engine::parameters::{SetOwnerArgs, SubmitResult, TransactionStatus};
+use aurora_engine::parameters::{
+    SetOwnerArgs, SetUpgradeDelayBlocksArgs, SubmitResult, TransactionStatus,
+};
 use aurora_engine_sdk as sdk;
 use borsh::BorshSerialize;
 use libsecp256k1::SecretKey;
@@ -1126,6 +1128,38 @@ fn test_set_owner_fail_on_same_owner() {
     assert_eq!(
         error.unwrap().to_string(),
         "Smart contract panicked: ERR_SAME_OWNER"
+    );
+}
+
+#[test]
+fn test_set_upgrade_delay_blocks() {
+    let mut runner = test_utils::deploy_evm();
+    let aurora_account_id = runner.aurora_account_id.clone();
+
+    // set upgrade_delay_blocks args
+    let set_upgrade_delay_blocks = SetUpgradeDelayBlocksArgs {
+        upgrade_delay_blocks: 2,
+    };
+
+    let (outcome, error) = runner.call(
+        "set_upgrade_delay_blocks",
+        &aurora_account_id,
+        set_upgrade_delay_blocks.try_to_vec().unwrap(),
+    );
+
+    // should succeed
+    assert!(outcome.is_some() && error.is_none());
+
+    // get upgrade_delay_blocks to see if the upgrade_delay_blocks property has changed
+    let (outcome, error) = runner.call("get_upgrade_delay_blocks", &aurora_account_id, vec![]);
+
+    // check if the query goes through the standalone runner
+    assert!(outcome.is_some() && error.is_none());
+
+    // check if the owner_id property has changed to 2
+    assert_eq!(
+        b"2",
+        outcome.unwrap().return_data.as_value().unwrap().as_slice()
     );
 }
 

--- a/engine-tests/src/tests/sanity.rs
+++ b/engine-tests/src/tests/sanity.rs
@@ -1157,10 +1157,11 @@ fn test_set_upgrade_delay_blocks() {
     assert!(outcome.is_some() && error.is_none());
 
     // check if the upgrade_delay_blocks property has changed to 2
-    assert_eq!(
-        [2, 0, 0, 0, 0, 0, 0, 0],
-        outcome.unwrap().return_data.as_value().unwrap().as_slice()
-    );
+    let result = SetUpgradeDelayBlocksArgs::try_from_slice(
+        outcome.unwrap().return_data.as_value().unwrap().as_slice(),
+    )
+    .unwrap();
+    assert_eq!(result.upgrade_delay_blocks, 2);
 }
 
 fn initialize_evm_sim() -> (state_migration::AuroraAccount, test_utils::Signer, Address) {

--- a/engine-tests/src/tests/sanity.rs
+++ b/engine-tests/src/tests/sanity.rs
@@ -7,7 +7,7 @@ use aurora_engine::parameters::{
     SetOwnerArgs, SetUpgradeDelayBlocksArgs, SubmitResult, TransactionStatus,
 };
 use aurora_engine_sdk as sdk;
-use borsh::BorshSerialize;
+use borsh::{BorshDeserialize, BorshSerialize};
 use libsecp256k1::SecretKey;
 use rand::RngCore;
 use std::path::{Path, PathBuf};

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -75,7 +75,7 @@ pub unsafe fn on_alloc_error(_: core::alloc::Layout) -> ! {
 #[cfg(feature = "contract")]
 mod contract {
     use borsh::{BorshDeserialize, BorshSerialize};
-    use parameters::SetOwnerArgs;
+    use parameters::{SetOwnerArgs, SetUpgradeDelayBlocksArgs};
 
     use crate::connector::{self, EthConnectorContract};
     use crate::engine::{self, Engine};
@@ -122,8 +122,8 @@ mod contract {
     #[no_mangle]
     pub extern "C" fn new() {
         let mut io = Runtime;
-        
-        if state::get_state(&io).is_some() {
+
+        if state::get_state(&io).is_ok() {
             sdk::panic_utf8(b"ERR_ALREADY_INITIALIZED");
         }
 
@@ -182,7 +182,7 @@ mod contract {
     pub extern "C" fn get_upgrade_delay_blocks() {
         let mut io = Runtime;
         let state = state::get_state(&io).sdk_unwrap();
-        io.return_output(state.upgrade_delay_blocks.as_bytes());
+        io.return_output(&state.upgrade_delay_blocks.to_le_bytes());
     }
 
     #[no_mangle]

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -122,8 +122,9 @@ mod contract {
     #[no_mangle]
     pub extern "C" fn new() {
         let mut io = Runtime;
-        if let Ok(state) = state::get_state(&io) {
-            require_owner_only(&state, &io.predecessor_account_id());
+        
+        if state::get_state(&io).is_some() {
+            sdk::panic_utf8(b"ERR_ALREADY_INITIALIZED");
         }
 
         let args: NewCallArgs = io.read_input_borsh().sdk_unwrap();
@@ -175,6 +176,23 @@ mod contract {
     pub extern "C" fn get_chain_id() {
         let mut io = Runtime;
         io.return_output(&state::get_state(&io).sdk_unwrap().chain_id);
+    }
+
+    #[no_mangle]
+    pub extern "C" fn get_upgrade_delay_blocks() {
+        let mut io = Runtime;
+        let state = state::get_state(&io).sdk_unwrap();
+        io.return_output(state.upgrade_delay_blocks.as_bytes());
+    }
+
+    #[no_mangle]
+    pub extern "C" fn set_upgrade_delay_blocks() {
+        let mut io = Runtime;
+        let mut state = state::get_state(&io).sdk_unwrap();
+        require_owner_only(&state, &io.predecessor_account_id());
+        let args: SetUpgradeDelayBlocksArgs = io.read_input_borsh().sdk_unwrap();
+        state.upgrade_delay_blocks = args.upgrade_delay_blocks;
+        state::set_state(&mut io, &state).sdk_unwrap();
     }
 
     #[no_mangle]

--- a/engine/src/parameters.rs
+++ b/engine/src/parameters.rs
@@ -32,6 +32,12 @@ pub struct SetOwnerArgs {
     pub new_owner: AccountId,
 }
 
+/// Borsh-encoded parameters for the `set_upgrade_delay_blocks` function.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct SetUpgradeDelayBlocksArgs {
+    pub upgrade_delay_blocks: u64,
+}
+
 /// Borsh-encoded (genesis) account balance used by the `begin_chain` function.
 #[cfg(feature = "evm_bully")]
 #[derive(BorshSerialize, BorshDeserialize)]


### PR DESCRIPTION
There is an issue in `deploy_upgrade()` that the upgrade index is not cleared after each call.

Therefore, `deploy_upgrade()` will pass the check` io.block_height() <= index + state.upgrade_delay_blocks` since
`index` remains unchanged from previous calls.