### PR TITLE
Fix: Private Calls Without Callbacks Require Access Keys

### DIFF
--- a/engine-tests/src/tests/eth_connector.rs
+++ b/engine-tests/src/tests/eth_connector.rs
@@ -50,8 +50,11 @@ pub struct IsUsedProofResult {
 
 fn init(custodian_address: &str) -> (UserAccount, UserAccount) {
     let master_account = near_sdk_sim::init_simulator(None);
-    let contract = init_contract(&master_account, CONTRACT_ACC, custodian_address);
-    (master_account, contract)
+    let contract_account = near_sdk_sim::init_simulator(None);
+    init_contract(&master_account, CONTRACT_ACC, custodian_address);
+    // let contract = init_contract(&master_account, CONTRACT_ACC, custodian_address);
+    // (master_account, contract)
+    (master_account, contract_account)
 }
 
 fn init_contract(

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -651,11 +651,8 @@ mod contract {
     pub extern "C" fn new_eth_connector() {
         let io = Runtime;
         // Only the owner can initialize the EthConnector
-        let is_private = io.assert_private_call();
-        if is_private.is_err() {
-            let state = state::get_state(&io).sdk_unwrap();
-            require_owner_only(&state, &io.predecessor_account_id());
-        }
+        let state = state::get_state(&io).sdk_unwrap();
+        require_owner_only(&state, &io.predecessor_account_id());
 
         let args: InitCallArgs = io.read_input_borsh().sdk_unwrap();
         let owner_id = io.current_account_id();
@@ -667,11 +664,8 @@ mod contract {
     pub extern "C" fn set_eth_connector_contract_data() {
         let mut io = Runtime;
         // Only the owner can set the EthConnector contract data
-        let is_private = io.assert_private_call();
-        if is_private.is_err() {
-            let state = state::get_state(&io).sdk_unwrap();
-            require_owner_only(&state, &io.predecessor_account_id());
-        }
+        let state = state::get_state(&io).sdk_unwrap();
+        require_owner_only(&state, &io.predecessor_account_id());
 
         let args: SetContractDataCallArgs = io.read_input_borsh().sdk_unwrap();
         connector::set_contract_data(&mut io, args).sdk_unwrap();
@@ -948,11 +942,8 @@ mod contract {
     #[no_mangle]
     pub extern "C" fn set_paused_flags() {
         let io = Runtime;
-        let is_private = io.assert_private_call();
-        if is_private.is_err() {
-            let state = state::get_state(&io).sdk_unwrap();
-            require_owner_only(&state, &io.predecessor_account_id());
-        }
+        let state = state::get_state(&io).sdk_unwrap();
+        require_owner_only(&state, &io.predecessor_account_id());
         let args: PauseEthConnectorCallArgs = io.read_input_borsh().sdk_unwrap();
         EthConnectorContract::init_instance(io)
             .sdk_unwrap()


### PR DESCRIPTION
The function `new_eth_connector()` is a private call that must be called by the current account.

The requirement `assert_private_call() `on line **[519]** ensures that the predecessor account ID matches the current
account ID. This requirement can only be filled by two conditions.

1. If the contract makes a callback to itself.
2. If an access key belonging to this account is used to sign the transaction.

It is advised to remove the access key and instead enforce the predecessor account to be `EngineState.owner_id` for each of the functions listed above.

This can be done using the function `require_owner_only() `.
