### PR TITLE
Chore: update to borsh version 0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
  "aurora-engine-transactions",
  "aurora-engine-types",
  "bitflags",
- "borsh",
+ "borsh 0.10.2",
  "byte-slice-cast",
  "digest 0.10.6",
  "ethabi",
@@ -164,7 +164,7 @@ dependencies = [
  "aurora-engine-sdk",
  "aurora-engine-test-doubles",
  "aurora-engine-types",
- "borsh",
+ "borsh 0.10.2",
  "ethabi",
  "evm",
  "hex",
@@ -185,7 +185,7 @@ version = "1.0.0"
 dependencies = [
  "aurora-engine-types",
  "base64 0.21.0",
- "borsh",
+ "borsh 0.10.2",
  "sha2 0.10.6",
  "sha3",
 ]
@@ -211,7 +211,7 @@ dependencies = [
  "aurora-engine-test-doubles",
  "aurora-engine-transactions",
  "aurora-engine-types",
- "borsh",
+ "borsh 0.10.2",
  "bstr",
  "byte-slice-cast",
  "criterion",
@@ -258,7 +258,8 @@ dependencies = [
 name = "aurora-engine-types"
 version = "1.0.0"
 dependencies = [
- "borsh",
+ "borsh 0.10.2",
+ "borsh 0.9.3",
  "hex",
  "primitive-types 0.12.1",
  "rand 0.8.5",
@@ -408,8 +409,18 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15bf3650200d8bffa99015595e10f1fbd17de07abbc25bb067da79e769939bfa"
 dependencies = [
- "borsh-derive",
+ "borsh-derive 0.9.3",
  "hashbrown 0.11.2",
+]
+
+[[package]]
+name = "borsh"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40f9ca3698b2e4cb7c15571db0abc5551dca417a21ae8140460b50309bb2cc62"
+dependencies = [
+ "borsh-derive 0.10.2",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -418,8 +429,21 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6441c552f230375d18e3cc377677914d2ca2b0d36e52129fe15450a2dce46775"
 dependencies = [
- "borsh-derive-internal",
- "borsh-schema-derive-internal",
+ "borsh-derive-internal 0.9.3",
+ "borsh-schema-derive-internal 0.9.3",
+ "proc-macro-crate 0.1.5",
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598b3eacc6db9c3ee57b22707ad8f6a8d2f6d442bfe24ffeb8cbb70ca59e6a35"
+dependencies = [
+ "borsh-derive-internal 0.10.2",
+ "borsh-schema-derive-internal 0.10.2",
  "proc-macro-crate 0.1.5",
  "proc-macro2",
  "syn",
@@ -437,10 +461,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh-derive-internal"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186b734fa1c9f6743e90c95d7233c9faab6360d1a96d4ffa19d9cfd1e9350f8a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "borsh-schema-derive-internal"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "borsh-schema-derive-internal"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b7ff1008316626f485991b960ade129253d4034014616b94f309a15366cc49"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1172,7 +1218,7 @@ dependencies = [
  "aurora-engine-sdk",
  "aurora-engine-transactions",
  "aurora-engine-types",
- "borsh",
+ "borsh 0.10.2",
  "evm-core",
  "hex",
  "postgres",
@@ -2354,7 +2400,7 @@ name = "near-account-id"
 version = "0.0.0"
 source = "git+https://github.com/birchmd/nearcore.git?rev=6033903be2037d67510188450f289b2d6e033f04#6033903be2037d67510188450f289b2d6e033f04"
 dependencies = [
- "borsh",
+ "borsh 0.9.3",
  "serde",
 ]
 
@@ -2391,7 +2437,7 @@ source = "git+https://github.com/birchmd/nearcore.git?rev=6033903be2037d67510188
 dependencies = [
  "arrayref",
  "blake2",
- "borsh",
+ "borsh 0.9.3",
  "bs58",
  "c2-chacha",
  "curve25519-dalek",
@@ -2436,7 +2482,7 @@ name = "near-pool"
 version = "0.0.0"
 source = "git+https://github.com/birchmd/nearcore.git?rev=6033903be2037d67510188450f289b2d6e033f04#6033903be2037d67510188450f289b2d6e033f04"
 dependencies = [
- "borsh",
+ "borsh 0.9.3",
  "near-crypto",
  "near-o11y",
  "near-primitives",
@@ -2449,7 +2495,7 @@ name = "near-primitives"
 version = "0.0.0"
 source = "git+https://github.com/birchmd/nearcore.git?rev=6033903be2037d67510188450f289b2d6e033f04#6033903be2037d67510188450f289b2d6e033f04"
 dependencies = [
- "borsh",
+ "borsh 0.9.3",
  "byteorder",
  "bytesize",
  "cfg-if 1.0.0",
@@ -2479,7 +2525,7 @@ version = "0.0.0"
 source = "git+https://github.com/birchmd/nearcore.git?rev=6033903be2037d67510188450f289b2d6e033f04#6033903be2037d67510188450f289b2d6e033f04"
 dependencies = [
  "base64 0.13.1",
- "borsh",
+ "borsh 0.9.3",
  "bs58",
  "derive_more",
  "near-account-id",
@@ -2516,7 +2562,7 @@ version = "3.1.0"
 source = "git+https://github.com/aurora-is-near/near-sdk-rs.git?rev=a4634850023fd115053970f17e10861779d5167d#a4634850023fd115053970f17e10861779d5167d"
 dependencies = [
  "base64 0.13.1",
- "borsh",
+ "borsh 0.9.3",
  "bs58",
  "near-primitives-core",
  "near-sdk-macros",
@@ -2577,7 +2623,7 @@ version = "0.0.0"
 source = "git+https://github.com/birchmd/nearcore.git?rev=6033903be2037d67510188450f289b2d6e033f04#6033903be2037d67510188450f289b2d6e033f04"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.9.3",
  "byteorder",
  "bytesize",
  "crossbeam",
@@ -2608,7 +2654,7 @@ name = "near-vm-errors"
 version = "0.0.0"
 source = "git+https://github.com/birchmd/nearcore.git?rev=6033903be2037d67510188450f289b2d6e033f04#6033903be2037d67510188450f289b2d6e033f04"
 dependencies = [
- "borsh",
+ "borsh 0.9.3",
  "near-account-id",
  "near-rpc-error-macro",
  "serde",
@@ -2620,7 +2666,7 @@ name = "near-vm-logic"
 version = "0.0.0"
 source = "git+https://github.com/birchmd/nearcore.git?rev=6033903be2037d67510188450f289b2d6e033f04#6033903be2037d67510188450f289b2d6e033f04"
 dependencies = [
- "borsh",
+ "borsh 0.9.3",
  "bs58",
  "byteorder",
  "ed25519-dalek",
@@ -2643,7 +2689,7 @@ version = "0.0.0"
 source = "git+https://github.com/birchmd/nearcore.git?rev=6033903be2037d67510188450f289b2d6e033f04#6033903be2037d67510188450f289b2d6e033f04"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.9.3",
  "loupe",
  "memoffset 0.6.5",
  "near-cache",
@@ -2687,7 +2733,7 @@ name = "node-runtime"
 version = "0.0.0"
 source = "git+https://github.com/birchmd/nearcore.git?rev=6033903be2037d67510188450f289b2d6e033f04#6033903be2037d67510188450f289b2d6e033f04"
 dependencies = [
- "borsh",
+ "borsh 0.9.3",
  "byteorder",
  "hex",
  "near-chain-configs",
@@ -4904,7 +4950,7 @@ checksum = "5a3fac37da3c625e98708c5dd92d3f642aaf700fd077168d3d0fff277ec6a165"
 dependencies = [
  "bincode",
  "blake3",
- "borsh",
+ "borsh 0.9.3",
  "cc",
  "digest 0.8.1",
  "errno",
@@ -4947,7 +4993,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6edd0ba6c0bcf9b279186d4dbe81649dda3e5ef38f586865943de4dcd653f8"
 dependencies = [
  "bincode",
- "borsh",
+ "borsh 0.9.3",
  "byteorder",
  "dynasm",
  "dynasmrt",
@@ -5341,7 +5387,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e61de68ede9ffdd69c01664f65a178c5188b73f78faa21f0936016a888ff7c"
 dependencies = [
- "borsh",
+ "borsh 0.9.3",
  "byteorder",
  "crunchy",
  "lazy_static",

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -82,7 +82,53 @@ command = "${CARGO}"
 args = [
     "clippy",
     "--all-targets",
-    "--all-features",
+    "--",
+    "-D",
+    "warnings",
+    "-D",
+    "clippy::as_conversions",
+]
+
+[tasks.clippy-contract]
+category = "Check"
+command = "${CARGO}"
+args = [
+    "clippy",
+    "--all-targets",
+    "--features",
+    "contract",
+    "--",
+    "-D",
+    "warnings",
+    "-D",
+    "clippy::as_conversions",
+]
+
+[tasks.clippy-contract-refund]
+category = "Check"
+command = "${CARGO}"
+args = [
+    "clippy",
+    "--all-targets",
+    "--features",
+    "contract,error_refund",
+    "--",
+    "-D",
+    "warnings",
+    "-D",
+    "clippy::as_conversions",
+]
+
+[tasks.clippy-borsh-compat]
+category = "Check"
+command = "${CARGO}"
+args = [
+    "clippy",
+    "-p",
+    "aurora-engine-types",
+    "--all-targets",
+    "--features",
+    "borsh-compat",
     "--",
     "-D",
     "warnings",
@@ -113,6 +159,9 @@ dependencies = [
     "check-contracts",
     "check-fmt",
     "clippy",
+    "clippy-contract",
+    "clippy-contract-refund",
+    "clippy-borsh-compat",
     "udeps",
 ]
 

--- a/engine-precompiles/Cargo.toml
+++ b/engine-precompiles/Cargo.toml
@@ -15,7 +15,7 @@ autobenches = false
 [dependencies]
 aurora-engine-types = { path = "../engine-types", default-features = false }
 aurora-engine-sdk = { path = "../engine-sdk", default-features = false }
-borsh = { version = "0.9.3", default-features = false }
+borsh = { version = "0.10", default-features = false }
 bn = { version = "0.5.11", package = "zeropool-bn", default-features = false }
 evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.4-aurora", default-features = false }
 libsecp256k1 = { version = "0.7.0", default-features = false, features = ["static-context", "hmac"] }

--- a/engine-sdk/Cargo.toml
+++ b/engine-sdk/Cargo.toml
@@ -16,7 +16,7 @@ autobenches = false
 aurora-engine-types = { path = "../engine-types", default-features = false }
 
 base64 = { version = "0.21", default-features = false, features = [ "alloc" ] }
-borsh = { version = "0.9", default-features = false }
+borsh = { version = "0.10", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 sha3 = { version = "0.10", default-features = false }
 

--- a/engine-standalone-storage/Cargo.toml
+++ b/engine-standalone-storage/Cargo.toml
@@ -19,7 +19,7 @@ aurora-engine-types = { path = "../engine-types", default-features = false, feat
 aurora-engine-sdk = { path = "../engine-sdk", default-features = false, features = ["std"] }
 aurora-engine-transactions = { path = "../engine-transactions", default-features = false, features = ["std"] }
 aurora-engine-precompiles = { path = "../engine-precompiles", default-features = false, features = ["std"] }
-borsh = "0.9"
+borsh = "0.10"
 evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.4-aurora", default-features = false }
 hex = "0.4.3"
 rocksdb = { version = "0.19.0", default-features = false }

--- a/engine-tests/Cargo.toml
+++ b/engine-tests/Cargo.toml
@@ -23,7 +23,7 @@ aurora-engine-precompiles = { path = "../engine-precompiles", default-features =
 aurora-engine-transactions = { path = "../engine-transactions", default-features = false, features = ["std", "impl-serde"] }
 engine-standalone-storage = { path = "../engine-standalone-storage" }
 engine-standalone-tracing = { path = "../engine-standalone-tracing", default-features = false, features = ["impl-serde"] }
-borsh = { version = "0.9.3", default-features = false }
+borsh = { version = "0.10", default-features = false }
 sha3 = { version = "0.10.2", default-features = false }
 evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.4-aurora", default-features = false, features = ["std", "tracing"] }
 evm-runtime = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.4-aurora", default-features = false, features = ["std", "tracing"] }

--- a/engine-tests/src/tests/erc20_connector.rs
+++ b/engine-tests/src/tests/erc20_connector.rs
@@ -682,7 +682,12 @@ pub mod sim_tests {
         // deploy contract with simple exit to near method
         let constructor = TesterConstructor::load();
         let deploy_data = constructor.deploy(0, Address::zero()).data;
-        let submit_result: SubmitResult = aurora.call("deploy_code", &deploy_data).unwrap_borsh();
+        let submit_result = match aurora.call("deploy_code", &deploy_data).status() {
+            near_primitives::transaction::ExecutionStatus::SuccessValue(bytes) => {
+                SubmitResult::try_from_slice(&bytes).unwrap()
+            }
+            other => panic!("Unexpected status {other:?}"),
+        };
         let tester_address =
             Address::try_from_slice(&test_utils::unwrap_success(submit_result)).unwrap();
 
@@ -852,7 +857,12 @@ pub mod sim_tests {
             input: balance_tx.data,
         });
         let result = aurora.call("call", &call_args.try_to_vec().unwrap());
-        let submit_result: SubmitResult = result.unwrap_borsh();
+        let submit_result = match result.status() {
+            near_primitives::transaction::ExecutionStatus::SuccessValue(bytes) => {
+                SubmitResult::try_from_slice(&bytes).unwrap()
+            }
+            other => panic!("Unexpected status {other:?}"),
+        };
         U256::from_big_endian(&test_utils::unwrap_success(submit_result))
     }
 

--- a/engine-tests/src/tests/sanity.rs
+++ b/engine-tests/src/tests/sanity.rs
@@ -973,7 +973,13 @@ fn test_eth_transfer_insufficient_balance_sim() {
         &signer.secret_key,
     );
     let call_result = aurora.call("submit", rlp::encode(&signed_tx).as_ref());
-    let result: SubmitResult = call_result.unwrap_borsh();
+    let result = match call_result.status() {
+        near_primitives::transaction::ExecutionStatus::SuccessValue(bytes) => {
+            use borsh::BorshDeserialize;
+            SubmitResult::try_from_slice(&bytes).unwrap()
+        }
+        other => panic!("Unexpected status {other:?}"),
+    };
     assert_eq!(result.status, TransactionStatus::OutOfFund);
 
     // validate post-state

--- a/engine-tests/src/tests/xcc.rs
+++ b/engine-tests/src/tests/xcc.rs
@@ -549,7 +549,12 @@ fn submit_xcc_transaction(
         0,
     );
     result.assert_success();
-    let submit_result: aurora_engine::parameters::SubmitResult = result.unwrap_borsh();
+    let submit_result = match result.status() {
+        near_primitives::transaction::ExecutionStatus::SuccessValue(bytes) => {
+            aurora_engine::parameters::SubmitResult::try_from_slice(&bytes).unwrap()
+        }
+        other => panic!("Unexpected status {other:?}"),
+    };
     assert!(
         submit_result.status.is_ok(),
         "Unexpected result: {submit_result:?}",

--- a/engine-types/Cargo.toml
+++ b/engine-types/Cargo.toml
@@ -13,7 +13,8 @@ publish = false
 autobenches = false
 
 [dependencies]
-borsh = { version = "0.9.3", default-features = false }
+borsh = { version = "0.10", default-features = false }
+borsh-compat = { version = "0.9", package = "borsh", default-features = false, optional = true }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 primitive-types = { version = "0.12", default-features = false, features = ["rlp", "serde_no_std"] }
 serde = { version = "1", default-features = false, features = ["alloc", "derive"] }

--- a/engine-types/src/account_id.rs
+++ b/engine-types/src/account_id.rs
@@ -105,11 +105,10 @@ impl BorshDeserialize for AccountId {
 
         // It's for saving backward compatibility.
         if account.is_empty() {
-            return Ok(AccountId::default());
+            return Ok(Self::default());
         }
 
-        AccountId::new(&account)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))
+        Self::new(&account).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))
     }
 }
 

--- a/engine-types/src/account_id.rs
+++ b/engine-types/src/account_id.rs
@@ -112,7 +112,7 @@ impl BorshDeserialize for AccountId {
     }
 }
 
-#[cfg(not(not(feature = "borsh-compat")))]
+#[cfg(feature = "borsh-compat")]
 impl BorshDeserialize for AccountId {
     fn deserialize(buf: &mut &[u8]) -> io::Result<Self> {
         let account: String = BorshDeserialize::deserialize(buf)?;

--- a/engine-types/src/account_id.rs
+++ b/engine-types/src/account_id.rs
@@ -3,7 +3,10 @@
 //! Inspired by: `https://github.com/near/nearcore/tree/master/core/account-id`
 
 use crate::{fmt, str, str::FromStr, Box, String, ToString, Vec};
+#[cfg(not(feature = "borsh-compat"))]
 use borsh::{maybestd::io, BorshDeserialize, BorshSerialize};
+#[cfg(feature = "borsh-compat")]
+use borsh_compat::{self as borsh, maybestd::io, BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 
 pub const MIN_ACCOUNT_ID_LEN: usize = 2;
@@ -95,6 +98,22 @@ impl AccountId {
     }
 }
 
+#[cfg(not(feature = "borsh-compat"))]
+impl BorshDeserialize for AccountId {
+    fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
+        let account: String = BorshDeserialize::deserialize_reader(reader)?;
+
+        // It's for saving backward compatibility.
+        if account.is_empty() {
+            return Ok(AccountId::default());
+        }
+
+        AccountId::new(&account)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))
+    }
+}
+
+#[cfg(not(not(feature = "borsh-compat")))]
 impl BorshDeserialize for AccountId {
     fn deserialize(buf: &mut &[u8]) -> io::Result<Self> {
         let account: String = BorshDeserialize::deserialize(buf)?;

--- a/engine-types/src/parameters/engine.rs
+++ b/engine-types/src/parameters/engine.rs
@@ -3,7 +3,10 @@ use crate::{
     types::{Address, RawH256, RawU256, WeiU256},
     Vec,
 };
+#[cfg(not(feature = "borsh-compat"))]
 use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "borsh-compat")]
+use borsh_compat::{self as borsh, BorshDeserialize, BorshSerialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 #[cfg_attr(feature = "impl-serde", derive(serde::Serialize, serde::Deserialize))]

--- a/engine-types/src/parameters/mod.rs
+++ b/engine-types/src/parameters/mod.rs
@@ -177,19 +177,19 @@ impl BorshDeserialize for NearPromise {
         match variant_byte {
             0x00 => {
                 let inner = SimpleNearPromise::deserialize_reader(reader)?;
-                Ok(NearPromise::Simple(inner))
+                Ok(Self::Simple(inner))
             }
             0x01 => {
                 let base = Self::deserialize_reader(reader)?;
                 let callback = SimpleNearPromise::deserialize_reader(reader)?;
-                Ok(NearPromise::Then {
+                Ok(Self::Then {
                     base: Box::new(base),
                     callback,
                 })
             }
             0x02 => {
-                let promises: Vec<NearPromise> = Vec::deserialize_reader(reader)?;
-                Ok(NearPromise::And(promises))
+                let promises: Vec<Self> = Vec::deserialize_reader(reader)?;
+                Ok(Self::And(promises))
             }
             _ => Err(io::Error::new(
                 io::ErrorKind::InvalidInput,

--- a/engine-types/src/parameters/mod.rs
+++ b/engine-types/src/parameters/mod.rs
@@ -3,7 +3,10 @@ use crate::{
     types::{Address, NEP141Wei, NearGas, RawU256, Yocto},
     Box, String, Vec,
 };
+#[cfg(not(feature = "borsh-compat"))]
 use borsh::{maybestd::io, BorshDeserialize, BorshSerialize};
+#[cfg(feature = "borsh-compat")]
+use borsh_compat::{self as borsh, maybestd::io, BorshDeserialize, BorshSerialize};
 
 pub mod engine;
 
@@ -163,6 +166,40 @@ impl BorshSerialize for NearPromise {
     }
 }
 
+#[cfg(not(feature = "borsh-compat"))]
+impl BorshDeserialize for NearPromise {
+    fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
+        let variant_byte = {
+            let mut buf = [0u8; 1];
+            reader.read_exact(&mut buf)?;
+            buf[0]
+        };
+        match variant_byte {
+            0x00 => {
+                let inner = SimpleNearPromise::deserialize_reader(reader)?;
+                Ok(NearPromise::Simple(inner))
+            }
+            0x01 => {
+                let base = Self::deserialize_reader(reader)?;
+                let callback = SimpleNearPromise::deserialize_reader(reader)?;
+                Ok(NearPromise::Then {
+                    base: Box::new(base),
+                    callback,
+                })
+            }
+            0x02 => {
+                let promises: Vec<NearPromise> = Vec::deserialize_reader(reader)?;
+                Ok(NearPromise::And(promises))
+            }
+            _ => Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Invalid variant byte for NearPromise",
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "borsh-compat")]
 impl BorshDeserialize for NearPromise {
     fn deserialize(buf: &mut &[u8]) -> io::Result<Self> {
         let variant_byte = buf[0];

--- a/engine-types/src/storage.rs
+++ b/engine-types/src/storage.rs
@@ -1,5 +1,8 @@
 use crate::{types::Address, Vec, H256};
+#[cfg(not(feature = "borsh-compat"))]
 use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "borsh-compat")]
+use borsh_compat::{self as borsh, BorshDeserialize, BorshSerialize};
 
 // NOTE: We start at 0x7 as our initial value as our original storage was not
 // version prefixed and ended as 0x6.

--- a/engine-types/src/types/address.rs
+++ b/engine-types/src/types/address.rs
@@ -93,7 +93,7 @@ impl BorshDeserialize for Address {
 fn address_deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Address> {
     let mut buf = [0u8; 20];
     let maybe_read = reader.read_exact(&mut buf);
-    if let Some(io::ErrorKind::UnexpectedEof) = maybe_read.as_ref().err().map(|e| e.kind()) {
+    if maybe_read.as_ref().err().map(io::Error::kind) == Some(io::ErrorKind::UnexpectedEof) {
         return Err(io::Error::new(
             io::ErrorKind::Other,
             format!("{}", error::AddressError::IncorrectLength),

--- a/engine-types/src/types/balance.rs
+++ b/engine-types/src/types/balance.rs
@@ -1,6 +1,9 @@
 use crate::fmt::Formatter;
 use crate::{format, Add, Display, Sub, ToString};
+#[cfg(not(feature = "borsh-compat"))]
 use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "borsh-compat")]
+use borsh_compat::{self as borsh, BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 pub const ZERO_BALANCE: Balance = Balance::new(0);

--- a/engine-types/src/types/fee.rs
+++ b/engine-types/src/types/fee.rs
@@ -1,7 +1,10 @@
 use crate::fmt::Formatter;
 use crate::types::NEP141Wei;
 use crate::{Add, Display};
+#[cfg(not(feature = "borsh-compat"))]
 use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "borsh-compat")]
+use borsh_compat::{self as borsh, BorshDeserialize, BorshSerialize};
 
 #[derive(
     Default, Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, BorshSerialize, BorshDeserialize,

--- a/engine-types/src/types/gas.rs
+++ b/engine-types/src/types/gas.rs
@@ -1,6 +1,9 @@
 use crate::fmt::Formatter;
 use crate::{Add, AddAssign, Display, Div, Mul, Sub};
+#[cfg(not(feature = "borsh-compat"))]
 use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "borsh-compat")]
+use borsh_compat::{self as borsh, BorshDeserialize, BorshSerialize};
 use core::num::NonZeroU64;
 use serde::{Deserialize, Serialize};
 

--- a/engine-types/src/types/mod.rs
+++ b/engine-types/src/types/mod.rs
@@ -1,5 +1,8 @@
 use crate::{str, vec, String, Vec, U256};
+#[cfg(not(feature = "borsh-compat"))]
 use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "borsh-compat")]
+use borsh_compat::{self as borsh, BorshDeserialize, BorshSerialize};
 
 pub mod address;
 pub mod balance;

--- a/engine-types/src/types/wei.rs
+++ b/engine-types/src/types/wei.rs
@@ -2,7 +2,10 @@ use crate::fmt::Formatter;
 use crate::types::balance::error;
 use crate::types::Fee;
 use crate::{format, Add, Display, Sub, SubAssign, ToString, U256};
+#[cfg(not(feature = "borsh-compat"))]
 use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "borsh-compat")]
+use borsh_compat::{self as borsh, BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 pub const ZERO_NEP141_WEI: NEP141Wei = NEP141Wei::new(0);

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ aurora-engine-sdk = { path = "../engine-sdk", default-features = false }
 aurora-engine-precompiles = { path = "../engine-precompiles", default-features = false }
 aurora-engine-transactions = { path = "../engine-transactions", default-features = false }
 bitflags = { version = "1.3", default-features = false }
-borsh = { version = "0.9.3", default-features = false }
+borsh = { version = "0.10", default-features = false }
 byte-slice-cast = { version = "1.0", default-features = false }
 ethabi = { version = "18.0", default-features = false }
 evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.4-aurora", default-features = false }

--- a/etc/tests/self-contained-5bEgfRQ/Cargo.toml
+++ b/etc/tests/self-contained-5bEgfRQ/Cargo.toml
@@ -37,7 +37,7 @@ codegen-units = 1
 rpath = false
 
 [dependencies]
-borsh = { version = "0.9.3", default-features = false }
+borsh = { version = "0.10", default-features = false }
 aurora-engine = { path = "../../../engine", default-features = false }
 aurora-engine-sdk = { path = "../../../engine-sdk", default-features = false, features = ["contract"] }
 aurora-engine-types = { path = "../../../engine-types", default-features = false }

--- a/etc/tests/state-migration-test/Cargo.toml
+++ b/etc/tests/state-migration-test/Cargo.toml
@@ -37,7 +37,7 @@ codegen-units = 1
 rpath = false
 
 [dependencies]
-borsh = { version = "0.9.3", default-features = false }
+borsh = { version = "0.10", default-features = false }
 aurora-engine = { path = "../../../engine", default-features = false }
 aurora-engine-sdk = { path = "../../../engine-sdk", default-features = false, features = ["contract"] }
 aurora-engine-types = { path = "../../../engine-types", default-features = false }

--- a/etc/xcc-router/Cargo.lock
+++ b/etc/xcc-router/Cargo.lock
@@ -41,7 +41,8 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 name = "aurora-engine-types"
 version = "1.0.0"
 dependencies = [
- "borsh",
+ "borsh 0.10.2",
+ "borsh 0.9.3",
  "hex",
  "primitive-types 0.12.1",
  "serde",
@@ -120,7 +121,17 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15bf3650200d8bffa99015595e10f1fbd17de07abbc25bb067da79e769939bfa"
 dependencies = [
- "borsh-derive",
+ "borsh-derive 0.9.3",
+ "hashbrown",
+]
+
+[[package]]
+name = "borsh"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40f9ca3698b2e4cb7c15571db0abc5551dca417a21ae8140460b50309bb2cc62"
+dependencies = [
+ "borsh-derive 0.10.2",
  "hashbrown",
 ]
 
@@ -130,8 +141,21 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6441c552f230375d18e3cc377677914d2ca2b0d36e52129fe15450a2dce46775"
 dependencies = [
- "borsh-derive-internal",
- "borsh-schema-derive-internal",
+ "borsh-derive-internal 0.9.3",
+ "borsh-schema-derive-internal 0.9.3",
+ "proc-macro-crate 0.1.5",
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598b3eacc6db9c3ee57b22707ad8f6a8d2f6d442bfe24ffeb8cbb70ca59e6a35"
+dependencies = [
+ "borsh-derive-internal 0.10.2",
+ "borsh-schema-derive-internal 0.10.2",
  "proc-macro-crate 0.1.5",
  "proc-macro2",
  "syn",
@@ -149,10 +173,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh-derive-internal"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186b734fa1c9f6743e90c95d7233c9faab6360d1a96d4ffa19d9cfd1e9350f8a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "borsh-schema-derive-internal"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "borsh-schema-derive-internal"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b7ff1008316626f485991b960ade129253d4034014616b94f309a15366cc49"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -503,7 +549,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de83d74a9241be8cc4eb3055216966b58bf8c463e8e285c0dc553925acdd19fa"
 dependencies = [
- "borsh",
+ "borsh 0.9.3",
  "serde",
 ]
 
@@ -515,7 +561,7 @@ checksum = "b8ecf0b8b31aa7f4e60f629f72213a2617ca4a5f45cd1ae9ed2cf7cecfebdbb7"
 dependencies = [
  "arrayref",
  "blake2",
- "borsh",
+ "borsh 0.9.3",
  "bs58",
  "c2-chacha",
  "curve25519-dalek",
@@ -540,7 +586,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a2ba19282e79a4485a77736b679d276b09870bbf8042a18e0f0ae36347489c5"
 dependencies = [
- "borsh",
+ "borsh 0.9.3",
  "byteorder",
  "bytesize",
  "chrono",
@@ -570,7 +616,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb561feb392bb8c4f540256073446e6689af087bf6356e8dddcf75fc279f201f"
 dependencies = [
  "base64 0.11.0",
- "borsh",
+ "borsh 0.9.3",
  "bs58",
  "derive_more",
  "near-account-id",
@@ -609,7 +655,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda34e06e28fb9a09ac54efbdc49f0c9308780fc932aaa81c49c493fde974045"
 dependencies = [
  "base64 0.13.0",
- "borsh",
+ "borsh 0.9.3",
  "bs58",
  "near-crypto",
  "near-primitives",
@@ -646,7 +692,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e02faf2bc1f6ef82b965cfe44389808fb5594f7aca4b596766117f4ce74df20"
 dependencies = [
- "borsh",
+ "borsh 0.9.3",
  "near-account-id",
  "near-rpc-error-macro",
  "serde",
@@ -659,7 +705,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f024d90451cd3c24d7a0a5cabf3636b192a60eb8e3ff0456f6c18b91152c346d"
 dependencies = [
  "base64 0.13.0",
- "borsh",
+ "borsh 0.9.3",
  "bs58",
  "byteorder",
  "near-account-id",

--- a/etc/xcc-router/Cargo.toml
+++ b/etc/xcc-router/Cargo.toml
@@ -15,7 +15,7 @@ debug = false
 panic = "abort"
 
 [dependencies]
-aurora-engine-types = { path = "../../engine-types", default-features = false }
+aurora-engine-types = { path = "../../engine-types", default-features = false, features = ["borsh-compat"] }
 near-sdk = "4.0.0"
 
 [features]


### PR DESCRIPTION
## Description

This PR updates the Engine contract to use borsh version 0.10. This is needed because [nearcore now uses borsh v0.10](https://github.com/near/nearcore/blob/a6d14feb03af14912f9c6d41857fd4013c8654b8/Cargo.toml#L92) and [borealis-engine-lib](https://github.com/aurora-is-near/borealis-engine-lib) must use both Engine and nearcore types in the same project.

Unfortunately there is a complexity here where the latest [near-sdk still depends on borsh v0.9](https://github.com/near/near-sdk-rs/blob/89f8c2d776c8d00feb45239fdb15725527f1894b/near-sdk/Cargo.toml#L27). Therefore the `aurora-engine-types` crate which is used with near-sdk in some other Near contracts (for example XCC router), actually must support both versions of borsh until there is a new release of near-sdk. This is accomplished by having a `borsh-compat` feature flag in the types crate.

## Performance / NEAR gas cost considerations

N/A

## Testing

Existing tests.