### PR TITLE
Fix(modexp): do not return an error when length cannot be cast to usize

### DIFF
--- a/engine-tests/src/tests/modexp.rs
+++ b/engine-tests/src/tests/modexp.rs
@@ -10,11 +10,15 @@ fn test_modexp_oom() {
     let (mut runner, mut signer, _) = initialize_transfer();
 
     let inputs = [
-        "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000007fffffff0000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", // exp_len: isize::MAX
-        "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffff0000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", // exp_len: usize::MAX
+        // exp_len: i32::MAX
+        "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000007fffffff0000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        // exp_len: u32::MAX
+        "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffff0000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        // exp_len: u64::MAX
+        "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000c000000000000000000000000000000000000000000000000000000000000000071000000000000ff600000000000000000000000000000000000000000000000",
     ];
 
-    let outputs = [Vec::new(), Vec::new()];
+    let outputs = [Vec::new(), Vec::new(), Vec::new()];
 
     for (input, output) in inputs.iter().zip(outputs.iter()) {
         check_wasm_modexp(


### PR DESCRIPTION
## Description

EVM precompiles generally do not return errors; they take whatever input users give and do their best to return a sensible output. For example

```
go-ethereum$ ./build/bin/evm \
    --input 0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000c000000000000000000000000000000000000000000000000000000000000000071000000000000ff600000000000000000000000000000000000000000000000 \
    --receiver 0x0000000000000000000000000000000000000005 \
    run

0x
```

We see this input calls `modexp` with the size of both base and modulus both equal to zero, and the size of the exponent equal to `u64::MAX`. Since the `modexp` precompile output is bounded by the size of the modulus, we know the output is empty because the size of the modulus is zero, even though an exponent of the requested size could not actually exist in most hardware.

In our implementation we return an error from the `modexp` precompile if the lengths do not fit in a `usize` value, which in the case of Wasm is 32 bits. Therefore our implementation returns an error on the above input instead of retuning the empty value that geth returns. This PR fixes the issue by using a saturating cast into `usize` from the given input. This should be fine because non-trivial inputs (i.e. inputs where the modulus is non-zero) will have lengths that fit into `usize` no problem, or else the computation will run out of gas.

This problem of returning an error for the `usize` cast is actually a little worse than just incompatibility with Ethereum. It also creates an inconsistency with the standalone engine because Wasm has 32-bit `usize` while the standalone tends to run on 64-bit platforms. This means that the above input (with exponent length equal to `u64::MAX`) returns an error in the Wasm contract, but passed in the standalone engine. After the change in this PR it passes on both compilation targets (as verified by the new integration test case).

## Testing

Additional test case in `modexp` integration tests.
