### PR TITLE
Fix: Lack of Division by 0 Checks In EthGas::Div()

### DIFF
--- a/engine-types/src/types/gas.rs
+++ b/engine-types/src/types/gas.rs
@@ -83,6 +83,9 @@ impl Div<u64> for EthGas {
     type Output = EthGas;
 
     fn div(self, rhs: u64) -> Self::Output {
+        if rhs == 0 {
+            panic!("Zero is an invalid denominator");
+        }
         EthGas(self.0 / rhs)
     }
 }


### PR DESCRIPTION
In `engine-types`, the `EthGas` struct does not perform checks on division by 0 in its `Div` implementation.
