### PR TITLE
Fix: use single crate for borsh version, allow to choose borsh v0.9 for all crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,7 +270,6 @@ dependencies = [
  "aurora-engine-transactions",
  "aurora-engine-types",
  "bitflags",
- "borsh 0.10.3",
  "byte-slice-cast",
  "digest 0.10.6",
  "ethabi",
@@ -300,7 +299,6 @@ dependencies = [
  "aurora-engine-sdk",
  "aurora-engine-test-doubles",
  "aurora-engine-types",
- "borsh 0.10.3",
  "ethabi",
  "evm",
  "hex",
@@ -321,7 +319,6 @@ version = "1.0.0"
 dependencies = [
  "aurora-engine-types",
  "base64 0.21.0",
- "borsh 0.10.3",
  "sha2 0.10.6",
  "sha3",
 ]
@@ -1443,7 +1440,6 @@ dependencies = [
  "aurora-engine-sdk",
  "aurora-engine-transactions",
  "aurora-engine-types",
- "borsh 0.10.3",
  "evm-core",
  "hex",
  "postgres",

--- a/engine-precompiles/Cargo.toml
+++ b/engine-precompiles/Cargo.toml
@@ -16,7 +16,6 @@ autobenches = false
 aurora-engine-modexp = { path = "../engine-modexp", default-features = false }
 aurora-engine-types = { path = "../engine-types", default-features = false }
 aurora-engine-sdk = { path = "../engine-sdk", default-features = false }
-borsh = { version = "0.10", default-features = false }
 bn = { version = "0.5.11", package = "zeropool-bn", default-features = false }
 evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.4-aurora", default-features = false }
 libsecp256k1 = { version = "0.7.0", default-features = false, features = ["static-context", "hmac"] }
@@ -35,7 +34,8 @@ rand = "0.8.5"
 
 [features]
 default = ["std"]
-std = ["aurora-engine-types/std", "aurora-engine-sdk/std", "borsh/std", "bn/std", "evm/std", "libsecp256k1/std", "ripemd/std", "sha2/std", "sha3/std", "ethabi/std"]
+std = ["aurora-engine-types/std", "aurora-engine-sdk/std", "bn/std", "evm/std", "libsecp256k1/std", "ripemd/std", "sha2/std", "sha3/std", "ethabi/std"]
+borsh-compat = ["aurora-engine-types/borsh-compat", "aurora-engine-sdk/borsh-compat"]
 contract = []
 log = []
 error_refund = []

--- a/engine-precompiles/src/prelude.rs
+++ b/engine-precompiles/src/prelude.rs
@@ -1,8 +1,7 @@
 pub use aurora_engine_sdk as sdk;
 pub use aurora_engine_types::account_id::*;
+pub use aurora_engine_types::borsh::{BorshDeserialize, BorshSerialize};
 pub use aurora_engine_types::parameters;
 pub use aurora_engine_types::storage;
 pub use aurora_engine_types::types;
 pub use aurora_engine_types::*;
-
-pub use borsh::{BorshDeserialize, BorshSerialize};

--- a/engine-precompiles/src/promise_result.rs
+++ b/engine-precompiles/src/promise_result.rs
@@ -2,8 +2,7 @@ use super::{EvmPrecompileResult, Precompile};
 use crate::prelude::types::{Address, EthGas};
 use crate::{utils, PrecompileOutput};
 use aurora_engine_sdk::promise::ReadOnlyPromiseHandler;
-use aurora_engine_types::{Cow, Vec};
-use borsh::BorshSerialize;
+use aurora_engine_types::{borsh::BorshSerialize, Cow, Vec};
 use evm::{Context, ExitError};
 
 /// `get_promise_results` precompile address

--- a/engine-precompiles/src/xcc.rs
+++ b/engine-precompiles/src/xcc.rs
@@ -7,12 +7,12 @@ use crate::{utils, HandleBasedPrecompile, PrecompileOutput};
 use aurora_engine_sdk::io::IO;
 use aurora_engine_types::{
     account_id::AccountId,
+    borsh::{BorshDeserialize, BorshSerialize},
     format,
     parameters::{CrossContractCallArgs, PromiseCreateArgs},
     types::{balance::ZERO_YOCTO, Address, EthGas, NearGas},
     vec, Cow, Vec, H160, H256, U256,
 };
-use borsh::{BorshDeserialize, BorshSerialize};
 use evm::backend::Log;
 use evm::executor::stack::{PrecompileFailure, PrecompileHandle};
 use evm::ExitError;
@@ -238,9 +238,9 @@ pub mod state {
 
     use aurora_engine_sdk::error::ReadU32Error;
     use aurora_engine_sdk::io::{StorageIntermediate, IO};
+    use aurora_engine_types::borsh::{self, BorshDeserialize, BorshSerialize};
     use aurora_engine_types::storage::{self, KeyPrefix};
     use aurora_engine_types::types::{Address, Yocto};
-    use borsh::{BorshDeserialize, BorshSerialize};
 
     pub const ERR_CORRUPTED_STORAGE: &str = "ERR_CORRUPTED_XCC_STORAGE";
     pub const ERR_MISSING_WNEAR_ADDRESS: &str = "ERR_MISSING_WNEAR_ADDRESS";

--- a/engine-sdk/Cargo.toml
+++ b/engine-sdk/Cargo.toml
@@ -16,12 +16,12 @@ autobenches = false
 aurora-engine-types = { path = "../engine-types", default-features = false }
 
 base64 = { version = "0.21", default-features = false, features = [ "alloc" ] }
-borsh = { version = "0.10", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 sha3 = { version = "0.10", default-features = false }
 
 [features]
-std = ["aurora-engine-types/std", "borsh/std", "sha3/std", "sha2/std", "base64/std" ]
+std = ["aurora-engine-types/std", "sha3/std", "sha2/std", "base64/std" ]
+borsh-compat = ["aurora-engine-types/borsh-compat"]
 contract = []
 log = []
 all-promise-actions = []

--- a/engine-sdk/src/io.rs
+++ b/engine-sdk/src/io.rs
@@ -1,7 +1,7 @@
 use crate::error;
 use crate::prelude::{vec, Vec};
+use aurora_engine_types::borsh::{BorshDeserialize, BorshSerialize};
 use aurora_engine_types::U256;
-use borsh::{BorshDeserialize, BorshSerialize};
 
 /// The purpose of this trait is to represent a reference to a value that
 /// could be obtained by IO, but without eagerly loading it into memory.

--- a/engine-sdk/src/prelude.rs
+++ b/engine-sdk/src/prelude.rs
@@ -1,3 +1,5 @@
 pub use aurora_engine_types::types::{Address, NearGas, PromiseResult, STORAGE_PRICE_PER_BYTE};
-pub use aurora_engine_types::{vec, Vec, H256, U256};
-pub use borsh::{BorshDeserialize, BorshSerialize};
+pub use aurora_engine_types::{
+    borsh::{BorshDeserialize, BorshSerialize},
+    vec, Vec, H256, U256,
+};

--- a/engine-standalone-storage/Cargo.toml
+++ b/engine-standalone-storage/Cargo.toml
@@ -19,7 +19,6 @@ aurora-engine-types = { path = "../engine-types", default-features = false, feat
 aurora-engine-sdk = { path = "../engine-sdk", default-features = false, features = ["std"] }
 aurora-engine-transactions = { path = "../engine-transactions", default-features = false, features = ["std"] }
 aurora-engine-precompiles = { path = "../engine-precompiles", default-features = false, features = ["std"] }
-borsh = "0.10"
 evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.4-aurora", default-features = false }
 hex = "0.4.3"
 rocksdb = { version = "0.19.0", default-features = false }
@@ -29,6 +28,7 @@ serde_json = "1.0.72"
 
 [features]
 default = ["snappy", "lz4", "zstd", "zlib"]
+borsh-compat = ["aurora-engine-types/borsh-compat", "aurora-engine-sdk/borsh-compat", "aurora-engine-precompiles/borsh-compat", "aurora-engine/borsh-compat"]
 mainnet = []
 testnet = []
 snappy = ["rocksdb/snappy"]

--- a/engine-standalone-storage/src/diff.rs
+++ b/engine-standalone-storage/src/diff.rs
@@ -1,4 +1,4 @@
-use borsh::{BorshDeserialize, BorshSerialize};
+use aurora_engine_types::borsh::{self, BorshDeserialize, BorshSerialize};
 use std::collections::{btree_map, BTreeMap};
 
 #[derive(Debug, Default, Clone, BorshDeserialize, BorshSerialize, PartialEq, Eq)]

--- a/engine-standalone-storage/src/sync/types.rs
+++ b/engine-standalone-storage/src/sync/types.rs
@@ -5,10 +5,10 @@ use aurora_engine_transactions::{EthTransactionKind, NormalizedEthTransaction};
 use aurora_engine_types::account_id::AccountId;
 use aurora_engine_types::types::Address;
 use aurora_engine_types::{
+    borsh::{self, BorshDeserialize, BorshSerialize},
     types::{self, Wei},
     H256, U256,
 };
-use borsh::{BorshDeserialize, BorshSerialize};
 use std::borrow::Cow;
 
 /// Type describing the format of messages sent to the storage layer for keeping

--- a/engine-tests/src/test_utils/erc20.rs
+++ b/engine-tests/src/test_utils/erc20.rs
@@ -60,7 +60,15 @@ impl ERC20Constructor {
             // if multiple tests running in parallel saw `contracts_dir` does not exist).
             DOWNLOAD_ONCE.call_once(|| {
                 let url = "https://github.com/OpenZeppelin/openzeppelin-contracts";
-                git2::Repository::clone(url, sources_dir).unwrap();
+                let repo = git2::Repository::clone(url, sources_dir).unwrap();
+                // We need to checkout a specific commit hash because the preset contract we use
+                // was removed from the repo later
+                // (https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3637).
+                let commit_hash =
+                    git2::Oid::from_str("dfef6a68ee18dbd2e1f5a099061a3b8a0e404485").unwrap();
+                repo.set_head_detached(commit_hash).unwrap();
+                let mut opts = git2::build::CheckoutBuilder::new();
+                repo.checkout_head(Some(opts.force())).unwrap();
             });
         }
 

--- a/engine-types/src/lib.rs
+++ b/engine-types/src/lib.rs
@@ -33,6 +33,11 @@ mod v0 {
         ops::Mul, ops::Sub, ops::SubAssign,
     };
     pub use primitive_types::{H160, H256, U256};
+
+    #[cfg(not(feature = "borsh-compat"))]
+    pub use borsh;
+    #[cfg(feature = "borsh-compat")]
+    pub use borsh_compat::{self as borsh};
 }
 
 pub use v0::*;

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,6 @@ aurora-engine-sdk = { path = "../engine-sdk", default-features = false }
 aurora-engine-precompiles = { path = "../engine-precompiles", default-features = false }
 aurora-engine-transactions = { path = "../engine-transactions", default-features = false }
 bitflags = { version = "1.3", default-features = false }
-borsh = { version = "0.10", default-features = false }
 byte-slice-cast = { version = "1.0", default-features = false }
 ethabi = { version = "18.0", default-features = false }
 evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.37.4-aurora", default-features = false }
@@ -40,8 +39,9 @@ digest = "0.10"
 
 [features]
 default = ["std"]
-std = ["aurora-engine-types/std", "aurora-engine-sdk/std", "aurora-engine-precompiles/std", "aurora-engine-transactions/std", "borsh/std", "byte-slice-cast/std", "ethabi/std", "evm/std", "hex/std", "rlp/std", "serde/std", "serde_json/std"]
+std = ["aurora-engine-types/std", "aurora-engine-sdk/std", "aurora-engine-precompiles/std", "aurora-engine-transactions/std", "byte-slice-cast/std", "ethabi/std", "evm/std", "hex/std", "rlp/std", "serde/std", "serde_json/std"]
 contract = ["aurora-engine-sdk/contract", "aurora-engine-precompiles/contract"]
+borsh-compat = ["aurora-engine-types/borsh-compat", "aurora-engine-sdk/borsh-compat", "aurora-engine-precompiles/borsh-compat"]
 evm_bully = []
 log = ["aurora-engine-sdk/log", "aurora-engine-precompiles/log"]
 tracing = ["evm/tracing"]

--- a/engine/src/connector.rs
+++ b/engine/src/connector.rs
@@ -19,6 +19,7 @@ use crate::prelude::{PromiseBatchAction, PromiseCreateArgs, PromiseWithCallbackA
 use crate::proof::Proof;
 use aurora_engine_sdk::env::Env;
 use aurora_engine_sdk::io::{StorageIntermediate, IO};
+use aurora_engine_types::borsh;
 
 pub const ERR_NOT_ENOUGH_BALANCE_FOR_FEE: &str = "ERR_NOT_ENOUGH_BALANCE_FOR_FEE";
 /// Indicate zero attached balance for promise call

--- a/engine/src/deposit_event.rs
+++ b/engine/src/deposit_event.rs
@@ -4,6 +4,7 @@ use crate::prelude::account_id::AccountId;
 use crate::prelude::{
     vec, Address, BorshDeserialize, BorshSerialize, Fee, NEP141Wei, String, ToString, Vec, U256,
 };
+use aurora_engine_types::borsh;
 use aurora_engine_types::types::address::error::AddressError;
 use byte_slice_cast::AsByteSlice;
 use ethabi::{Event, EventParam, Hash, Log, ParamType, RawLog};

--- a/engine/src/fungible_token.rs
+++ b/engine/src/fungible_token.rs
@@ -9,6 +9,7 @@ use crate::prelude::{
     StorageBalanceBounds, StorageUsage, String, ToString, Vec,
 };
 use aurora_engine_sdk::io::{StorageIntermediate, IO};
+use aurora_engine_types::borsh;
 use aurora_engine_types::types::{NEP141Wei, Yocto, ZERO_NEP141_WEI, ZERO_YOCTO};
 use serde::{Deserialize, Serialize};
 

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -74,7 +74,6 @@ pub unsafe fn on_alloc_error(_: core::alloc::Layout) -> ! {
 
 #[cfg(feature = "contract")]
 mod contract {
-    use borsh::{BorshDeserialize, BorshSerialize};
     use parameters::{SetOwnerArgs, SetUpgradeDelayBlocksArgs};
 
     use crate::connector::{self, EthConnectorContract};
@@ -106,6 +105,7 @@ mod contract {
     use aurora_engine_sdk::io::{StorageIntermediate, IO};
     use aurora_engine_sdk::near_runtime::{Runtime, ViewEnv};
     use aurora_engine_sdk::promise::PromiseHandler;
+    use aurora_engine_types::borsh::{BorshDeserialize, BorshSerialize};
 
     #[cfg(feature = "integration-test")]
     use crate::prelude::NearGas;

--- a/engine/src/parameters.rs
+++ b/engine/src/parameters.rs
@@ -3,6 +3,7 @@ use crate::fungible_token::FungibleTokenMetadata;
 use crate::prelude::account_id::AccountId;
 use crate::prelude::{Address, Balance, BorshDeserialize, BorshSerialize, RawU256, String, Vec};
 use crate::proof::Proof;
+use aurora_engine_types::borsh;
 pub use aurora_engine_types::parameters::engine::{
     CallArgs, DeployErc20TokenArgs, FunctionCallArgsV1, FunctionCallArgsV2,
     GetErc20FromNep141CallArgs, GetStorageAtArgs, ResultLog, SubmitResult, TransactionStatus,

--- a/engine/src/pausables.rs
+++ b/engine/src/pausables.rs
@@ -1,9 +1,9 @@
 use crate::prelude::{AccountId, Address, BTreeSet, Vec};
 use aurora_engine_precompiles::native::{exit_to_ethereum, exit_to_near};
 use aurora_engine_sdk::io::{StorageIntermediate, IO};
+use aurora_engine_types::borsh::{self, BorshDeserialize, BorshSerialize};
 use aurora_engine_types::storage::{bytes_to_key, KeyPrefix};
 use bitflags::bitflags;
-use borsh::{BorshDeserialize, BorshSerialize};
 
 bitflags! {
     /// Wraps unsigned integer where each bit identifies a different precompile.

--- a/engine/src/prelude.rs
+++ b/engine/src/prelude.rs
@@ -4,11 +4,11 @@ mod v0 {
     pub use aurora_engine_sdk::types::*;
     pub use aurora_engine_transactions as transactions;
     pub use aurora_engine_types::account_id::*;
+    pub use aurora_engine_types::borsh::{BorshDeserialize, BorshSerialize};
     pub use aurora_engine_types::parameters::*;
     pub use aurora_engine_types::storage::*;
     pub use aurora_engine_types::types::*;
     pub use aurora_engine_types::*;
-    pub use borsh::{BorshDeserialize, BorshSerialize};
 }
 
 pub use v0::*;

--- a/engine/src/proof.rs
+++ b/engine/src/proof.rs
@@ -1,4 +1,5 @@
 use crate::prelude::{sdk, BorshDeserialize, BorshSerialize, String, ToString, Vec};
+use aurora_engine_types::borsh;
 
 #[derive(Debug, Default, BorshDeserialize, BorshSerialize, Clone)]
 #[cfg_attr(feature = "impl-serde", derive(serde::Deserialize, serde::Serialize))]

--- a/engine/src/state.rs
+++ b/engine/src/state.rs
@@ -1,9 +1,9 @@
 use crate::parameters::{LegacyNewCallArgs, NewCallArgs, NewCallArgsV2};
 use aurora_engine_sdk::io::{StorageIntermediate, IO};
 use aurora_engine_types::account_id::AccountId;
+use aurora_engine_types::borsh::{self, BorshDeserialize, BorshSerialize};
 use aurora_engine_types::storage::{bytes_to_key, KeyPrefix};
 use aurora_engine_types::{Cow, Vec};
-use borsh::{BorshDeserialize, BorshSerialize};
 
 pub use error::EngineStateError;
 

--- a/engine/src/xcc.rs
+++ b/engine/src/xcc.rs
@@ -5,11 +5,11 @@ use aurora_engine_sdk::env::Env;
 use aurora_engine_sdk::io::{StorageIntermediate, IO};
 use aurora_engine_sdk::promise::PromiseHandler;
 use aurora_engine_types::account_id::AccountId;
+use aurora_engine_types::borsh::{self, BorshDeserialize, BorshSerialize};
 use aurora_engine_types::parameters::{PromiseAction, PromiseBatchAction, PromiseCreateArgs};
 use aurora_engine_types::storage::{self, KeyPrefix};
 use aurora_engine_types::types::{Address, NearGas, Yocto, ZERO_YOCTO};
 use aurora_engine_types::{format, Cow, Vec, U256};
-use borsh::{BorshDeserialize, BorshSerialize};
 
 pub const ERR_NO_ROUTER_CODE: &str = "ERR_MISSING_XCC_BYTECODE";
 pub const ERR_INVALID_ACCOUNT: &str = "ERR_INVALID_XCC_ACCOUNT";


### PR DESCRIPTION
## Description

[Near Workspaces](https://crates.io/crates/workspaces) still uses `borsh` version 0.9. Therefore we need the `borsh-compat` feature on all our crates that use `borsh` if we want to use them in Workspaces-based tests. This PR makes this change.

This is a non-functional change (impacts only a dependency version and only if a feature is specified), therefore has no impact on tests or performance.