### PR TITLE
fix: check for `0` value as a part of `Depth::decrement()`

### DIFF
--- a/engine-standalone-tracing/src/types/mod.rs
+++ b/engine-standalone-tracing/src/types/mod.rs
@@ -24,7 +24,9 @@ impl Depth {
     }
 
     pub fn decrement(&mut self) {
-        self.0 -= 1;
+        if !self.is_zero() {
+            self.0 -= 1;
+        }
     }
 
     #[must_use]


### PR DESCRIPTION
Given `Depth` is of `u32` type, decrementing it into negative will trigger panic, stopping execution of the executable.