### PR TITLE
Fix: deploy_upgrade() Does Not Clear Upgrade Index 

### DIFF
--- a/engine-tests/src/tests/state_migration.rs
+++ b/engine-tests/src/tests/state_migration.rs
@@ -3,10 +3,7 @@ use crate::test_utils::{self, str_to_account_id, AuroraRunner};
 use aurora_engine::fungible_token::FungibleTokenMetadata;
 use aurora_engine::parameters::{InitCallArgs, NewCallArgs};
 use borsh::BorshSerialize;
-use near_primitives::errors::{ActionError, ActionErrorKind, TxExecutionError};
-use near_primitives::transaction::ExecutionStatus;
 use near_sdk_sim::{ExecutionResult, UserAccount};
-use near_vm_errors::FunctionCallErrorSer;
 use std::fs;
 use std::path::Path;
 
@@ -40,7 +37,7 @@ fn test_repeated_calls_to_deploy_upgrade_should_fail() {
     aurora.call("deploy_upgrade", &[]).assert_success();
 
     // Second upgrade should fail
-    let result = aurora.call("stage_upgrade", &upgraded_contract_bytes);
+    aurora.call("stage_upgrade", &upgraded_contract_bytes);
     let result = aurora.call("deploy_upgrade", &[]);
     assert!(!result.is_ok());
 }

--- a/engine-tests/src/tests/state_migration.rs
+++ b/engine-tests/src/tests/state_migration.rs
@@ -42,25 +42,7 @@ fn test_repeated_calls_to_deploy_upgrade_should_fail() {
     // Second upgrade should fail
     let result = aurora.call("stage_upgrade", &upgraded_contract_bytes);
     let result = aurora.call("deploy_upgrade", &[]);
-    assert!(
-        !result.is_ok(),
-        "First upgrade didn't fail: {:?}",
-        result.outcome()
-    );
-
-    let outcome = result.outcome();
-    let expected_error = "ERR_NOT_ALLOWED:TOO_EARLY".to_string();
-
-    // Assert that the second upgrade failed with the correct error message
-    assert_eq!(
-        outcome.status,
-        ExecutionStatus::Failure(TxExecutionError::ActionError(ActionError {
-            index: Some(0),
-            kind: ActionErrorKind::FunctionCallError(FunctionCallErrorSer::ExecutionError(
-                expected_error
-            ))
-        }))
-    );
+    assert!(!result.is_ok());
 }
 
 pub fn deploy_evm() -> AuroraAccount {

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -201,7 +201,7 @@ mod contract {
     /// Deploy staged upgrade.
     #[no_mangle]
     pub extern "C" fn deploy_upgrade() {
-        let io = Runtime;
+        let mut io = Runtime;
         let state = state::get_state(&io).sdk_unwrap();
         require_owner_only(&state, &io.predecessor_account_id());
         let index = internal_get_upgrade_index();

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -209,6 +209,10 @@ mod contract {
             sdk::panic_utf8(errors::ERR_NOT_ALLOWED_TOO_EARLY);
         }
         Runtime::self_deploy(&bytes_to_key(KeyPrefix::Config, CODE_KEY));
+        io.write_storage(
+            &bytes_to_key(KeyPrefix::Config, CODE_STAGE_KEY),
+            &u64::MIN.to_le_bytes(),
+        );
     }
 
     /// Called as part of the upgrade process (see `engine-sdk::self_deploy`). This function is meant

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -209,10 +209,7 @@ mod contract {
             sdk::panic_utf8(errors::ERR_NOT_ALLOWED_TOO_EARLY);
         }
         Runtime::self_deploy(&bytes_to_key(KeyPrefix::Config, CODE_KEY));
-        io.write_storage(
-            &bytes_to_key(KeyPrefix::Config, CODE_STAGE_KEY),
-            &u64::MIN.to_le_bytes(),
-        );
+        io.remove_storage(&bytes_to_key(KeyPrefix::Config, CODE_STAGE_KEY));
     }
 
     /// Called as part of the upgrade process (see `engine-sdk::self_deploy`). This function is meant


### PR DESCRIPTION
There is an issue in `deploy_upgrade()` that the upgrade index is not cleared after each call.

Therefore, `deploy_upgrade() `will pass the check `io.block_height() <= index + state.upgrade_delay_blocks` since
`index` remains unchanged from previous calls.