### PR TITLE
Feat: allow creating and funding XCC sub-accounts from external NEAR accounts

### DIFF
--- a/engine-standalone-storage/src/sync/mod.rs
+++ b/engine-standalone-storage/src/sync/mod.rs
@@ -413,6 +413,12 @@ fn non_submit_execute<'db>(
 
             None
         }
+        TransactionKind::FundXccSubAccound(args) => {
+            let mut handler = crate::promise::NoScheduler { promise_data };
+            xcc::fund_xcc_sub_account(&io, &mut handler, &env, args.clone())?;
+
+            None
+        }
         TransactionKind::Unknown => None,
         // Not handled in this function; is handled by the general `execute_transaction` function
         TransactionKind::Submit(_) | TransactionKind::SubmitWithArgs(_) => unreachable!(),
@@ -468,7 +474,7 @@ pub enum TransactionExecutionResult {
 }
 
 pub mod error {
-    use aurora_engine::{connector, engine, fungible_token, state};
+    use aurora_engine::{connector, engine, fungible_token, state, xcc};
 
     #[derive(Debug)]
     pub enum Error {
@@ -484,6 +490,7 @@ pub mod error {
         InvalidAddress(aurora_engine_types::types::address::error::AddressError),
         ConnectorInit(connector::error::InitContractError),
         ConnectorStorage(connector::error::StorageReadError),
+        FundXccError(xcc::FundXccError),
     }
 
     impl From<state::EngineStateError> for Error {
@@ -555,6 +562,12 @@ pub mod error {
     impl From<connector::error::StorageReadError> for Error {
         fn from(e: connector::error::StorageReadError) -> Self {
             Self::ConnectorStorage(e)
+        }
+    }
+
+    impl From<xcc::FundXccError> for Error {
+        fn from(e: xcc::FundXccError) -> Self {
+            Self::FundXccError(e)
         }
     }
 }

--- a/engine-standalone-storage/src/sync/types.rs
+++ b/engine-standalone-storage/src/sync/types.rs
@@ -1,6 +1,6 @@
 use crate::Storage;
 use aurora_engine::parameters;
-use aurora_engine::xcc::AddressVersionUpdateArgs;
+use aurora_engine::xcc::{AddressVersionUpdateArgs, FundXccArgs};
 use aurora_engine_transactions::{EthTransactionKind, NormalizedEthTransaction};
 use aurora_engine_types::account_id::AccountId;
 use aurora_engine_types::types::Address;
@@ -128,6 +128,7 @@ pub enum TransactionKind {
     /// Update the version of a deployed xcc-router contract
     FactoryUpdateAddressVersion(AddressVersionUpdateArgs),
     FactorySetWNearAddress(Address),
+    FundXccSubAccound(FundXccArgs),
     /// Sentinel kind for cases where a NEAR receipt caused a
     /// change in Aurora state, but we failed to parse the Action.
     Unknown,
@@ -349,6 +350,7 @@ impl TransactionKind {
             Self::PausePrecompiles(_) => Self::no_evm_execution("pause_precompiles"),
             Self::ResumePrecompiles(_) => Self::no_evm_execution("resume_precompiles"),
             Self::SetOwner(_) => Self::no_evm_execution("set_owner"),
+            Self::FundXccSubAccound(_) => Self::no_evm_execution("fund_xcc_sub_account"),
         }
     }
 
@@ -516,6 +518,7 @@ enum BorshableTransactionKind<'a> {
     Unknown,
     SetOwner(Cow<'a, parameters::SetOwnerArgs>),
     SubmitWithArgs(Cow<'a, parameters::SubmitArgs>),
+    FundXccSubAccound(Cow<'a, FundXccArgs>),
 }
 
 impl<'a> From<&'a TransactionKind> for BorshableTransactionKind<'a> {
@@ -558,6 +561,7 @@ impl<'a> From<&'a TransactionKind> for BorshableTransactionKind<'a> {
             TransactionKind::PausePrecompiles(x) => Self::PausePrecompiles(Cow::Borrowed(x)),
             TransactionKind::ResumePrecompiles(x) => Self::ResumePrecompiles(Cow::Borrowed(x)),
             TransactionKind::SetOwner(x) => Self::SetOwner(Cow::Borrowed(x)),
+            TransactionKind::FundXccSubAccound(x) => Self::FundXccSubAccound(Cow::Borrowed(x)),
         }
     }
 }
@@ -617,6 +621,9 @@ impl<'a> TryFrom<BorshableTransactionKind<'a>> for TransactionKind {
                 Ok(Self::ResumePrecompiles(x.into_owned()))
             }
             BorshableTransactionKind::SetOwner(x) => Ok(Self::SetOwner(x.into_owned())),
+            BorshableTransactionKind::FundXccSubAccound(x) => {
+                Ok(Self::FundXccSubAccound(x.into_owned()))
+            }
         }
     }
 }

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -432,6 +432,22 @@ mod contract {
         crate::xcc::set_wnear_address(&mut io, &Address::from_array(address));
     }
 
