### PR TITLE
Feat(precompiles): Abstract modexp impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,7 @@ dependencies = [
 name = "aurora-engine"
 version = "2.9.0"
 dependencies = [
+ "aurora-engine-modexp",
  "aurora-engine-precompiles",
  "aurora-engine-sdk",
  "aurora-engine-test-doubles",
@@ -339,6 +340,7 @@ name = "aurora-engine-tests"
 version = "1.0.0"
 dependencies = [
  "aurora-engine",
+ "aurora-engine-modexp",
  "aurora-engine-precompiles",
  "aurora-engine-sdk",
  "aurora-engine-test-doubles",
@@ -1382,6 +1384,7 @@ name = "engine-standalone-storage"
 version = "0.1.0"
 dependencies = [
  "aurora-engine",
+ "aurora-engine-modexp",
  "aurora-engine-precompiles",
  "aurora-engine-sdk",
  "aurora-engine-transactions",

--- a/engine-modexp/src/lib.rs
+++ b/engine-modexp/src/lib.rs
@@ -9,6 +9,22 @@ mod mpnat;
 
 use maybe_std::Vec;
 
+/// Trait providing the interface for the modexp function.
+/// The implementation provided by this crate is `AuroraModExp` below,
+/// but other users of Aurora Engine may wish to select a different implementation.
+pub trait ModExpAlgorithm {
+    /// Computes `(base ^ exp) % modulus`, where all values are given as big-endian encoded bytes.
+    fn modexp(base: &[u8], exp: &[u8], modulus: &[u8]) -> Vec<u8>;
+}
+
+pub struct AuroraModExp;
+
+impl ModExpAlgorithm for AuroraModExp {
+    fn modexp(base: &[u8], exp: &[u8], modulus: &[u8]) -> Vec<u8> {
+        modexp(base, exp, modulus)
+    }
+}
+
 /// Computes `(base ^ exp) % modulus`, where all values are given as big-endian
 /// encoded bytes.
 pub fn modexp(base: &[u8], exp: &[u8], modulus: &[u8]) -> Vec<u8> {

--- a/engine-precompiles/src/lib.rs
+++ b/engine-precompiles/src/lib.rs
@@ -35,6 +35,7 @@ use crate::prepaid_gas::PrepaidGas;
 use crate::random::RandomSeed;
 use crate::secp256k1::ECRecover;
 use crate::xcc::CrossContractCall;
+use aurora_engine_modexp::ModExpAlgorithm;
 use aurora_engine_sdk::env::Env;
 use aurora_engine_sdk::io::IO;
 use aurora_engine_sdk::promise::ReadOnlyPromiseHandler;
@@ -197,17 +198,20 @@ fn post_process(
     })
 }
 
-pub struct PrecompileConstructorContext<'a, I, E, H> {
+pub struct PrecompileConstructorContext<'a, I, E, H, M> {
     pub current_account_id: AccountId,
     pub random_seed: H256,
     pub io: I,
     pub env: &'a E,
     pub promise_handler: H,
+    pub mod_exp_algorithm: crate::prelude::PhantomData<M>,
 }
 
 impl<'a, I: IO + Copy, E: Env, H: ReadOnlyPromiseHandler> Precompiles<'a, I, E, H> {
     #[allow(dead_code)]
-    pub fn new_homestead(ctx: PrecompileConstructorContext<'a, I, E, H>) -> Self {
+    pub fn new_homestead<M: ModExpAlgorithm + 'static>(
+        ctx: PrecompileConstructorContext<'a, I, E, H, M>,
+    ) -> Self {
         let addresses = vec![
             ECRecover::ADDRESS,
             SHA256::ADDRESS,
@@ -231,13 +235,15 @@ impl<'a, I: IO + Copy, E: Env, H: ReadOnlyPromiseHandler> Precompiles<'a, I, E, 
     }
 
     #[allow(dead_code)]
-    pub fn new_byzantium(ctx: PrecompileConstructorContext<'a, I, E, H>) -> Self {
+    pub fn new_byzantium<M: ModExpAlgorithm + 'static>(
+        ctx: PrecompileConstructorContext<'a, I, E, H, M>,
+    ) -> Self {
         let addresses = vec![
             ECRecover::ADDRESS,
             SHA256::ADDRESS,
             RIPEMD160::ADDRESS,
             Identity::ADDRESS,
-            ModExp::<Byzantium>::ADDRESS,
+            ModExp::<Byzantium, M>::ADDRESS,
             Bn256Add::<Byzantium>::ADDRESS,
             Bn256Mul::<Byzantium>::ADDRESS,
             Bn256Pair::<Byzantium>::ADDRESS,
@@ -249,7 +255,7 @@ impl<'a, I: IO + Copy, E: Env, H: ReadOnlyPromiseHandler> Precompiles<'a, I, E, 
             Box::new(SHA256),
             Box::new(RIPEMD160),
             Box::new(Identity),
-            Box::new(ModExp::<Byzantium>::new()),
+            Box::new(ModExp::<Byzantium, M>::new()),
             Box::new(Bn256Add::<Byzantium>::new()),
             Box::new(Bn256Mul::<Byzantium>::new()),
             Box::new(Bn256Pair::<Byzantium>::new()),
@@ -265,13 +271,15 @@ impl<'a, I: IO + Copy, E: Env, H: ReadOnlyPromiseHandler> Precompiles<'a, I, E, 
         Self::with_generic_precompiles(map, ctx)
     }
 
-    pub fn new_istanbul(ctx: PrecompileConstructorContext<'a, I, E, H>) -> Self {
+    pub fn new_istanbul<M: ModExpAlgorithm + 'static>(
+        ctx: PrecompileConstructorContext<'a, I, E, H, M>,
+    ) -> Self {
         let addresses = vec![
             ECRecover::ADDRESS,
             SHA256::ADDRESS,
             RIPEMD160::ADDRESS,
             Identity::ADDRESS,
-            ModExp::<Byzantium>::ADDRESS,
+            ModExp::<Byzantium, M>::ADDRESS,
             Bn256Add::<Istanbul>::ADDRESS,
             Bn256Mul::<Istanbul>::ADDRESS,
             Bn256Pair::<Istanbul>::ADDRESS,
@@ -284,7 +292,7 @@ impl<'a, I: IO + Copy, E: Env, H: ReadOnlyPromiseHandler> Precompiles<'a, I, E, 
             Box::new(SHA256),
             Box::new(RIPEMD160),
             Box::new(Identity),
-            Box::new(ModExp::<Byzantium>::new()),
+            Box::new(ModExp::<Byzantium, M>::new()),
             Box::new(Bn256Add::<Istanbul>::new()),
             Box::new(Bn256Mul::<Istanbul>::new()),
             Box::new(Bn256Pair::<Istanbul>::new()),
@@ -301,13 +309,15 @@ impl<'a, I: IO + Copy, E: Env, H: ReadOnlyPromiseHandler> Precompiles<'a, I, E, 
         Self::with_generic_precompiles(map, ctx)
     }
 
-    pub fn new_berlin(ctx: PrecompileConstructorContext<'a, I, E, H>) -> Self {
+    pub fn new_berlin<M: ModExpAlgorithm + 'static>(
+        ctx: PrecompileConstructorContext<'a, I, E, H, M>,
+    ) -> Self {
         let addresses = vec![
             ECRecover::ADDRESS,
             SHA256::ADDRESS,
             RIPEMD160::ADDRESS,
             Identity::ADDRESS,
-            ModExp::<Berlin>::ADDRESS,
+            ModExp::<Berlin, M>::ADDRESS,
             Bn256Add::<Istanbul>::ADDRESS,
             Bn256Mul::<Istanbul>::ADDRESS,
             Bn256Pair::<Istanbul>::ADDRESS,
@@ -320,7 +330,7 @@ impl<'a, I: IO + Copy, E: Env, H: ReadOnlyPromiseHandler> Precompiles<'a, I, E, 
             Box::new(SHA256),
             Box::new(RIPEMD160),
             Box::new(Identity),
-            Box::new(ModExp::<Berlin>::new()),
+            Box::new(ModExp::<Berlin, M>::new()),
             Box::new(Bn256Add::<Istanbul>::new()),
             Box::new(Bn256Mul::<Istanbul>::new()),
             Box::new(Bn256Pair::<Istanbul>::new()),
@@ -337,14 +347,16 @@ impl<'a, I: IO + Copy, E: Env, H: ReadOnlyPromiseHandler> Precompiles<'a, I, E, 
         Self::with_generic_precompiles(map, ctx)
     }
 
-    pub fn new_london(ctx: PrecompileConstructorContext<'a, I, E, H>) -> Self {
+    pub fn new_london<M: ModExpAlgorithm + 'static>(
+        ctx: PrecompileConstructorContext<'a, I, E, H, M>,
+    ) -> Self {
         // no precompile changes in London HF
         Self::new_berlin(ctx)
     }
 
-    fn with_generic_precompiles(
+    fn with_generic_precompiles<M: ModExpAlgorithm + 'static>(
         mut generic_precompiles: BTreeMap<Address, AllPrecompiles<'a, I, E, H>>,
-        ctx: PrecompileConstructorContext<'a, I, E, H>,
+        ctx: PrecompileConstructorContext<'a, I, E, H, M>,
     ) -> Self {
         let near_exit = ExitToNear::new(ctx.current_account_id.clone(), ctx.io);
         let ethereum_exit = ExitToEthereum::new(ctx.current_account_id.clone(), ctx.io);
@@ -466,6 +478,7 @@ const fn make_h256(x: u128, y: u128) -> prelude::H256 {
 mod tests {
     use crate::prelude::H160;
     use crate::{prelude, Byzantium, Istanbul};
+    use aurora_engine_modexp::AuroraModExp;
     use prelude::types::Address;
     use rand::Rng;
 
@@ -475,7 +488,10 @@ mod tests {
         assert_eq!(super::hash::SHA256::ADDRESS, u8_to_address(2));
         assert_eq!(super::hash::RIPEMD160::ADDRESS, u8_to_address(3));
         assert_eq!(super::identity::Identity::ADDRESS, u8_to_address(4));
-        assert_eq!(super::ModExp::<Byzantium>::ADDRESS, u8_to_address(5));
+        assert_eq!(
+            super::ModExp::<Byzantium, AuroraModExp>::ADDRESS,
+            u8_to_address(5)
+        );
         assert_eq!(super::Bn256Add::<Istanbul>::ADDRESS, u8_to_address(6));
         assert_eq!(super::Bn256Mul::<Istanbul>::ADDRESS, u8_to_address(7));
         assert_eq!(super::Bn256Pair::<Istanbul>::ADDRESS, u8_to_address(8));

--- a/engine-standalone-storage/Cargo.toml
+++ b/engine-standalone-storage/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["lib"]
 [dependencies]
 aurora-engine = { path = "../engine", default-features = false, features = ["std"] }
 aurora-engine-types = { path = "../engine-types", default-features = false, features = ["std"] }
+aurora-engine-modexp = { path = "../engine-modexp", default-features = false, features = ["std"] }
 aurora-engine-sdk = { path = "../engine-sdk", default-features = false, features = ["std"] }
 aurora-engine-transactions = { path = "../engine-transactions", default-features = false, features = ["std"] }
 aurora-engine-precompiles = { path = "../engine-precompiles", default-features = false, features = ["std"] }

--- a/engine-standalone-storage/src/relayer_db/mod.rs
+++ b/engine-standalone-storage/src/relayer_db/mod.rs
@@ -107,7 +107,7 @@ where
             ..Default::default()
         };
         let result = storage.with_engine_access(block_height, transaction_position, &[], |io| {
-            engine::submit(
+            engine::submit::<_, _, _, aurora_engine_modexp::AuroraModExp>(
                 io,
                 &env,
                 &args,

--- a/engine-standalone-storage/src/sync/mod.rs
+++ b/engine-standalone-storage/src/sync/mod.rs
@@ -3,6 +3,7 @@ use aurora_engine::pausables::{
     EnginePrecompilesPauser, PausedPrecompilesManager, PrecompileFlags,
 };
 use aurora_engine::{connector, engine, parameters::SubmitResult, state, xcc};
+use aurora_engine_modexp::ModExpAlgorithm;
 use aurora_engine_sdk::env::{self, Env, DEFAULT_PREPAID_GAS};
 use aurora_engine_types::{
     account_id::AccountId,
@@ -17,7 +18,7 @@ use crate::engine_state::EngineStateAccess;
 use crate::{BlockMetadata, Diff, Storage};
 use types::{Message, TransactionKind, TransactionMessage};
 
-pub fn consume_message(
+pub fn consume_message<M: ModExpAlgorithm + 'static>(
     storage: &mut Storage,
     message: Message,
 ) -> Result<ConsumeMessageOutcome, crate::Error> {
@@ -46,7 +47,7 @@ pub fn consume_message(
 
             let (tx_hash, diff, result) = storage
                 .with_engine_access(block_height, transaction_position, &[], |io| {
-                    execute_transaction(
+                    execute_transaction::<M>(
                         transaction_message.as_ref(),
                         block_height,
                         &block_metadata,
@@ -72,7 +73,7 @@ pub fn consume_message(
     }
 }
 
-pub fn execute_transaction_message(
+pub fn execute_transaction_message<M: ModExpAlgorithm + 'static>(
     storage: &Storage,
     transaction_message: TransactionMessage,
 ) -> Result<TransactionIncludedOutcome, crate::Error> {
@@ -82,7 +83,7 @@ pub fn execute_transaction_message(
     let block_metadata = storage.get_block_metadata(block_hash)?;
     let engine_account_id = storage.get_engine_account_id()?;
     let result = storage.with_engine_access(block_height, transaction_position, &[], |io| {
-        execute_transaction(
+        execute_transaction::<M>(
             &transaction_message,
             block_height,
             &block_metadata,
@@ -100,7 +101,7 @@ pub fn execute_transaction_message(
     Ok(outcome)
 }
 
-fn execute_transaction<'db>(
+fn execute_transaction<'db, M: ModExpAlgorithm + 'static>(
     transaction_message: &TransactionMessage,
     block_height: u64,
     block_metadata: &BlockMetadata,
@@ -143,7 +144,7 @@ fn execute_transaction<'db>(
             };
             let result = state::get_state(&io)
                 .map(|engine_state| {
-                    let submit_result = engine::submit(
+                    let submit_result = engine::submit::<_, _, _, M>(
                         io,
                         &env,
                         &args,
@@ -165,7 +166,7 @@ fn execute_transaction<'db>(
             let tx_hash = aurora_engine_sdk::keccak(&args.tx_data);
             let result = state::get_state(&io)
                 .map(|engine_state| {
-                    let submit_result = engine::submit(
+                    let submit_result = engine::submit::<_, _, _, M>(
                         io,
                         &env,
                         args,
@@ -181,7 +182,7 @@ fn execute_transaction<'db>(
             (tx_hash, result)
         }
         other => {
-            let result = non_submit_execute(
+            let result = non_submit_execute::<M>(
                 other,
                 io,
                 env,
@@ -201,7 +202,7 @@ fn execute_transaction<'db>(
 /// The `submit` transaction kind is special because it is the only one where the transaction hash
 /// differs from the NEAR receipt hash.
 #[allow(clippy::too_many_lines)]
-fn non_submit_execute<'db>(
+fn non_submit_execute<'db, M: ModExpAlgorithm + 'static>(
     transaction: &TransactionKind,
     mut io: EngineStateAccess<'db, 'db, 'db>,
     env: env::Fixed,
@@ -212,7 +213,7 @@ fn non_submit_execute<'db>(
         TransactionKind::Call(args) => {
             // We can ignore promises in the standalone engine (see above)
             let mut handler = crate::promise::NoScheduler { promise_data };
-            let mut engine =
+            let mut engine: engine::Engine<_, _, M> =
                 engine::Engine::new(relayer_address, env.current_account_id(), io, &env)?;
 
             let result = engine.call_with_args(args.clone(), &mut handler);
@@ -223,7 +224,7 @@ fn non_submit_execute<'db>(
         TransactionKind::Deploy(input) => {
             // We can ignore promises in the standalone engine (see above)
             let mut handler = crate::promise::NoScheduler { promise_data };
-            let mut engine =
+            let mut engine: engine::Engine<_, _, M> =
                 engine::Engine::new(relayer_address, env.current_account_id(), io, &env)?;
 
             let result = engine.deploy_code_with_input(input.clone(), &mut handler);
@@ -242,7 +243,7 @@ fn non_submit_execute<'db>(
         TransactionKind::FtOnTransfer(args) => {
             // No promises can be created by `ft_on_transfer`
             let mut handler = crate::promise::NoScheduler { promise_data };
-            let mut engine =
+            let mut engine: engine::Engine<_, _, M> =
                 engine::Engine::new(relayer_address, env.current_account_id(), io, &env)?;
 
             if env.predecessor_account_id == env.current_account_id {
@@ -353,7 +354,7 @@ fn non_submit_execute<'db>(
         }
 
         TransactionKind::RegisterRelayer(evm_address) => {
-            let mut engine =
+            let mut engine: engine::Engine<_, _, M> =
                 engine::Engine::new(relayer_address, env.current_account_id(), io, &env)?;
             engine.register_relayer(env.predecessor_account_id.as_bytes(), *evm_address);
 

--- a/engine-tests/Cargo.toml
+++ b/engine-tests/Cargo.toml
@@ -18,6 +18,7 @@ autobenches = false
 aurora-engine = { path = "../engine", default-features = false, features = ["std", "tracing", "impl-serde"] }
 aurora-engine-precompiles = { path = "../engine-precompiles", default-features = false, features = ["std"] }
 aurora-engine-sdk = { path = "../engine-sdk", default-features = false, features = ["std"] }
+aurora-engine-modexp = { path = "../engine-modexp", default-features = false, features = ["std"] }
 aurora-engine-test-doubles = { path = "../engine-test-doubles", default-features = false }
 aurora-engine-transactions = { path = "../engine-transactions", default-features = false, features = ["std", "impl-serde"] }
 aurora-engine-types = { path = "../engine-types", default-features = false, features = ["std", "impl-serde"] }

--- a/engine-tests/src/test_utils/standalone/mocks/mod.rs
+++ b/engine-tests/src/test_utils/standalone/mocks/mod.rs
@@ -83,7 +83,8 @@ pub fn mint_evm_account<I: IO + Copy, E: Env>(
     use evm::backend::ApplyBackend;
 
     let aurora_account_id = env.current_account_id();
-    let mut engine = engine::Engine::new(address, aurora_account_id.clone(), io, env).unwrap();
+    let mut engine: engine::Engine<I, E, aurora_engine_modexp::AuroraModExp> =
+        engine::Engine::new(address, aurora_account_id.clone(), io, env).unwrap();
     let state_change = evm::backend::Apply::Modify {
         address: address.raw(),
         basic: evm::backend::Basic {

--- a/engine-tests/src/test_utils/standalone/mod.rs
+++ b/engine-tests/src/test_utils/standalone/mod.rs
@@ -3,6 +3,7 @@ use aurora_engine::parameters::{
     CallArgs, DeployErc20TokenArgs, PausePrecompilesCallArgs, SetOwnerArgs,
     SetUpgradeDelayBlocksArgs, SubmitArgs, SubmitResult, TransactionStatus,
 };
+use aurora_engine_modexp::AuroraModExp;
 use aurora_engine_sdk::env::{self, Env};
 use aurora_engine_transactions::legacy::{LegacyEthSignedTransaction, TransactionLegacy};
 use aurora_engine_types::types::{Address, NearGas, PromiseResult, Wei};
@@ -170,7 +171,7 @@ impl StandaloneRunner {
         tx_msg.position = transaction_position;
         tx_msg.transaction =
             TransactionKind::Submit(transaction_bytes.as_slice().try_into().unwrap());
-        let outcome = sync::execute_transaction_message(storage, tx_msg).unwrap();
+        let outcome = sync::execute_transaction_message::<AuroraModExp>(storage, tx_msg).unwrap();
 
         match outcome.maybe_result.as_ref().unwrap().as_ref().unwrap() {
             sync::TransactionExecutionResult::Submit(result) => {
@@ -218,7 +219,8 @@ impl StandaloneRunner {
                 Self::template_tx_msg(storage, &env, 0, transaction_hash, promise_results);
             tx_msg.transaction = TransactionKind::SubmitWithArgs(submit_args);
 
-            let outcome = sync::execute_transaction_message(storage, tx_msg).unwrap();
+            let outcome =
+                sync::execute_transaction_message::<AuroraModExp>(storage, tx_msg).unwrap();
             self.cumulative_diff.append(outcome.diff.clone());
             storage::commit(storage, &outcome);
 
@@ -230,7 +232,8 @@ impl StandaloneRunner {
                 Self::template_tx_msg(storage, &env, 0, transaction_hash, promise_results);
             tx_msg.transaction = TransactionKind::Call(call_args);
 
-            let outcome = sync::execute_transaction_message(storage, tx_msg).unwrap();
+            let outcome =
+                sync::execute_transaction_message::<AuroraModExp>(storage, tx_msg).unwrap();
             self.cumulative_diff.append(outcome.diff.clone());
             storage::commit(storage, &outcome);
 
@@ -242,7 +245,8 @@ impl StandaloneRunner {
                 Self::template_tx_msg(storage, &env, 0, transaction_hash, promise_results);
             tx_msg.transaction = TransactionKind::DeployErc20(deploy_args);
 
-            let outcome = sync::execute_transaction_message(storage, tx_msg).unwrap();
+            let outcome =
+                sync::execute_transaction_message::<AuroraModExp>(storage, tx_msg).unwrap();
             self.cumulative_diff.append(outcome.diff.clone());
             storage::commit(storage, &outcome);
 
@@ -263,7 +267,8 @@ impl StandaloneRunner {
                 Self::template_tx_msg(storage, &env, 0, transaction_hash, promise_results);
             tx_msg.transaction = TransactionKind::ResumePrecompiles(call_args);
 
-            let outcome = sync::execute_transaction_message(storage, tx_msg).unwrap();
+            let outcome =
+                sync::execute_transaction_message::<AuroraModExp>(storage, tx_msg).unwrap();
             self.cumulative_diff.append(outcome.diff.clone());
             storage::commit(storage, &outcome);
 
@@ -282,7 +287,8 @@ impl StandaloneRunner {
                 Self::template_tx_msg(storage, &env, 0, transaction_hash, promise_results);
             tx_msg.transaction = TransactionKind::PausePrecompiles(call_args);
 
-            let outcome = sync::execute_transaction_message(storage, tx_msg).unwrap();
+            let outcome =
+                sync::execute_transaction_message::<AuroraModExp>(storage, tx_msg).unwrap();
             self.cumulative_diff.append(outcome.diff.clone());
             storage::commit(storage, &outcome);
 
@@ -301,7 +307,8 @@ impl StandaloneRunner {
                 Self::template_tx_msg(storage, &env, 0, transaction_hash, promise_results);
             tx_msg.transaction = TransactionKind::SetOwner(call_args);
 
-            let outcome = sync::execute_transaction_message(storage, tx_msg).unwrap();
+            let outcome =
+                sync::execute_transaction_message::<AuroraModExp>(storage, tx_msg).unwrap();
             self.cumulative_diff.append(outcome.diff.clone());
             storage::commit(storage, &outcome);
 
@@ -320,7 +327,8 @@ impl StandaloneRunner {
                 Self::template_tx_msg(storage, &env, 0, transaction_hash, promise_results);
             tx_msg.transaction = TransactionKind::SetUpgradeDelayBlocks(call_args);
 
-            let outcome = sync::execute_transaction_message(storage, tx_msg).unwrap();
+            let outcome =
+                sync::execute_transaction_message::<AuroraModExp>(storage, tx_msg).unwrap();
             self.cumulative_diff.append(outcome.diff.clone());
             storage::commit(storage, &outcome);
 
@@ -420,7 +428,7 @@ impl StandaloneRunner {
         );
         tx_msg.transaction = TransactionKind::Submit(transaction_bytes.try_into().unwrap());
 
-        let outcome = sync::execute_transaction_message(storage, tx_msg).unwrap();
+        let outcome = sync::execute_transaction_message::<AuroraModExp>(storage, tx_msg).unwrap();
         cumulative_diff.append(outcome.diff.clone());
         storage::commit(storage, &outcome);
 

--- a/engine-tests/src/tests/standalone/call_tracer.rs
+++ b/engine-tests/src/tests/standalone/call_tracer.rs
@@ -1,5 +1,6 @@
 use crate::prelude::H256;
 use crate::test_utils::{self, standalone};
+use aurora_engine_modexp::AuroraModExp;
 use aurora_engine_types::{
     parameters::{CrossContractCallArgs, PromiseArgs, PromiseCreateArgs},
     storage,
@@ -245,6 +246,7 @@ fn test_trace_contract_with_precompile_sub_call() {
     runner.close();
 }
 
+#[allow(clippy::too_many_lines)]
 #[test]
 fn test_trace_precompiles_with_subcalls() {
     // The XCC precompile does internal sub-calls. We will trace an XCC call.
@@ -289,7 +291,7 @@ fn test_trace_precompiles_with_subcalls() {
                 nep141: "wrap.near".parse().unwrap(),
             },
         );
-        let mut outcome = sync::execute_transaction_message(storage, tx).unwrap();
+        let mut outcome = sync::execute_transaction_message::<AuroraModExp>(storage, tx).unwrap();
         let key = storage::bytes_to_key(storage::KeyPrefix::Nep141Erc20Map, b"wrap.near");
         outcome.diff.modify(key, wnear_address.as_bytes().to_vec());
         let key =
@@ -312,7 +314,8 @@ fn test_trace_precompiles_with_subcalls() {
         tx.transaction = sync::types::TransactionKind::FactoryUpdate(xcc_router_bytes);
         tx
     };
-    let outcome = sync::execute_transaction_message(&runner.storage, factory_update).unwrap();
+    let outcome =
+        sync::execute_transaction_message::<AuroraModExp>(&runner.storage, factory_update).unwrap();
     test_utils::standalone::storage::commit(&mut runner.storage, &outcome);
     let set_wnear_address = {
         runner.env.block_height += 1;
@@ -324,7 +327,9 @@ fn test_trace_precompiles_with_subcalls() {
         tx.transaction = sync::types::TransactionKind::FactorySetWNearAddress(wnear_address);
         tx
     };
-    let outcome = sync::execute_transaction_message(&runner.storage, set_wnear_address).unwrap();
+    let outcome =
+        sync::execute_transaction_message::<AuroraModExp>(&runner.storage, set_wnear_address)
+            .unwrap();
     test_utils::standalone::storage::commit(&mut runner.storage, &outcome);
 
     // User calls XCC precompile

--- a/engine-tests/src/tests/standalone/sanity.rs
+++ b/engine-tests/src/tests/standalone/sanity.rs
@@ -34,7 +34,8 @@ fn test_deploy_code() {
         prepaid_gas: DEFAULT_PREPAID_GAS,
     };
     let mut handler = PromiseTracker::default();
-    let mut engine = engine::Engine::new_with_state(state, origin, owner_id, io, &env);
+    let mut engine: engine::Engine<_, _, aurora_engine_modexp::AuroraModExp> =
+        engine::Engine::new_with_state(state, origin, owner_id, io, &env);
     let code_to_deploy = vec![1, 2, 3, 4, 5, 6];
     let result = engine.deploy_code(
         origin,

--- a/engine-tests/src/tests/standalone/sync.rs
+++ b/engine-tests/src/tests/standalone/sync.rs
@@ -1,4 +1,5 @@
 use aurora_engine::deposit_event::TokenMessageData;
+use aurora_engine_modexp::AuroraModExp;
 use aurora_engine_sdk::env::{Env, Timestamp};
 use aurora_engine_types::types::{Address, Balance, Fee, NEP141Wei, Wei};
 use aurora_engine_types::{account_id::AccountId, H160, H256, U256};
@@ -56,7 +57,7 @@ fn test_consume_deposit_message() {
         promise_data: Vec::new(),
     };
 
-    let outcome = sync::consume_message(
+    let outcome = sync::consume_message::<AuroraModExp>(
         &mut runner.storage,
         sync::types::Message::Transaction(Box::new(transaction_message)),
     )
@@ -88,7 +89,7 @@ fn test_consume_deposit_message() {
         promise_data: Vec::new(),
     };
 
-    let outcome = sync::consume_message(
+    let outcome = sync::consume_message::<AuroraModExp>(
         &mut runner.storage,
         sync::types::Message::Transaction(Box::new(transaction_message)),
     )
@@ -118,7 +119,7 @@ fn test_consume_deposit_message() {
         promise_data: Vec::new(),
     };
 
-    sync::consume_message(
+    sync::consume_message::<AuroraModExp>(
         &mut runner.storage,
         sync::types::Message::Transaction(Box::new(transaction_message)),
     )
@@ -148,7 +149,7 @@ fn test_consume_deploy_message() {
         promise_data: Vec::new(),
     };
 
-    sync::consume_message(
+    sync::consume_message::<AuroraModExp>(
         &mut runner.storage,
         sync::types::Message::Transaction(Box::new(transaction_message)),
     )
@@ -201,7 +202,7 @@ fn test_consume_deploy_erc20_message() {
     };
 
     // Deploy ERC-20 (this would be the flow for bridging a new NEP-141 to Aurora)
-    sync::consume_message(
+    sync::consume_message::<AuroraModExp>(
         &mut runner.storage,
         sync::types::Message::Transaction(Box::new(transaction_message)),
     )
@@ -239,7 +240,7 @@ fn test_consume_deploy_erc20_message() {
     };
 
     // Mint new tokens (via ft_on_transfer flow, same as the bridge)
-    sync::consume_message(
+    sync::consume_message::<AuroraModExp>(
         &mut runner.storage,
         sync::types::Message::Transaction(Box::new(transaction_message)),
     )
@@ -295,7 +296,7 @@ fn test_consume_ft_on_transfer_message() {
         promise_data: Vec::new(),
     };
 
-    sync::consume_message(
+    sync::consume_message::<AuroraModExp>(
         &mut runner.storage,
         sync::types::Message::Transaction(Box::new(transaction_message)),
     )
@@ -339,7 +340,7 @@ fn test_consume_call_message() {
         promise_data: Vec::new(),
     };
 
-    sync::consume_message(
+    sync::consume_message::<AuroraModExp>(
         &mut runner.storage,
         sync::types::Message::Transaction(Box::new(transaction_message)),
     )
@@ -389,7 +390,7 @@ fn test_consume_submit_message() {
         promise_data: Vec::new(),
     };
 
-    sync::consume_message(
+    sync::consume_message::<AuroraModExp>(
         &mut runner.storage,
         sync::types::Message::Transaction(Box::new(transaction_message)),
     )
@@ -479,7 +480,7 @@ fn initialize() -> (StandaloneRunner, sync::types::BlockMessage) {
     runner.init_evm();
 
     let block_message = sample_block();
-    sync::consume_message(
+    sync::consume_message::<AuroraModExp>(
         &mut runner.storage,
         sync::types::Message::Block(block_message.clone()),
     )

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -18,6 +18,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 aurora-engine-types = { path = "../engine-types", default-features = false }
 aurora-engine-sdk = { path = "../engine-sdk", default-features = false }
+aurora-engine-modexp = { path = "../engine-modexp", default-features = false }
 aurora-engine-precompiles = { path = "../engine-precompiles", default-features = false }
 aurora-engine-transactions = { path = "../engine-transactions", default-features = false }
 bitflags = { version = "1.3", default-features = false }

--- a/engine/src/connector.rs
+++ b/engine/src/connector.rs
@@ -576,9 +576,9 @@ impl<I: IO + Copy> EthConnectorContract<I> {
     }
 
     /// `ft_on_transfer` callback function.
-    pub fn ft_on_transfer<E: Env>(
+    pub fn ft_on_transfer<E: Env, M: aurora_engine_modexp::ModExpAlgorithm>(
         &mut self,
-        engine: &Engine<I, E>,
+        engine: &Engine<I, E, M>,
         args: &NEP141FtOnTransferArgs,
     ) -> Result<(), error::FtTransferCallError> {
         sdk::log!("Call ft_on_transfer");

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -1,6 +1,7 @@
 use crate::parameters::{
     CallArgs, NEP141FtOnTransferArgs, ResultLog, SubmitArgs, SubmitResult, ViewCallArgs,
 };
+use aurora_engine_types::PhantomData;
 use core::mem;
 use evm::backend::{Apply, ApplyBackend, Backend, Basic, Log};
 use evm::executor;
@@ -30,6 +31,7 @@ use crate::prelude::{
     Yocto, ERC20_MINT_SELECTOR, H160, H256, U256,
 };
 use crate::state::EngineState;
+use aurora_engine_modexp::ModExpAlgorithm;
 use aurora_engine_precompiles::PrecompileConstructorContext;
 use core::cell::RefCell;
 use core::iter::once;
@@ -347,13 +349,14 @@ impl<'env, I: IO + Copy, E: Env, H: ReadOnlyPromiseHandler> StackExecutorParams<
         }
     }
 
-    fn make_executor<'a>(
+    #[allow(clippy::type_complexity)]
+    fn make_executor<'a, M: ModExpAlgorithm>(
         &'a self,
-        engine: &'a Engine<'env, I, E>,
+        engine: &'a Engine<'env, I, E, M>,
     ) -> executor::stack::StackExecutor<
         'static,
         'a,
-        executor::stack::MemoryStackState<Engine<'env, I, E>>,
+        executor::stack::MemoryStackState<Engine<'env, I, E, M>>,
         Precompiles<'env, I, E, H>,
     > {
         let metadata = executor::stack::StackSubstateMetadata::new(self.gas_limit, CONFIG);
@@ -369,7 +372,7 @@ pub struct GasPaymentResult {
     pub priority_fee_per_gas: U256,
 }
 
-pub struct Engine<'env, I: IO, E: Env> {
+pub struct Engine<'env, I: IO, E: Env, M: ModExpAlgorithm + 'static> {
     state: EngineState,
     origin: Address,
     gas_price: U256,
@@ -380,11 +383,12 @@ pub struct Engine<'env, I: IO, E: Env> {
     account_info_cache: RefCell<FullCache<Address, Basic>>,
     contract_code_cache: RefCell<FullCache<Address, Vec<u8>>>,
     contract_storage_cache: RefCell<FullCache<(Address, H256), H256>>,
+    modexp_algorithm: PhantomData<M>,
 }
 
 pub(crate) const CONFIG: &Config = &Config::london();
 
-impl<'env, I: IO + Copy, E: Env> Engine<'env, I, E> {
+impl<'env, I: IO + Copy, E: Env, M: ModExpAlgorithm> Engine<'env, I, E, M> {
     pub fn new(
         origin: Address,
         current_account_id: AccountId,
@@ -413,6 +417,7 @@ impl<'env, I: IO + Copy, E: Env> Engine<'env, I, E> {
             account_info_cache: RefCell::new(FullCache::default()),
             contract_code_cache: RefCell::new(FullCache::default()),
             contract_storage_cache: RefCell::new(FullCache::default()),
+            modexp_algorithm: PhantomData::default(),
         }
     }
 
@@ -790,6 +795,7 @@ impl<'env, I: IO + Copy, E: Env> Engine<'env, I, E> {
             io,
             env,
             promise_handler: ro_promise_handler,
+            mod_exp_algorithm: self.modexp_algorithm,
         });
 
         Self::apply_pause_flags_to_precompiles(precompiles, pause_flags)
@@ -811,7 +817,7 @@ impl<'env, I: IO + Copy, E: Env> Engine<'env, I, E> {
     }
 }
 
-pub fn submit<I: IO + Copy, E: Env, P: PromiseHandler>(
+pub fn submit<I: IO + Copy, E: Env, P: PromiseHandler, M: ModExpAlgorithm + 'static>(
     mut io: I,
     env: &E,
     args: &SubmitArgs,
@@ -874,7 +880,8 @@ pub fn submit<I: IO + Copy, E: Env, P: PromiseHandler>(
         return Err(EngineErrorKind::MaxPriorityGasFeeTooLarge.into());
     }
 
-    let mut engine = Engine::new_with_state(state, sender, current_account_id, io, env);
+    let mut engine: Engine<I, E, M> =
+        Engine::new_with_state(state, sender, current_account_id, io, env);
     let prepaid_amount =
         match engine.charge_gas(&sender, &transaction, args.max_gas_price.map(Into::into)) {
             Ok(gas_result) => gas_result,
@@ -958,7 +965,7 @@ pub fn refund_on_error<I: IO + Copy, E: Env, P: PromiseHandler>(
     if let Some(erc20_address) = args.erc20_address {
         // ERC-20 exit; re-mint burned tokens
         let erc20_admin_address = current_address(&current_account_id);
-        let mut engine =
+        let mut engine: Engine<I, E, aurora_engine_modexp::AuroraModExp> =
             Engine::new_with_state(state, erc20_admin_address, current_account_id, io, env);
         let erc20_address = erc20_address;
         let refund_address = args.recipient_address;
@@ -977,7 +984,8 @@ pub fn refund_on_error<I: IO + Copy, E: Env, P: PromiseHandler>(
     } else {
         // ETH exit; transfer ETH back from precompile address
         let exit_address = aurora_engine_precompiles::native::exit_to_near::ADDRESS;
-        let mut engine = Engine::new_with_state(state, exit_address, current_account_id, io, env);
+        let mut engine: Engine<I, E, aurora_engine_modexp::AuroraModExp> =
+            Engine::new_with_state(state, exit_address, current_account_id, io, env);
         let refund_address = args.recipient_address;
         let amount = Wei::new(U256::from_big_endian(&args.amount));
         engine.call(
@@ -1104,7 +1112,7 @@ pub fn deploy_erc20_token<I: IO + Copy, E: Env, P: PromiseHandler>(
 ) -> Result<Address, DeployErc20Error> {
     let current_account_id = env.current_account_id();
     let input = setup_deploy_erc20_input(&current_account_id);
-    let mut engine = Engine::new(
+    let mut engine: Engine<I, E, aurora_engine_modexp::AuroraModExp> = Engine::new(
         aurora_engine_sdk::types::near_account_to_evm_address(
             env.predecessor_account_id().as_bytes(),
         ),
@@ -1427,7 +1435,9 @@ unsafe fn schedule_promise_callback<P: PromiseHandler>(
     handler.promise_attach_callback(base_id, promise)
 }
 
-impl<'env, I: IO + Copy, E: Env> evm::backend::Backend for Engine<'env, I, E> {
+impl<'env, I: IO + Copy, E: Env, M: ModExpAlgorithm> evm::backend::Backend
+    for Engine<'env, I, E, M>
+{
     /// Returns the "effective" gas price (as defined by EIP-1559)
     fn gas_price(&self) -> U256 {
         self.gas_price
@@ -1594,7 +1604,7 @@ impl<'env, I: IO + Copy, E: Env> evm::backend::Backend for Engine<'env, I, E> {
     }
 }
 
-impl<'env, J: IO + Copy, E: Env> ApplyBackend for Engine<'env, J, E> {
+impl<'env, J: IO + Copy, E: Env, M: ModExpAlgorithm> ApplyBackend for Engine<'env, J, E, M> {
     fn apply<A, I, L>(&mut self, values: A, _logs: L, delete_empty: bool)
     where
         A: IntoIterator<Item = Apply<I>>,
@@ -1722,6 +1732,7 @@ impl<'env, J: IO + Copy, E: Env> ApplyBackend for Engine<'env, J, E> {
 mod tests {
     use super::*;
     use crate::parameters::{FunctionCallArgsV1, FunctionCallArgsV2};
+    use aurora_engine_modexp::AuroraModExp;
     use aurora_engine_precompiles::make_address;
     use aurora_engine_sdk::env::Fixed;
     use aurora_engine_sdk::promise::Noop;
@@ -1738,7 +1749,7 @@ mod tests {
         let storage = RefCell::new(Storage::default());
         let mut io = StoragePointer(&storage);
         add_balance(&mut io, &origin, Wei::new_u64(22000)).unwrap();
-        let engine =
+        let engine: Engine<_, _, AuroraModExp> =
             Engine::new_with_state(EngineState::default(), origin, current_account_id, io, &env);
 
         let contract = make_address(1, 1);
@@ -1763,7 +1774,7 @@ mod tests {
         let env = Fixed::default();
         let storage = RefCell::new(Storage::default());
         let io = StoragePointer(&storage);
-        let mut engine =
+        let mut engine: Engine<_, _, AuroraModExp> =
             Engine::new_with_state(EngineState::default(), origin, current_account_id, io, &env);
 
         let input = vec![];
@@ -1789,7 +1800,7 @@ mod tests {
         let storage = RefCell::new(Storage::default());
         let mut io = StoragePointer(&storage);
         add_balance(&mut io, &origin, Wei::new_u64(22000)).unwrap();
-        let mut engine =
+        let mut engine: Engine<_, _, AuroraModExp> =
             Engine::new_with_state(EngineState::default(), origin, current_account_id, io, &env);
 
         let input = Vec::<u8>::new();
@@ -1819,7 +1830,7 @@ mod tests {
         let env = Fixed::default();
         let storage = RefCell::new(Storage::default());
         let io = StoragePointer(&storage);
-        let mut engine =
+        let mut engine: Engine<_, _, AuroraModExp> =
             Engine::new_with_state(EngineState::default(), origin, current_account_id, io, &env);
 
         let input = Vec::<u8>::new();
@@ -1849,7 +1860,7 @@ mod tests {
         let storage = RefCell::new(Storage::default());
         let mut io = StoragePointer(&storage);
         add_balance(&mut io, &origin, Wei::new_u64(22000)).unwrap();
-        let mut engine =
+        let mut engine: Engine<_, _, AuroraModExp> =
             Engine::new_with_state(EngineState::default(), origin, current_account_id, io, &env);
 
         let gas_limit = u64::MAX;
@@ -1877,7 +1888,7 @@ mod tests {
         let storage = RefCell::new(Storage::default());
         let mut io = StoragePointer(&storage);
         add_balance(&mut io, &origin, Wei::new_u64(22000)).unwrap();
-        let mut engine =
+        let mut engine: Engine<_, _, AuroraModExp> =
             Engine::new_with_state(EngineState::default(), origin, current_account_id, io, &env);
 
         let input = Vec::<u8>::new();
@@ -1903,7 +1914,7 @@ mod tests {
         let storage = RefCell::new(Storage::default());
         let mut io = StoragePointer(&storage);
         add_balance(&mut io, &origin, Wei::new_u64(22000)).unwrap();
-        let mut engine =
+        let mut engine: Engine<_, _, AuroraModExp> =
             Engine::new_with_state(EngineState::default(), origin, current_account_id, io, &env);
 
         let account_id = AccountId::new("relayer").unwrap();
@@ -1922,7 +1933,7 @@ mod tests {
         let storage = RefCell::new(Storage::default());
         let mut io = StoragePointer(&storage);
         set_balance(&mut io, &origin, &Wei::new_u64(22000));
-        let mut engine = Engine::new_with_state(
+        let mut engine: Engine<_, _, AuroraModExp> = Engine::new_with_state(
             EngineState::default(),
             origin,
             current_account_id.clone(),
@@ -1982,7 +1993,7 @@ mod tests {
         let storage = RefCell::new(Storage::default());
         let mut io = StoragePointer(&storage);
         add_balance(&mut io, &origin, Wei::new_u64(22000)).unwrap();
-        let mut engine =
+        let mut engine: Engine<_, _, AuroraModExp> =
             Engine::new_with_state(EngineState::default(), origin, current_account_id, io, &env);
 
         let transaction = NormalizedEthTransaction {
@@ -2072,7 +2083,7 @@ mod tests {
         let env = Fixed::default();
         let storage = RefCell::new(Storage::default());
         let mut io = StoragePointer(&storage);
-        let engine =
+        let engine: Engine<_, _, AuroraModExp> =
             Engine::new_with_state(EngineState::default(), origin, current_account_id, io, &env);
 
         let expected_value = H256::from_low_u64_le(64);
@@ -2093,7 +2104,8 @@ mod tests {
         let mut io = StoragePointer(&storage);
         let expected_state = EngineState::default();
         state::set_state(&mut io, &expected_state).unwrap();
-        let engine = Engine::new(origin, current_account_id, io, &env).unwrap();
+        let engine: Engine<_, _, AuroraModExp> =
+            Engine::new(origin, current_account_id, io, &env).unwrap();
         let actual_state = engine.state;
 
         assert_eq!(expected_state, actual_state);

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -101,6 +101,7 @@ mod contract {
     use crate::prelude::storage::{bytes_to_key, KeyPrefix};
     use crate::prelude::{sdk, u256_to_arr, Address, PromiseResult, Yocto, ERR_FAILED_PARSE, H256};
     use crate::{errors, pausables, state};
+    use aurora_engine_modexp::AuroraModExp;
     use aurora_engine_sdk::env::Env;
     use aurora_engine_sdk::io::{StorageIntermediate, IO};
     use aurora_engine_sdk::near_runtime::{Runtime, ViewEnv};
@@ -293,7 +294,7 @@ mod contract {
         let io = Runtime;
         let input = io.read_input().to_vec();
         let current_account_id = io.current_account_id();
-        let mut engine = Engine::new(
+        let mut engine: Engine<_, _, AuroraModExp> = Engine::new(
             predecessor_address(&io.predecessor_account_id()),
             current_account_id,
             io,
@@ -326,7 +327,7 @@ mod contract {
             check_promise.sdk_unwrap();
         }
 
-        let mut engine = Engine::new(
+        let mut engine: Engine<_, _, AuroraModExp> = Engine::new(
             predecessor_address(&predecessor_account_id),
             current_account_id,
             io,
@@ -352,7 +353,7 @@ mod contract {
             tx_data,
             ..Default::default()
         };
-        let result = engine::submit(
+        let result = engine::submit::<_, _, _, AuroraModExp>(
             io,
             &io,
             &args,
@@ -376,7 +377,7 @@ mod contract {
         let current_account_id = io.current_account_id();
         let state = state::get_state(&io).sdk_unwrap();
         let relayer_address = predecessor_address(&io.predecessor_account_id());
-        let result = engine::submit(
+        let result = engine::submit::<_, _, _, AuroraModExp>(
             io,
             &io,
             &args,
@@ -398,7 +399,7 @@ mod contract {
 
         let current_account_id = io.current_account_id();
         let predecessor_account_id = io.predecessor_account_id();
-        let mut engine = Engine::new(
+        let mut engine: Engine<_, _, AuroraModExp> = Engine::new(
             predecessor_address(&predecessor_account_id),
             current_account_id,
             io,
@@ -478,7 +479,7 @@ mod contract {
         let io = Runtime;
         let current_account_id = io.current_account_id();
         let predecessor_account_id = io.predecessor_account_id();
-        let mut engine = Engine::new(
+        let mut engine: Engine<_, _, AuroraModExp> = Engine::new(
             predecessor_address(&predecessor_account_id),
             current_account_id.clone(),
             io,
@@ -561,7 +562,8 @@ mod contract {
         let env = ViewEnv;
         let args: ViewCallArgs = io.read_input_borsh().sdk_unwrap();
         let current_account_id = io.current_account_id();
-        let engine = Engine::new(args.sender, current_account_id, io, &env).sdk_unwrap();
+        let engine: Engine<_, _, AuroraModExp> =
+            Engine::new(args.sender, current_account_id, io, &env).sdk_unwrap();
         let result = Engine::view_with_args(&engine, args).sdk_unwrap();
         io.return_output(&result.try_to_vec().sdk_expect(errors::ERR_SERIALIZE));
     }
@@ -1026,7 +1028,8 @@ mod contract {
         let nonce = U256::from(args.1);
         let balance = NEP141Wei::new(u128::from(args.2));
         let current_account_id = io.current_account_id();
-        let mut engine = Engine::new(address, current_account_id, io, &io).sdk_unwrap();
+        let mut engine: Engine<_, _, AuroraModExp> =
+            Engine::new(address, current_account_id, io, &io).sdk_unwrap();
         let state_change = evm::backend::Apply::Modify {
             address: address.raw(),
             basic: evm::backend::Basic {


### PR DESCRIPTION
## Description

This makes the modexp precompile take a generic type parameter for the implementation of the algorithm. This allows the standalone engine (or other downstream users of Aurora Engine) to select their own modexp implementation. The implementation used for our Wasm contract remains unchanged (the generic is filled with a type using the implementation we already had).

## Performance / NEAR gas cost considerations

N/A

## Testing

N/A