### PR TITLE
Fix: Lack of Checks of Array Bounds

### DIFF
--- a/engine-standalone-storage/src/lib.rs
+++ b/engine-standalone-storage/src/lib.rs
@@ -318,11 +318,20 @@ impl Storage {
         while iter.valid() {
             // unwrap is safe because the iterator is valid
             let db_key = iter.key().unwrap().to_vec();
+            if db_key.len() <= engine_prefix_len {
+                break;
+            }
             if db_key[0..engine_prefix_len] != engine_prefix {
                 break;
             }
             // raw engine key skips the 2-byte prefix and the block+position suffix
+            if db_key.len() <= ENGINE_KEY_SUFFIX_LEN {
+                break;
+            }
             let engine_key = &db_key[engine_prefix_len..(db_key.len() - ENGINE_KEY_SUFFIX_LEN)];
+            if db_key.len() <= n + 8 {
+                break;
+            }
             let key_block_height = {
                 let n = engine_prefix_len + engine_key.len();
                 let mut buf = [0u8; 8];

--- a/engine-standalone-storage/src/lib.rs
+++ b/engine-standalone-storage/src/lib.rs
@@ -318,15 +318,17 @@ impl Storage {
         while iter.valid() {
             // unwrap is safe because the iterator is valid
             let db_key = iter.key().unwrap().to_vec();
-            if db_key.get_mut(0..engine_prefix_len) != Some(&mut engine_prefix) {
+            if db_key.get(0..engine_prefix_len) != Some(&engine_prefix) {
                 break;
             }
             // raw engine key skips the 2-byte prefix and the block+position suffix
-            let engine_key = &db_key.get_mut(engine_prefix_len..(db_key.len() - ENGINE_KEY_SUFFIX_LEN)).unwrap();
+            let engine_key = &db_key
+                .get(engine_prefix_len..(db_key.len() - ENGINE_KEY_SUFFIX_LEN))
+                .unwrap();
             let key_block_height = {
                 let n = engine_prefix_len + engine_key.len();
                 let mut buf = [0u8; 8];
-                buf.copy_from_slic(&db_key.get_mut(n..(n + 8)).unwrap());
+                buf.copy_from_slice(db_key.get(n..(n + 8)).unwrap());
                 u64::from_be_bytes(buf)
             };
             // If the key was created after the block height we want then we can skip it
@@ -359,7 +361,7 @@ impl Storage {
                 && iter.key().map_or(false, |db_key| {
                     db_key[0..engine_prefix_len] == engine_prefix
                         && &db_key[engine_prefix_len..(db_key.len() - ENGINE_KEY_SUFFIX_LEN)]
-                            == engine_key
+                            == *engine_key
                 })
             {
                 iter.next();

--- a/engine-standalone-storage/src/lib.rs
+++ b/engine-standalone-storage/src/lib.rs
@@ -318,24 +318,15 @@ impl Storage {
         while iter.valid() {
             // unwrap is safe because the iterator is valid
             let db_key = iter.key().unwrap().to_vec();
-            if db_key.len() <= engine_prefix_len {
-                break;
-            }
-            if db_key[0..engine_prefix_len] != engine_prefix {
+            if db_key.get_mut(0..engine_prefix_len) != Some(&mut engine_prefix) {
                 break;
             }
             // raw engine key skips the 2-byte prefix and the block+position suffix
-            if db_key.len() <= ENGINE_KEY_SUFFIX_LEN {
-                break;
-            }
-            let engine_key = &db_key[engine_prefix_len..(db_key.len() - ENGINE_KEY_SUFFIX_LEN)];
-            if db_key.len() <= n + 8 {
-                break;
-            }
+            let engine_key = &db_key.get_mut(engine_prefix_len..(db_key.len() - ENGINE_KEY_SUFFIX_LEN)).unwrap();
             let key_block_height = {
                 let n = engine_prefix_len + engine_key.len();
                 let mut buf = [0u8; 8];
-                buf.copy_from_slice(&db_key[n..(n + 8)]);
+                buf.copy_from_slic(&db_key.get_mut(n..(n + 8)).unwrap());
                 u64::from_be_bytes(buf)
             };
             // If the key was created after the block height we want then we can skip it

--- a/engine-standalone-storage/src/lib.rs
+++ b/engine-standalone-storage/src/lib.rs
@@ -324,11 +324,11 @@ impl Storage {
             // raw engine key skips the 2-byte prefix and the block+position suffix
             let engine_key = &db_key
                 .get(engine_prefix_len..(db_key.len() - ENGINE_KEY_SUFFIX_LEN))
-                .unwrap();
+                .expect("index out of bounds");
             let key_block_height = {
                 let n = engine_prefix_len + engine_key.len();
                 let mut buf = [0u8; 8];
-                buf.copy_from_slice(db_key.get(n..(n + 8)).unwrap());
+                buf.copy_from_slice(db_key.get(n..(n + 8)).expect("index out of bounds"));
                 u64::from_be_bytes(buf)
             };
             // If the key was created after the block height we want then we can skip it

--- a/engine-standalone-tracing/src/types/mod.rs
+++ b/engine-standalone-tracing/src/types/mod.rs
@@ -233,10 +233,7 @@ impl Index<usize> for Logs {
     type Output = TraceLog;
 
     fn index(&self, index: usize) -> &Self::Output {
-        if index >= self.0.len() {
-            panic!("index out of bounds");
-        }
-        &self.0[index]
+        &self.0.get(index).unwrap()
     }
 }
 
@@ -322,11 +319,11 @@ impl StepTransactionTrace {
     /// `None`.
     #[allow(dead_code)]
     pub fn step(&mut self) -> Option<&TraceLog> {
-        if self.step > self.inner.struct_logs.len() - 2 {
+        if self.step > self.inner.struct_logs.len() {
             None
         } else {
             self.step += 1;
-            Some(&self.inner.struct_logs[self.step])
+            Some(&self.inner.struct_logs.get(self.step).unwrap())
         }
     }
 }

--- a/engine-standalone-tracing/src/types/mod.rs
+++ b/engine-standalone-tracing/src/types/mod.rs
@@ -319,6 +319,8 @@ impl StepTransactionTrace {
     /// `None`.
     #[allow(dead_code)]
     pub fn step(&mut self) -> Option<&TraceLog> {
+        /// We subtract 2 from the length to avoid "index out of bounds" error,
+        /// given the else block increments the step by 1.
         if self.step > self.inner.struct_logs.len() - 2 {
             None
         } else {

--- a/engine-standalone-tracing/src/types/mod.rs
+++ b/engine-standalone-tracing/src/types/mod.rs
@@ -319,8 +319,8 @@ impl StepTransactionTrace {
     /// `None`.
     #[allow(dead_code)]
     pub fn step(&mut self) -> Option<&TraceLog> {
-        /// We subtract 2 from the length to avoid "index out of bounds" error,
-        /// given the else block increments the step by 1.
+        // We subtract 2 from the length to avoid "index out of bounds" error,
+        // given the else block increments the step by 1.
         if self.step > self.inner.struct_logs.len() - 2 {
             None
         } else {

--- a/engine-standalone-tracing/src/types/mod.rs
+++ b/engine-standalone-tracing/src/types/mod.rs
@@ -233,7 +233,7 @@ impl Index<usize> for Logs {
     type Output = TraceLog;
 
     fn index(&self, index: usize) -> &Self::Output {
-        &self.0.get(index).unwrap()
+        self.0.get(index).unwrap()
     }
 }
 
@@ -319,11 +319,11 @@ impl StepTransactionTrace {
     /// `None`.
     #[allow(dead_code)]
     pub fn step(&mut self) -> Option<&TraceLog> {
-        if self.step > self.inner.struct_logs.len() {
+        if self.step > self.inner.struct_logs.len() - 2 {
             None
         } else {
             self.step += 1;
-            Some(&self.inner.struct_logs.get(self.step).unwrap())
+            Some(&self.inner.struct_logs[self.step])
         }
     }
 }

--- a/engine-standalone-tracing/src/types/mod.rs
+++ b/engine-standalone-tracing/src/types/mod.rs
@@ -233,6 +233,9 @@ impl Index<usize> for Logs {
     type Output = TraceLog;
 
     fn index(&self, index: usize) -> &Self::Output {
+        if index >= self.0.len() {
+            panic!("index out of bounds");
+        }
         &self.0[index]
     }
 }
@@ -319,7 +322,7 @@ impl StepTransactionTrace {
     /// `None`.
     #[allow(dead_code)]
     pub fn step(&mut self) -> Option<&TraceLog> {
-        if self.step > self.inner.struct_logs.len() {
+        if self.step > self.inner.struct_logs.len() - 2 {
             None
         } else {
             self.step += 1;

--- a/engine-standalone-tracing/src/types/mod.rs
+++ b/engine-standalone-tracing/src/types/mod.rs
@@ -233,7 +233,7 @@ impl Index<usize> for Logs {
     type Output = TraceLog;
 
     fn index(&self, index: usize) -> &Self::Output {
-        self.0.get(index).unwrap()
+        self.0.get(index).expect("index out of bounds")
     }
 }
 


### PR DESCRIPTION
Several instances of lack of array bounds checks were identified in the `engine-standalone-storage` and `engine-standalone-tracing` crates.

**Recommendations**

Implement checks to ensure values used when slicing arrays or referencing items from arrays are within array bound- aries.

Use safer alternatives, such as `.get(n..m)` or `.get_mut(n..m) `when accessing array elements.