### PR TITLE
chore: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,9 @@
-* @artob
 * @joshuajbouw
+/engine/ @aleksuss
+/engine-precompiles/ @mandreyel
+/engine-sdk/ @aleksuss
+/engine-standalone-storage/ @RomanHodulak
+/engine-standalone-tracing/ @RomanHodulak
+/engine-test-doubles/ @hskang9
+/engine-tests/ @hskang9
+/engine-transactions/ @aleksuss


### PR DESCRIPTION
## Description

Code owners were defined during a meeting to ensure there are no blockages of PRs and they are swiftly reviewed. Generally, a code owner must sign off on a PR to push it in if it touches the code which they own.