+    /// Create and/or fund an XCC sub-account directly (as opposed to having one be automatically
+    /// created via the XCC precompile in the EVM). The purpose of this method is to enable
+    /// XCC on engine instances where wrapped NEAR (WNEAR) is not bridged.
+    #[no_mangle]
+    pub extern "C" fn fund_xcc_sub_account() {
+        let io = Runtime;
+        let state = state::get_state(&io).sdk_unwrap();
+        // This method can only be called by the owner because it allows specifying the
+        // account ID of the wNEAR account. This information must be accurate for the
+        // sub-account to work properly, therefore this method can only be called by
+        // a trusted user.
+        require_owner_only(&state, &io.predecessor_account_id());
+        let args: crate::xcc::FundXccArgs = io.read_input_borsh().sdk_unwrap();
+        crate::xcc::fund_xcc_sub_account(&io, &mut Runtime, &io, args).sdk_unwrap();
+    }
+
     /// Allow receiving NEP141 tokens to the EVM contract.
     ///
     /// This function returns the amount of tokens to return to the sender.

--- a/engine/src/xcc.rs
+++ b/engine/src/xcc.rs
@@ -91,6 +91,9 @@ where
 
             promise_actions.push(PromiseAction::CreateAccount);
         }
+        promise_actions.push(PromiseAction::Transfer {
+            amount: fund_amount,
+        });
         promise_actions.push(PromiseAction::DeployContract {
             code: get_router_code(io).0.into_owned(),
         });
@@ -115,12 +118,12 @@ where
             attached_yocto: ZERO_YOCTO,
             gas: INITIALIZE_GAS,
         });
+    } else {
+        // No matter what include the transfer of the funding amount
+        promise_actions.push(PromiseAction::Transfer {
+            amount: fund_amount,
+        });
     }
