### PR TITLE
Fix: new() May Be Called Multiple Times

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,9 @@
-* @artob
 * @joshuajbouw
+/engine/ @aleksuss
+/engine-precompiles/ @mandreyel
+/engine-sdk/ @aleksuss
+/engine-standalone-storage/ @RomanHodulak
+/engine-standalone-tracing/ @RomanHodulak
+/engine-test-doubles/ @hskang9
+/engine-tests/ @hskang9
+/engine-transactions/ @aleksuss

--- a/engine-standalone-tracing/src/sputnik.rs
+++ b/engine-standalone-tracing/src/sputnik.rs
@@ -51,8 +51,11 @@ impl evm_gasometer::tracing::EventListener for TransactionTraceBuilder {
             Event::RecordCost { cost, snapshot } => {
                 self.current.gas_cost = EthGas::new(cost);
                 if let Some(snapshot) = snapshot {
-                    self.current.gas =
-                        EthGas::new(snapshot.gas_limit - snapshot.used_gas - snapshot.memory_gas);
+                    self.current.gas = EthGas::new(
+                        snapshot
+                            .gas_limit
+                            .saturating_sub(snapshot.used_gas + snapshot.memory_gas),
+                    );
                 }
             }
             Event::RecordDynamicCost {
@@ -73,8 +76,11 @@ impl evm_gasometer::tracing::EventListener for TransactionTraceBuilder {
                 self.current_memory_gas = memory_gas;
                 self.current.gas_cost = EthGas::new(gas_cost + memory_cost_diff);
                 if let Some(snapshot) = snapshot {
-                    self.current.gas =
-                        EthGas::new(snapshot.gas_limit - snapshot.used_gas - snapshot.memory_gas);
+                    self.current.gas = EthGas::new(
+                        snapshot
+                            .gas_limit
+                            .saturating_sub(snapshot.used_gas + snapshot.memory_gas),
+                    );
                 }
             }
             Event::RecordRefund {

--- a/engine-standalone-tracing/src/types/mod.rs
+++ b/engine-standalone-tracing/src/types/mod.rs
@@ -23,7 +23,7 @@ impl Depth {
     }
 
     pub fn decrement(&mut self) {
-        self.0 -= 1;
+        self.0 = self.0.saturating_sub(1);
     }
 
     pub fn is_zero(&self) -> bool {

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -695,7 +695,9 @@ impl<'env, I: IO + Copy, E: Env> Engine<'env, I, E> {
             assert_or_finish!(message.len() >= 40, output_on_fail, self.io);
 
             Address::new(H160(unwrap_res_or_finish!(
-                hex::decode(&message[..40]).unwrap().as_slice().try_into(),
+                unwrap_res_or_finish!(hex::decode(&message[..40]), output_on_fail, self.io)
+                    .as_slice()
+                    .try_into(),
                 output_on_fail,
                 self.io
             )))

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -116,12 +116,13 @@ mod contract {
     #[no_mangle]
     pub extern "C" fn new() {
         let mut io = Runtime;
-        if let Ok(state) = state::get_state(&io) {
-            require_owner_only(&state, &io.predecessor_account_id());
+        match state::get_state(&io) {
+            Ok(state) => sdk::panic_utf8("ERR_ALREADY_INITIALIZED".as_bytes()),
+            _ => {
+                let args: NewCallArgs = io.read_input_borsh().sdk_unwrap();
+                state::set_state(&mut io, args.into()).sdk_unwrap();
+            }
         }
-
-        let args: NewCallArgs = io.read_input_borsh().sdk_unwrap();
-        state::set_state(&mut io, args.into()).sdk_unwrap();
     }
 
     /// Get version of the contract.

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -4,7 +4,13 @@
     all(feature = "log", target_arch = "wasm32"),
     feature(panic_info_message)
 )]
-#![deny(clippy::as_conversions)]
+#![deny(clippy::pedantic, clippy::nursery)]
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::module_name_repetitions,
+    clippy::unreadable_literal
+)]
 
 use aurora_engine_types::parameters::PromiseCreateArgs;
 
@@ -79,7 +85,7 @@ mod contract {
         self, CallArgs, DeployErc20TokenArgs, GetErc20FromNep141CallArgs, GetStorageAtArgs,
         InitCallArgs, IsUsedProofCallArgs, NEP141FtOnTransferArgs, NewCallArgs,
         PauseEthConnectorCallArgs, PausePrecompilesCallArgs, ResolveTransferCallArgs,
-        SetContractDataCallArgs, StorageDepositCallArgs, StorageWithdrawCallArgs,
+        SetContractDataCallArgs, StorageDepositCallArgs, StorageWithdrawCallArgs, SubmitArgs,
         TransferCallCallArgs, ViewCallArgs,
     };
     #[cfg(feature = "evm_bully")]
@@ -129,11 +135,9 @@ mod contract {
     #[no_mangle]
     pub extern "C" fn get_version() {
         let mut io = Runtime;
-        let version = match option_env!("NEAR_EVM_VERSION") {
-            Some(v) => v.as_bytes(),
-            None => include_bytes!("../../VERSION"),
-        };
-        io.return_output(version)
+        let version = option_env!("NEAR_EVM_VERSION")
+            .map_or(&include_bytes!("../../VERSION")[..], str::as_bytes);
+        io.return_output(version);
     }
 
     /// Get owner account id for this contract.
@@ -155,7 +159,7 @@ mod contract {
             sdk::panic_utf8(errors::ERR_SAME_OWNER);
         } else {
             state.owner_id = args.new_owner;
-            state::set_state(&mut io, state).sdk_unwrap();
+            state::set_state(&mut io, &state).sdk_unwrap();
         }
     }
 
@@ -171,15 +175,14 @@ mod contract {
     #[no_mangle]
     pub extern "C" fn get_chain_id() {
         let mut io = Runtime;
-        io.return_output(&state::get_state(&io).sdk_unwrap().chain_id)
+        io.return_output(&state::get_state(&io).sdk_unwrap().chain_id);
     }
 
     #[no_mangle]
     pub extern "C" fn get_upgrade_index() {
         let mut io = Runtime;
-        let state = state::get_state(&io).sdk_unwrap();
         let index = internal_get_upgrade_index();
-        io.return_output(&(index + state.upgrade_delay_blocks).to_le_bytes())
+        io.return_output(&index.to_le_bytes());
     }
 
     /// Stage new code for deployment.
@@ -187,12 +190,12 @@ mod contract {
     pub extern "C" fn stage_upgrade() {
         let mut io = Runtime;
         let state = state::get_state(&io).sdk_unwrap();
-        let block_height = io.block_height();
+        let delay_block_height = io.block_height() + state.upgrade_delay_blocks;
         require_owner_only(&state, &io.predecessor_account_id());
         io.read_input_and_store(&bytes_to_key(KeyPrefix::Config, CODE_KEY));
         io.write_storage(
             &bytes_to_key(KeyPrefix::Config, CODE_STAGE_KEY),
-            &block_height.to_le_bytes(),
+            &delay_block_height.to_le_bytes(),
         );
     }
 
@@ -203,7 +206,7 @@ mod contract {
         let state = state::get_state(&io).sdk_unwrap();
         require_owner_only(&state, &io.predecessor_account_id());
         let index = internal_get_upgrade_index();
-        if io.block_height() <= index + state.upgrade_delay_blocks {
+        if io.block_height() <= index {
             sdk::panic_utf8(errors::ERR_NOT_ALLOWED_TOO_EARLY);
         }
         Runtime::self_deploy(&bytes_to_key(KeyPrefix::Config, CODE_KEY));
@@ -213,6 +216,7 @@ mod contract {
     /// to make any necessary changes to the state such that it aligns with the newly deployed
     /// code.
     #[no_mangle]
+    #[allow(clippy::missing_const_for_fn)]
     pub extern "C" fn state_migration() {
         // TODO: currently we don't have migrations
     }
@@ -241,7 +245,7 @@ mod contract {
         let authorizer: pausables::EngineAuthorizer = engine::get_authorizer();
 
         if !authorizer.is_authorized(&io.predecessor_account_id()) {
-            sdk::panic_utf8("ERR_UNAUTHORIZED".as_bytes());
+            sdk::panic_utf8(b"ERR_UNAUTHORIZED");
         }
 
         let args: PausePrecompilesCallArgs = io.read_input_borsh().sdk_unwrap();
@@ -317,18 +321,46 @@ mod contract {
     }
 
     /// Process signed Ethereum transaction.
-    /// Must match CHAIN_ID to make sure it's signed for given chain vs replayed from another chain.
+    /// Must match `CHAIN_ID` to make sure it's signed for given chain vs replayed from another chain.
     #[no_mangle]
     pub extern "C" fn submit() {
         let io = Runtime;
-        let input = io.read_input().to_vec();
+        let tx_data = io.read_input().to_vec();
+        let current_account_id = io.current_account_id();
+        let state = state::get_state(&io).sdk_unwrap();
+        let relayer_address = predecessor_address(&io.predecessor_account_id());
+        let args = SubmitArgs {
+            tx_data,
+            ..Default::default()
+        };
+        let result = engine::submit(
+            io,
+            &io,
+            &args,
+            state,
+            current_account_id,
+            relayer_address,
+            &mut Runtime,
+        );
+
+        result
+            .map(|res| res.try_to_vec().sdk_expect(errors::ERR_SERIALIZE))
+            .sdk_process();
+    }
+
+    /// Analog of the `submit` function, but waits for the `SubmitArgs` structure rather than
+    /// the array of bytes representing the transaction.
+    #[no_mangle]
+    pub extern "C" fn submit_with_args() {
+        let io = Runtime;
+        let args: SubmitArgs = io.read_input_borsh().sdk_unwrap();
         let current_account_id = io.current_account_id();
         let state = state::get_state(&io).sdk_unwrap();
         let relayer_address = predecessor_address(&io.predecessor_account_id());
         let result = engine::submit(
             io,
             &io,
-            &input,
+            &args,
             state,
             current_account_id,
             relayer_address,
@@ -390,7 +422,7 @@ mod contract {
         crate::xcc::set_code_version_of_address(&mut io, &args.address, args.version);
     }
 
-    /// Sets the address for the wNEAR ERC-20 contract. This contract will be used by the
+    /// Sets the address for the `wNEAR` ERC-20 contract. This contract will be used by the
     /// cross-contract calls feature to have users pay for their NEAR transactions.
     #[no_mangle]
     pub extern "C" fn factory_set_wnear_address() {
@@ -477,7 +509,7 @@ mod contract {
             let args: RefundCallArgs = io.read_input_borsh().sdk_unwrap();
             let state = state::get_state(&io).sdk_unwrap();
             let refund_result =
-                engine::refund_on_error(io, &io, state, args, &mut Runtime).sdk_unwrap();
+                engine::refund_on_error(io, &io, state, &args, &mut Runtime).sdk_unwrap();
 
             if !refund_result.status.is_ok() {
                 sdk::panic_utf8(errors::ERR_REFUND_FAILURE);
@@ -509,7 +541,7 @@ mod contract {
             .sdk_unwrap();
         let block_hash =
             crate::engine::compute_block_hash(chain_id, block_height, account_id.as_bytes());
-        io.return_output(block_hash.as_bytes())
+        io.return_output(block_hash.as_bytes());
     }
 
     #[no_mangle]
@@ -517,7 +549,7 @@ mod contract {
         let mut io = Runtime;
         let address = io.read_input_arr20().sdk_unwrap();
         let code = engine::get_code(&io, &Address::from_array(address));
-        io.return_output(&code)
+        io.return_output(&code);
     }
 
     #[no_mangle]
@@ -525,7 +557,7 @@ mod contract {
         let mut io = Runtime;
         let address = io.read_input_arr20().sdk_unwrap();
         let balance = engine::get_balance(&io, &Address::from_array(address));
-        io.return_output(&balance.to_bytes())
+        io.return_output(&balance.to_bytes());
     }
 
     #[no_mangle]
@@ -533,7 +565,7 @@ mod contract {
         let mut io = Runtime;
         let address = io.read_input_arr20().sdk_unwrap();
         let nonce = engine::get_nonce(&io, &Address::from_array(address));
-        io.return_output(&u256_to_arr(&nonce))
+        io.return_output(&u256_to_arr(&nonce));
     }
 
     #[no_mangle]
@@ -543,7 +575,7 @@ mod contract {
         let address = args.address;
         let generation = engine::get_generation(&io, &address);
         let value = engine::get_storage(&io, &args.address, &H256(args.key), generation);
-        io.return_output(&value.0)
+        io.return_output(&value.0);
     }
 
     ///
@@ -558,17 +590,17 @@ mod contract {
         require_owner_only(&state, &io.predecessor_account_id());
         let args: BeginChainArgs = io.read_input_borsh().sdk_unwrap();
         state.chain_id = args.chain_id;
-        state::set_state(&mut io, state).sdk_unwrap();
+        state::set_state(&mut io, &state).sdk_unwrap();
         // set genesis block balances
         for account_balance in args.genesis_alloc {
             engine::set_balance(
                 &mut io,
                 &account_balance.address,
                 &crate::prelude::Wei::new(U256::from(account_balance.balance)),
-            )
+            );
         }
         // return new chain ID
-        io.return_output(&state::get_state(&io).sdk_unwrap().chain_id)
+        io.return_output(&state::get_state(&io).sdk_unwrap().chain_id);
     }
 
     #[cfg(feature = "evm_bully")]
@@ -594,7 +626,7 @@ mod contract {
         let args: InitCallArgs = io.read_input_borsh().sdk_unwrap();
         let owner_id = io.current_account_id();
 
-        EthConnectorContract::create_contract(io, owner_id, args).sdk_unwrap();
+        EthConnectorContract::create_contract(io, &owner_id, args).sdk_unwrap();
     }
 
     #[no_mangle]
@@ -620,7 +652,7 @@ mod contract {
         let predecessor_account_id = io.predecessor_account_id();
         let result = EthConnectorContract::init_instance(io)
             .sdk_unwrap()
-            .withdraw_eth_from_near(&current_account_id, &predecessor_account_id, args)
+            .withdraw_eth_from_near(&current_account_id, &predecessor_account_id, &args)
             .sdk_unwrap();
         let result_bytes = result.try_to_vec().sdk_expect(errors::ERR_SERIALIZE);
         // We intentionally do not go through the `io` struct here because we must bypass
@@ -699,7 +731,7 @@ mod contract {
 
         let is_used_proof = EthConnectorContract::init_instance(io)
             .sdk_unwrap()
-            .is_used_proof(args.proof);
+            .is_used_proof(&args.proof);
         let res = is_used_proof.try_to_vec().unwrap();
         io.return_output(&res[..]);
     }
@@ -736,7 +768,7 @@ mod contract {
             .sdk_unwrap();
         EthConnectorContract::init_instance(io)
             .sdk_unwrap()
-            .ft_balance_of(args);
+            .ft_balance_of(&args);
     }
 
     #[no_mangle]
@@ -745,7 +777,7 @@ mod contract {
         let args: parameters::BalanceOfEthCallArgs = io.read_input().to_value().sdk_unwrap();
         EthConnectorContract::init_instance(io)
             .sdk_unwrap()
-            .ft_balance_of_eth_on_aurora(args)
+            .ft_balance_of_eth_on_aurora(&args)
             .sdk_unwrap();
     }
 
@@ -759,7 +791,7 @@ mod contract {
             .sdk_unwrap();
         EthConnectorContract::init_instance(io)
             .sdk_unwrap()
-            .ft_transfer(&predecessor_account_id, args)
+            .ft_transfer(&predecessor_account_id, &args)
             .sdk_unwrap();
     }
 
@@ -777,7 +809,7 @@ mod contract {
 
         EthConnectorContract::init_instance(io)
             .sdk_unwrap()
-            .ft_resolve_transfer(args, promise_result);
+            .ft_resolve_transfer(&args, promise_result);
     }
 
     #[no_mangle]
@@ -853,8 +885,8 @@ mod contract {
         let predecessor_account_id = io.predecessor_account_id();
         EthConnectorContract::init_instance(io)
             .sdk_unwrap()
-            .storage_withdraw(&predecessor_account_id, args)
-            .sdk_unwrap()
+            .storage_withdraw(&predecessor_account_id, &args)
+            .sdk_unwrap();
     }
 
     #[no_mangle]
@@ -866,7 +898,7 @@ mod contract {
                 .sdk_unwrap();
         EthConnectorContract::init_instance(io)
             .sdk_unwrap()
-            .storage_balance_of(args)
+            .storage_balance_of(&args);
     }
 
     #[no_mangle]
@@ -890,7 +922,7 @@ mod contract {
         let args: PauseEthConnectorCallArgs = io.read_input_borsh().sdk_unwrap();
         EthConnectorContract::init_instance(io)
             .sdk_unwrap()
-            .set_paused_flags(args);
+            .set_paused_flags(&args);
     }
 
     #[no_mangle]
@@ -931,7 +963,7 @@ mod contract {
         let mut io = Runtime;
         let metadata: FungibleTokenMetadata = connector::get_metadata(&io).unwrap_or_default();
         let bytes = serde_json::to_vec(&metadata).unwrap_or_default();
-        io.return_output(&bytes)
+        io.return_output(&bytes);
     }
 
     #[cfg(feature = "integration-test")]
@@ -948,7 +980,7 @@ mod contract {
     #[no_mangle]
     pub extern "C" fn mint_account() {
         use crate::connector::ZERO_ATTACHED_BALANCE;
-        use crate::prelude::{NEP141Wei, ToString, U256};
+        use crate::prelude::{NEP141Wei, U256};
         use evm::backend::ApplyBackend;
         const GAS_FOR_VERIFY: NearGas = NearGas::new(20_000_000_000_000);
         const GAS_FOR_FINISH: NearGas = NearGas::new(50_000_000_000_000);
@@ -985,14 +1017,14 @@ mod contract {
         };
         let verify_call = aurora_engine_types::parameters::PromiseCreateArgs {
             target_account_id: aurora_account_id.clone(),
-            method: "verify_log_entry".to_string(),
+            method: crate::prelude::String::from("verify_log_entry"),
             args: crate::prelude::Vec::new(),
             attached_balance: ZERO_ATTACHED_BALANCE,
             attached_gas: GAS_FOR_VERIFY,
         };
         let finish_call = aurora_engine_types::parameters::PromiseCreateArgs {
             target_account_id: aurora_account_id,
-            method: "finish_deposit".to_string(),
+            method: crate::prelude::String::from("finish_deposit"),
             args: args.try_to_vec().unwrap(),
             attached_balance: ZERO_ATTACHED_BALANCE,
             attached_gas: GAS_FOR_FINISH,


### PR DESCRIPTION
The engine initialisation function `new() `is not limited in the number of times it may be called by the owner.

Recommendation:

Only allow `new() `to be called once at deployment.