### PR TITLE
chore: add bench-modexp flow to CI script

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -31,8 +31,6 @@ jobs:
       - run: cargo make build-contracts
       - name: Run Contract cargo clippy
         run: cargo make clippy
-      - name: Run cargo clippy
-        run: cargo clippy
   udeps:
     name: Udeps
     runs-on: [self-hosted, heavy]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,29 @@ jobs:
         run: |
           cache-util save cargo_git cargo_registry yarn_cache
           cache-util msave aurora-engine-target@generic@${{ hashFiles('**/Cargo.lock') }}:target
+
+  test_modexp:
+    name: Test modexp suite (mainnet, testnet)
+    runs-on: [ self-hosted, heavy ]
+    steps:
+      - name: Potential broken submodules fix
+        run: |
+          git checkout -f $(git -c user.name=x -c user.email=x@x commit-tree $(git hash-object -t tree /dev/null) < /dev/null) || :
+      - name: Clone the repository
+        uses: actions/checkout@v3
+      - name: Restore cache
+        run: |
+          cache-util restore cargo_git cargo_registry yarn_cache
+          cache-util restore aurora-engine-target@generic@${{ hashFiles('**/Cargo.lock') }}:target
+      - name: Test mainnet bench-modexp
+        run: cargo make --profile mainnet bench-modexp
+      - name: Test testnet bench-modexp
+        run: cargo make --profile testnet bench-modexp
+      - name: Save cache
+        run: |
+          cache-util save cargo_git cargo_registry yarn_cache
+          cache-util msave aurora-engine-target@generic@${{ hashFiles('**/Cargo.lock') }}:target
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -333,7 +333,7 @@ args = [
     "${CARGO_FEATURES_TEST}",
 ]
 
-[tasks.bench-modexp]
+[tasks.bench-modexp-test]
 condition = { profiles = ["mainnet", "testnet", "custom"] }
 category = "Test"
 command = "${CARGO}"
@@ -353,12 +353,21 @@ dependencies = [
     "build-test",
     "test-contracts",
     "test-workspace",
-    "bench-modexp",
+]
+
+[tasks.bench-modexp]
+category = "Test"
+dependencies = [
+    "build-test",
+    "bench-modexp-test",
 ]
 
 [tasks.test]
 category = "Test"
-run_task = "test-flow"
+dependencies = [
+    "test-flow",
+    "bench-modexp-test",
+]
 
 [tasks.default]
 condition = { profiles = ["mainnet", "testnet", "localnet", "development", "custom"] }


### PR DESCRIPTION
## Description

The goal of the PR is to speed up passing CI flow. Also, it adds an additional job for testing the `bech_modexp` flow.
