### PR TITLE
chore: precompile librocksdb for speed up tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,8 +19,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Restore cache
         run: |
-          cache-util restore cargo_git cargo_registry yarn_cache
+          cache-util restore cargo_git cargo_registry yarn_cache rocksdb:/root/rocksdb
           cache-util restore aurora-engine-target@generic@${{ hashFiles('**/Cargo.lock') }}:target
+      - name: Preparing rocksdb library
+        run: scripts/ci/build_rocksdb.sh
       - name: Build contracts
         run: cargo make build-contracts
       - name: Test contracts
@@ -53,8 +55,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Restore cache
         run: |
-          cache-util restore cargo_git cargo_registry yarn_cache
+          cache-util restore cargo_git cargo_registry yarn_cache rocksdb:/root/rocksdb
           cache-util restore aurora-engine-target@generic@${{ hashFiles('**/Cargo.lock') }}:target
+      - name: Preparing rocksdb library
+        run: scripts/ci/build_rocksdb.sh
       - name: Test mainnet bench-modexp
         run: cargo make --profile mainnet bench-modexp
       - name: Test testnet bench-modexp
@@ -67,3 +71,6 @@ jobs:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
+  ROCKSDB_INCLUDE_DIR: /root/rocksdb/include
+  ROCKSDB_LIB_DIR: /root/rocksdb/lib
+  ROCKSDB_STATIC: 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Restore cache
         run: |
           cache-util restore cargo_git cargo_registry yarn_cache rocksdb:/root/rocksdb
-          cache-util restore aurora-engine-target@generic@${{ hashFiles('**/Cargo.lock') }}:target
+          cache-util restore aurora-engine-target@tests@${{ hashFiles('**/Cargo.lock') }}:target
       - name: Preparing rocksdb library
         run: scripts/ci/build_rocksdb.sh
       - name: Build contracts
@@ -42,7 +42,7 @@ jobs:
       - name: Save cache
         run: |
           cache-util save cargo_git cargo_registry yarn_cache
-          cache-util msave aurora-engine-target@generic@${{ hashFiles('**/Cargo.lock') }}:target
+          cache-util msave aurora-engine-target@tests@${{ hashFiles('**/Cargo.lock') }}:target
 
   test_modexp:
     name: Test modexp suite (mainnet, testnet)
@@ -56,7 +56,7 @@ jobs:
       - name: Restore cache
         run: |
           cache-util restore cargo_git cargo_registry yarn_cache rocksdb:/root/rocksdb
-          cache-util restore aurora-engine-target@generic@${{ hashFiles('**/Cargo.lock') }}:target
+          cache-util restore aurora-engine-target@modexp@${{ hashFiles('**/Cargo.lock') }}:target
       - name: Preparing rocksdb library
         run: scripts/ci/build_rocksdb.sh
       - name: Test mainnet bench-modexp
@@ -66,7 +66,7 @@ jobs:
       - name: Save cache
         run: |
           cache-util save cargo_git cargo_registry yarn_cache
-          cache-util msave aurora-engine-target@generic@${{ hashFiles('**/Cargo.lock') }}:target
+          cache-util msave aurora-engine-target@modexp@${{ hashFiles('**/Cargo.lock') }}:target
 
 env:
   CARGO_TERM_COLOR: always

--- a/scripts/ci/build_rocksdb.sh
+++ b/scripts/ci/build_rocksdb.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+ROCKSDB_VER=v7.4.4
+INSTALL_PATH=/root/rocksdb
+LIB_PATH=$INSTALL_PATH/lib/librocksdb.a
+
+if [[ ! -f $LIB_PATH ]]; then
+  apt -y install cmake libgflags-dev libsnappy-dev libbz2-dev liblz4-dev libzstd-dev
+  git clone --branch $ROCKSDB_VER https://github.com/facebook/rocksdb
+  cd rocksdb && mkdir build && cd build
+  cmake -DCMAKE_BUILD_TYPE=Release -DWITH_ZLIB=1 -DWITH_SNAPPY=1 -DWITH_LZ4=1 -DWITH_ZSTD=1 -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH ..
+  make -j32 install
+  cache-util save rocksdb:$INSTALL_PATH
+  cd $HOME
+fi


### PR DESCRIPTION
## Description

Compiling the `rocksdb` crate consumes a lot of time because it compiles `librocksdb.a` library under the hood. The PR adds additional flow in CI to precompile this library and save it into the cache for further re-using. 