### PR TITLE
Fix: Precompile panics on signature with invalid length

### DIFF
--- a/engine-precompiles/src/secp256k1.rs
+++ b/engine-precompiles/src/secp256k1.rs
@@ -19,7 +19,9 @@ mod consts {
 // Quite a few library methods rely on this and that should be changed. This
 // should only be for precompiles.
 pub fn ecrecover(hash: H256, signature: &[u8]) -> Result<Address, ExitError> {
-    assert_eq!(signature.len(), 65);
+    if signature.len() != 65 {
+        return Err(ExitError::Other(Borrowed("ERR_INCORRECT_SIGNATURE_LENGTH")));
+    }
 
     #[cfg(feature = "contract")]
     return sdk::ecrecover(hash, signature).map_err(|e| ExitError::Other(Borrowed(e.as_str())));


### PR DESCRIPTION
In `aurora-engine`, the `ecrecover` precompile panics if provided signature length is not exactly 65

Panics will stop execution of the executable and hence panicking macros such as `assert_eq!` should be avoided in the
release code.

Gracefully handle the invalid signature length condition by returning an `ExitError` , instead of panicking.