### PR TITLE
fix: check inputs in `alt_bn256`

### DIFF
--- a/engine-precompiles/src/alt_bn256.rs
+++ b/engine-precompiles/src/alt_bn256.rs
@@ -67,6 +67,15 @@ mod consts {
 }
 
 #[cfg(feature = "contract")]
+mod type_arith {
+    pub struct Double<const P: usize>;
+    pub trait Is<const S: usize> {}
+    impl Is<128> for Double<64> {}
+    impl Is<64> for Double<32> {}
+    impl Is<32> for Double<16> {}
+}
+
+#[cfg(feature = "contract")]
 trait HostFnEncode {
     type Encoded;
 
@@ -74,8 +83,10 @@ trait HostFnEncode {
 }
 
 #[cfg(feature = "contract")]
-fn concat_low_high<const P: usize, const S: usize>(low: [u8; P], high: [u8; P]) -> [u8; S] {
-    assert!(S >= (P * 2), "INSUFFICIENT_OUTPUT_ARRAY_SIZE");
+fn concat_low_high<const P: usize, const S: usize>(low: [u8; P], high: [u8; P]) -> [u8; S]
+where
+    type_arith::Double<P>: type_arith::Is<S>,
+{
     let mut bytes = [0u8; S];
     bytes[0..P].copy_from_slice(&low);
     bytes[P..P * 2].copy_from_slice(&high);

--- a/engine-precompiles/src/alt_bn256.rs
+++ b/engine-precompiles/src/alt_bn256.rs
@@ -151,6 +151,9 @@ impl HostFnEncode for bn::G2 {
 /// Reads the `x` and `y` points from an input at a given position.
 fn read_point(input: &[u8], pos: usize) -> Result<bn::G1, ExitError> {
     use bn::{AffineG1, Fq, G1};
+    if input.len() < (pos + consts::SCALAR_LEN * 2) {
+        return Err(ExitError::Other(Borrowed("INVALID_INPUT_LENGTH")));
+    }
 
     let px = Fq::from_slice(&input[pos..(pos + consts::SCALAR_LEN)])
         .map_err(|_e| ExitError::Other(Borrowed("ERR_FQ_INCORRECT")))?;

--- a/engine-precompiles/src/alt_bn256.rs
+++ b/engine-precompiles/src/alt_bn256.rs
@@ -89,7 +89,7 @@ where
 {
     let mut bytes = [0u8; S];
     bytes[0..P].copy_from_slice(&low);
-    bytes[P..P * 2].copy_from_slice(&high);
+    bytes[P..S].copy_from_slice(&high);
     bytes
 }
 

--- a/engine-precompiles/src/alt_bn256.rs
+++ b/engine-precompiles/src/alt_bn256.rs
@@ -75,6 +75,7 @@ trait HostFnEncode {
 
 #[cfg(feature = "contract")]
 fn concat_low_high<const P: usize, const S: usize>(low: [u8; P], high: [u8; P]) -> [u8; S] {
+    assert!(S >= (P * 2), "INSUFFICIENT_OUTPUT_ARRAY_SIZE");
     let mut bytes = [0u8; S];
     bytes[0..P].copy_from_slice(&low);
     bytes[P..P * 2].copy_from_slice(&high);


### PR DESCRIPTION
## Description

- [x] There are no size checks implemented on input array passed to `read_point()` , which may result in panic if accessing elements outside of array boundaries.
- [x] In `concat_low_high`, there are no size checks implemented to ensure provided size of output array `S` is at least twice the size of input arrays sizes `P`.
