### PR TITLE
Fix: Use the transfer-accept pattern for ownership transfer.

### DIFF
--- a/engine-standalone-storage/src/relayer_db/mod.rs
+++ b/engine-standalone-storage/src/relayer_db/mod.rs
@@ -217,6 +217,7 @@ mod test {
         let mut connection = super::connect_without_tls(&ConnectionParams::default()).unwrap();
         let engine_state = state::EngineState {
             chain_id: aurora_engine_types::types::u256_to_arr(&1_313_161_555.into()),
+            proposed_owner_id: "aurora".parse().unwrap(),
             owner_id: "aurora".parse().unwrap(),
             bridge_prover_id: "prover.bridge.near".parse().unwrap(),
             upgrade_delay_blocks: 0,

--- a/engine-tests/src/test_utils/mod.rs
+++ b/engine-tests/src/test_utils/mod.rs
@@ -662,6 +662,7 @@ pub fn deploy_evm() -> AuroraRunner {
     let mut runner = AuroraRunner::default();
     let args = NewCallArgs {
         chain_id: crate::prelude::u256_to_arr(&U256::from(runner.chain_id)),
+        proposed_owner_id: str_to_account_id(runner.aurora_account_id.as_str()),
         owner_id: str_to_account_id(runner.aurora_account_id.as_str()),
         bridge_prover_id: str_to_account_id("bridge_prover.near"),
         upgrade_delay_blocks: 1,

--- a/engine-tests/src/test_utils/standalone/mocks/mod.rs
+++ b/engine-tests/src/test_utils/standalone/mocks/mod.rs
@@ -51,6 +51,7 @@ pub fn default_env(block_height: u64) -> aurora_engine_sdk::env::Fixed {
 pub fn init_evm<I: IO + Copy, E: Env>(mut io: I, env: &E, chain_id: u64) {
     let new_args = NewCallArgs {
         chain_id: aurora_engine_types::types::u256_to_arr(&U256::from(chain_id)),
+        proposed_owner_id: env.current_account_id(),
         owner_id: env.current_account_id(),
         bridge_prover_id: test_utils::str_to_account_id("bridge_prover.near"),
         upgrade_delay_blocks: 1,

--- a/engine-tests/src/tests/eth_connector.rs
+++ b/engine-tests/src/tests/eth_connector.rs
@@ -70,6 +70,7 @@ fn init_contract(
             "new",
             &NewCallArgs {
                 chain_id: [0u8; 32],
+                proposed_owner_id: str_to_account_id(master_account.account_id.clone().as_str()),
                 owner_id: str_to_account_id(master_account.account_id.clone().as_str()),
                 bridge_prover_id: str_to_account_id(accounts(0).as_str()),
                 upgrade_delay_blocks: 1,

--- a/engine-tests/src/tests/sanity.rs
+++ b/engine-tests/src/tests/sanity.rs
@@ -135,6 +135,7 @@ fn test_state_format() {
     // break the contract unless we do a state migration.
     let args = aurora_engine::parameters::NewCallArgs {
         chain_id: aurora_engine_types::types::u256_to_arr(&666.into()),
+        proposed_owner_id: "boss".parse().unwrap(),
         owner_id: "boss".parse().unwrap(),
         bridge_prover_id: "prover_mcprovy_face".parse().unwrap(),
         upgrade_delay_blocks: 3,

--- a/engine-tests/src/tests/standalone/sanity.rs
+++ b/engine-tests/src/tests/standalone/sanity.rs
@@ -17,6 +17,7 @@ fn test_deploy_code() {
     let owner_id: AccountId = "aurora".parse().unwrap();
     let state = state::EngineState {
         chain_id,
+        proposed_owner_id: owner_id.clone(),
         owner_id: owner_id.clone(),
         bridge_prover_id: "mr_the_prover".parse().unwrap(),
         upgrade_delay_blocks: 0,

--- a/engine-tests/src/tests/state_migration.rs
+++ b/engine-tests/src/tests/state_migration.rs
@@ -41,6 +41,7 @@ pub fn deploy_evm() -> AuroraAccount {
     let prover_account = str_to_account_id("prover.near");
     let new_args = NewCallArgs {
         chain_id: crate::prelude::u256_to_arr(&U256::from(aurora_runner.chain_id)),
+        proposed_owner_id: str_to_account_id(main_account.account_id.as_str()),
         owner_id: str_to_account_id(main_account.account_id.as_str()),
         bridge_prover_id: prover_account.clone(),
         upgrade_delay_blocks: 1,

--- a/engine/src/parameters.rs
+++ b/engine/src/parameters.rs
@@ -16,6 +16,8 @@ use serde::{Deserialize, Serialize};
 pub struct NewCallArgs {
     /// Chain id, according to the EIP-115 / ethereum-lists spec.
     pub chain_id: RawU256,
+    /// Account which can claim ownership
+    pub proposed_owner_id: AccountId,
     /// Account which can upgrade this contract.
     /// Use empty to disable updatability.
     pub owner_id: AccountId,

--- a/engine/src/state.rs
+++ b/engine/src/state.rs
@@ -15,6 +15,8 @@ const STATE_KEY: &[u8; 5] = b"STATE";
 pub struct EngineState {
     /// Chain id, according to the EIP-155 / ethereum-lists spec.
     pub chain_id: [u8; 32],
+    /// Account which can claim ownership
+    pub proposed_owner_id: AccountId,
     /// Account which can upgrade this contract.
     /// Use empty to disable updatability.
     pub owner_id: AccountId,
@@ -29,6 +31,7 @@ impl From<NewCallArgs> for EngineState {
     fn from(args: NewCallArgs) -> Self {
         Self {
             chain_id: args.chain_id,
+            proposed_owner_id: args.proposed_owner_id,
             owner_id: args.owner_id,
             bridge_prover_id: args.bridge_prover_id,
             upgrade_delay_blocks: args.upgrade_delay_blocks,


### PR DESCRIPTION
Use the transfer-accept pattern for ownership transfer.

This is implemented by adding a `proposed_owner_id` field to the `EngineState` struct.
The current `owner_id` account can then proposed a new owner, and said new owner can accept ownership.