-
-    // No matter what include the transfer of the funding amount
-    promise_actions.push(PromiseAction::Transfer {
-        amount: fund_amount,
-    });
 
     let batch = PromiseBatchAction {
         target_account_id,

--- a/engine/src/xcc.rs
+++ b/engine/src/xcc.rs
@@ -340,6 +340,7 @@ pub fn set_code_version_of_address<I: IO>(io: &mut I, address: &Address, version
     io.write_storage(&key, &value_bytes);
 }
 
+#[derive(Debug, Clone, Copy)]
 pub enum FundXccError {
     InsufficientBalance,
     InvalidAccount,

--- a/engine/src/xcc.rs
+++ b/engine/src/xcc.rs
@@ -1,5 +1,6 @@
 use crate::parameters::{CallArgs, FunctionCallArgsV2};
 use aurora_engine_precompiles::xcc::state;
+use aurora_engine_sdk::env::Env;
 use aurora_engine_sdk::io::{StorageIntermediate, IO};
 use aurora_engine_sdk::promise::PromiseHandler;
 use aurora_engine_types::account_id::AccountId;
@@ -49,6 +50,107 @@ pub struct AddressVersionUpdateArgs {
     pub version: CodeVersion,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, BorshDeserialize, BorshSerialize)]
+pub struct FundXccArgs {
+    pub target: Address,
+    pub wnear_account_id: Option<AccountId>,
+}
+
+pub fn fund_xcc_sub_account<I, P, E>(
+    io: &I,
+    handler: &mut P,
+    env: &E,
+    args: FundXccArgs,
+) -> Result<(), FundXccError>
+where
+    P: PromiseHandler,
+    I: IO + Copy,
+    E: Env,
+{
+    let current_account_id = env.current_account_id();
+    let target_account_id = AccountId::new(&format!(
+        "{}.{}",
+        args.target.encode(),
+        current_account_id.as_ref()
+    ))?;
+
+    let latest_code_version = get_latest_code_version(io);
+    let target_code_version = get_code_version_of_address(io, &args.target);
+    let deploy_needed = AddressVersionStatus::new(latest_code_version, target_code_version);
+
+    let fund_amount = Yocto::new(env.attached_deposit());
+
+    let mut promise_actions = Vec::with_capacity(4);
+
+    // If account needs to be created and/or updated then include those actions.
+    if let AddressVersionStatus::DeployNeeded { create_needed } = deploy_needed {
+        if create_needed {
+            if fund_amount < STORAGE_AMOUNT {
+                return Err(FundXccError::InsufficientBalance);
+            }
+
+            promise_actions.push(PromiseAction::CreateAccount);
+        }
+        promise_actions.push(PromiseAction::DeployContract {
+            code: get_router_code(io).0.into_owned(),
+        });
+        // Either we need to assume it is set in the Engine or we need to accept it as input.
+        let wnear_account = args.wnear_account_id.unwrap_or_else(|| {
+            // If the wnear account is not specified then we must look it up based on the
+            // bridged token registry for the engine.
+            let wnear_address = get_wnear_address(io);
+            crate::engine::nep141_erc20_map(*io)
+                .lookup_right(&crate::engine::ERC20Address(wnear_address))
+                .unwrap()
+                .0
+        });
+        let init_args = format!(
+            r#"{{"wnear_account": "{}", "must_register": {}}}"#,
+            wnear_account.as_ref(),
+            create_needed,
+        );
+        promise_actions.push(PromiseAction::FunctionCall {
+            name: "initialize".into(),
+            args: init_args.into_bytes(),
+            attached_yocto: ZERO_YOCTO,
+            gas: INITIALIZE_GAS,
+        });
+    }
+
+    // No matter what include the transfer of the funding amount
+    promise_actions.push(PromiseAction::Transfer {
+        amount: fund_amount,
+    });
+
+    let batch = PromiseBatchAction {
+        target_account_id,
+        actions: promise_actions,
+    };
+    // Safety: same as safety in `handle_precompile_promise`
+    let promise_id = unsafe { handler.promise_create_batch(&batch) };
+
+    if let AddressVersionStatus::DeployNeeded { .. } = deploy_needed {
+        // If a create and/or deploy was needed then we must attach a callback to update
+        // the Engine's record of the account.
+
+        let args = AddressVersionUpdateArgs {
+            address: args.target,
+            version: latest_code_version,
+        };
+        let callback = PromiseCreateArgs {
+            target_account_id: current_account_id,
+            method: "factory_update_address_version".into(),
+            args: args.try_to_vec().unwrap(),
+            attached_balance: ZERO_YOCTO,
+            attached_gas: VERSION_UPDATE_GAS,
+        };
+        // Safety: same as safety in `handle_precompile_promise`
+        let _promise_id = unsafe { handler.promise_attach_callback(promise_id, &callback) };
+    }
+
+    Ok(())
+}
+
 #[allow(clippy::too_many_lines)]
 pub fn handle_precompile_promise<I, P>(
     io: &I,
@@ -77,15 +179,7 @@ pub fn handle_precompile_promise<I, P>(
 
     let latest_code_version = get_latest_code_version(io);
     let sender_code_version = get_code_version_of_address(io, &sender);
-    let deploy_needed = match sender_code_version {
-        None => AddressVersionStatus::DeployNeeded {
-            create_needed: true,
-        },
-        Some(version) if version < latest_code_version => AddressVersionStatus::DeployNeeded {
-            create_needed: false,
-        },
-        Some(_version) => AddressVersionStatus::UpToDate,
-    };
+    let deploy_needed = AddressVersionStatus::new(latest_code_version, sender_code_version);
     // 1. If the router contract account does not exist or is out of date then we start
     //    with a batch transaction to deploy the router. This batch also has an attached
     //    callback to update the engine's storage with the new version of that router account.
@@ -243,6 +337,26 @@ pub fn set_code_version_of_address<I: IO>(io: &mut I, address: &Address, version
     io.write_storage(&key, &value_bytes);
 }
 
+pub enum FundXccError {
+    InsufficientBalance,
+    InvalidAccount,
+}
+
+impl From<aurora_engine_types::account_id::ParseAccountError> for FundXccError {
+    fn from(_: aurora_engine_types::account_id::ParseAccountError) -> Self {
+        Self::InvalidAccount
+    }
+}
+
+impl AsRef<[u8]> for FundXccError {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            Self::InsufficientBalance => b"ERR_INSUFFICIENT_FUNDING_OF_NEW_XCC_ACCOUNT",
+            Self::InvalidAccount => ERR_INVALID_ACCOUNT.as_bytes(),
+        }
+    }
+}
+
 /// Sets the latest router contract version. This function is intentionally private because
 /// it should never be set manually. The version is managed automatically by `update_router_code`.
 fn set_latest_code_version<I: IO>(io: &mut I, version: CodeVersion) {
@@ -255,6 +369,20 @@ fn set_latest_code_version<I: IO>(io: &mut I, version: CodeVersion) {
 enum AddressVersionStatus {
     UpToDate,
     DeployNeeded { create_needed: bool },
+}
+
+impl AddressVersionStatus {
+    fn new(latest_code_version: CodeVersion, target_code_version: Option<CodeVersion>) -> Self {
+        match target_code_version {
+            None => Self::DeployNeeded {
+                create_needed: true,
+            },
+            Some(version) if version < latest_code_version => Self::DeployNeeded {
+                create_needed: false,
+            },
+            Some(_version) => Self::UpToDate,
+        }
+    }
 }
 
 fn withdraw_to_near_args(recipient: &AccountId, amount: Yocto) -> Vec<u8> {


### PR DESCRIPTION
## Description

The purpose of this PR is to add a new function to the Engine for creating XCC sub-accounts that are funded from an external Near account. The reason this is useful is because it allows the XCC feature to be used in an instance of the Engine where the wNEAR token has not been bridged (this is not the case on mainnet `aurora`, but could be the case on other Engine instances).

Note: this allows creating XCC accounts without requiring the Engine to know about wNEAR, but if a user wants to attach NEAR to their cross-contract calls then then Engine (and that user) will still need wNEAR. This should not be too much of a limitation since many things can be done on Near without spending the base token.

## Testing

One new XCC test to show this works to create a sub-account and use it for XCC in an Engine where wNEAR is not bridged.