### PR TITLE
Fix: Lack of 0 Value Checks in Depth::decrement()

### DIFF
--- a/engine-standalone-tracing/src/types/mod.rs
+++ b/engine-standalone-tracing/src/types/mod.rs
@@ -23,6 +23,9 @@ impl Depth {
     }
 
     pub fn decrement(&mut self) {
+        if self.0 == 0 {
+            panic!("Cannot decrement 0 value");
+        }
         self.0 -= 1;
     }
 

--- a/engine-standalone-tracing/src/types/mod.rs
+++ b/engine-standalone-tracing/src/types/mod.rs
@@ -23,9 +23,7 @@ impl Depth {
     }
 
     pub fn decrement(&mut self) {
-        if self.0 == 0 {
-            panic!("Cannot decrement 0 value");
-        }
+        assert!(!(self.0 == 0), "Cannot decrement 0 value");
         self.0 -= 1;
     }
 


### PR DESCRIPTION
In `engine-standalone-tracing`, calling `Depth::decrement() `on value of 0 will cause unhandled panic.

Given `Depth` is of `u32` type, decrementing it into negative will trigger panic, stopping execution of the executable.
