### PR TITLE
fix: return error if signature len does not eq `65`

### DIFF
--- a/engine-precompiles/src/secp256k1.rs
+++ b/engine-precompiles/src/secp256k1.rs
@@ -19,7 +19,9 @@ mod consts {
 // Quite a few library methods rely on this and that should be changed. This
 // should only be for precompiles.
 pub fn ecrecover(hash: H256, signature: &[u8]) -> Result<Address, ExitError> {
-    assert_eq!(signature.len(), 65);
+    if signature.len() != 65 {
+        return Err(ExitError::Other(Borrowed("INVALID_SIGNATURE_LENGTH")));
+    }
 
     #[cfg(feature = "contract")]
     return sdk::ecrecover(hash, signature).map_err(|e| ExitError::Other(Borrowed(e.as_str())));
@@ -246,5 +248,16 @@ mod tests {
             .unwrap()
             .output;
         assert_eq!(res, expected);
+    }
+
+    #[test]
+    pub fn test_invalid_signature_length() {
+        let hash = H256::from_slice(
+            &hex::decode("1111111111111111111111111111111111111111111111111111111111111111")
+                .unwrap(),
+        );
+        let signature = hex::decode("123").unwrap();
+        let res = ecrecover(hash, &signature);
+        assert!(res.is_err());
     }
 }


### PR DESCRIPTION
### Description

the `ecrecover` precompile panics if provided signature length is not exactly 65.