### PR TITLE
fix: Lack of Division by `0` Checks In `EthGas::Div()`

### DIFF
--- a/engine-precompiles/src/alt_bn256.rs
+++ b/engine-precompiles/src/alt_bn256.rs
@@ -3,6 +3,7 @@ use crate::prelude::{Borrowed, PhantomData, Vec};
 use crate::utils;
 use crate::{Byzantium, EvmPrecompileResult, HardFork, Istanbul, Precompile, PrecompileOutput};
 use bn::Group;
+use core::num::{NonZeroU64, NonZeroUsize};
 use evm::{Context, ExitError};
 
 /// bn128 costs.
@@ -491,8 +492,9 @@ impl<HF: HardFork> Bn256Pair<HF> {
 impl Precompile for Bn256Pair<Byzantium> {
     fn required_gas(input: &[u8]) -> Result<EthGas, ExitError> {
         let input_len = u64::try_from(input.len()).map_err(utils::err_usize_conv)?;
-        let pair_element_len =
-            u64::try_from(consts::PAIR_ELEMENT_LEN).map_err(utils::err_usize_conv)?;
+        let pair_element_len = NonZeroUsize::try_from(consts::PAIR_ELEMENT_LEN)
+            .and_then(NonZeroU64::try_from)
+            .map_err(utils::err_usize_conv)?;
         Ok(
             costs::BYZANTIUM_PAIR_PER_POINT * input_len / pair_element_len
                 + costs::BYZANTIUM_PAIR_BASE,
@@ -525,8 +527,9 @@ impl Precompile for Bn256Pair<Byzantium> {
 impl Precompile for Bn256Pair<Istanbul> {
     fn required_gas(input: &[u8]) -> Result<EthGas, ExitError> {
         let input_len = u64::try_from(input.len()).map_err(utils::err_usize_conv)?;
-        let pair_element_len =
-            u64::try_from(consts::PAIR_ELEMENT_LEN).map_err(utils::err_usize_conv)?;
+        let pair_element_len = NonZeroUsize::try_from(consts::PAIR_ELEMENT_LEN)
+            .and_then(NonZeroU64::try_from)
+            .map_err(utils::err_usize_conv)?;
         Ok(
             costs::ISTANBUL_PAIR_PER_POINT * input_len / pair_element_len
                 + costs::ISTANBUL_PAIR_BASE,

--- a/engine-types/src/types/gas.rs
+++ b/engine-types/src/types/gas.rs
@@ -1,6 +1,7 @@
 use crate::fmt::Formatter;
 use crate::{Add, AddAssign, Display, Div, Mul, Sub};
 use borsh::{BorshDeserialize, BorshSerialize};
+use core::num::NonZeroU64;
 use serde::{Deserialize, Serialize};
 
 #[derive(
@@ -83,11 +84,10 @@ impl AddAssign for EthGas {
     }
 }
 
-impl Div<u64> for EthGas {
+impl Div<NonZeroU64> for EthGas {
     type Output = Self;
 
-    fn div(self, rhs: u64) -> Self::Output {
-        assert!(rhs != 0, "ZERO_IS_AN_INVALID_DENOMINATOR");
+    fn div(self, rhs: NonZeroU64) -> Self::Output {
         Self(self.0 / rhs)
     }
 }

--- a/engine-types/src/types/gas.rs
+++ b/engine-types/src/types/gas.rs
@@ -87,6 +87,7 @@ impl Div<u64> for EthGas {
     type Output = Self;
 
     fn div(self, rhs: u64) -> Self::Output {
+        assert!(rhs != 0, "ZERO_IS_AN_INVALID_DENOMINATOR");
         Self(self.0 / rhs)
     }
 }


### PR DESCRIPTION
## Description

In engine-types, the `EthGas` struct does not perform checks on division by `0` in its `Div` implementation.