### PR TITLE
chore: use workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -252,7 +252,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-engine"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "aurora-engine-modexp",
  "aurora-engine-precompiles",
@@ -838,7 +838,7 @@ dependencies = [
  "bitflags",
  "clap_derive 3.2.25",
  "clap_lex 0.2.4",
- "indexmap",
+ "indexmap 1.9.3",
  "once_cell",
  "strsim",
  "termcolor",
@@ -847,9 +847,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.5"
+version = "4.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2686c4115cb0810d9a984776e197823d08ec94f176549a89a9efded477c456dc"
+checksum = "bba77a07e4489fb41bd90e8d4201c3eb246b3c2c9ea2ba0bddd6c1d1df87db7d"
 dependencies = [
  "clap_builder",
  "clap_derive 4.3.2",
@@ -858,9 +858,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.5"
+version = "4.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e53afce1efce6ed1f633cf0e57612fe51db54a1ee4fd8f8503d078fe02d69ae"
+checksum = "2c9b4a88bb4bc35d3d6f65a21b0f0bafe9c894fa00978de242c555ec28bea1c0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -891,7 +891,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -1014,7 +1014,7 @@ dependencies = [
  "cranelift-entity",
  "fxhash",
  "hashbrown 0.12.3",
- "indexmap",
+ "indexmap 1.9.3",
  "log",
  "smallvec",
 ]
@@ -1084,19 +1084,19 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
 dependencies = [
  "anes",
- "atty",
  "cast",
  "ciborium",
- "clap 3.2.25",
+ "clap 4.3.9",
  "criterion-plot",
+ "is-terminal",
  "itertools",
- "lazy_static",
  "num-traits",
+ "once_cell",
  "oorandom",
  "plotters",
  "rayon",
@@ -1244,7 +1244,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -1255,7 +1255,7 @@ checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -1266,7 +1266,7 @@ checksum = "53e0efad4403bfc52dc201159c4b842a246a14b98c64b55dfd0f2d89729dfeb8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -1456,7 +1456,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -1464,6 +1464,12 @@ name = "environmental"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48c92028aaa870e83d51c64e5d4e0b6981b360c522198c23959f219a4e1b15b"
+
+[[package]]
+name = "equivalent"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
 
 [[package]]
 name = "errno"
@@ -1643,7 +1649,7 @@ dependencies = [
  "num-traits",
  "prefix-sum-vec",
  "thiserror",
- "wasm-encoder",
+ "wasm-encoder 0.22.1",
  "wasmparser 0.99.0",
  "wasmprinter",
 ]
@@ -1767,7 +1773,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -1857,7 +1863,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 dependencies = [
  "fallible-iterator",
- "indexmap",
+ "indexmap 1.9.3",
  "stable_deref_trait",
 ]
 
@@ -1890,9 +1896,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
+checksum = "97ec8491ebaf99c8eaa73058b045fe58073cd6be7f596ac993ced0b0a0c01049"
 dependencies = [
  "bytes",
  "fnv",
@@ -1900,7 +1906,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "slab",
  "tokio",
  "tokio-util 0.7.3",
@@ -1954,6 +1960,12 @@ checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash 0.8.3",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "heapsize"
@@ -2078,9 +2090,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.26"
+version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2218,6 +2230,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2305,7 +2327,7 @@ checksum = "b111244b70d4cf22aaaf8e0461ede19d623880f0f4779ee33dc35850a825bec3"
 dependencies = [
  "lazy_static",
  "manifest-dir-macros",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -2331,9 +2353,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.146"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libgit2-sys"
@@ -2533,7 +2555,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -2800,7 +2822,7 @@ source = "git+https://github.com/birchmd/nearcore.git?rev=71c9b3f4c62f1bff24982a
 dependencies = [
  "actix",
  "atty",
- "clap 4.3.5",
+ "clap 4.3.9",
  "near-crypto 0.0.0",
  "near-primitives-core 0.0.0",
  "once_cell",
@@ -2977,7 +2999,7 @@ source = "git+https://github.com/birchmd/nearcore.git?rev=71c9b3f4c62f1bff24982a
 dependencies = [
  "quote",
  "serde",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -2999,7 +3021,7 @@ dependencies = [
  "fs2",
  "near-rpc-error-core 0.0.0",
  "serde",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -3350,7 +3372,7 @@ name = "near-vm-types"
 version = "0.0.0"
 source = "git+https://github.com/birchmd/nearcore.git?rev=71c9b3f4c62f1bff24982a179be64e6d03df0e16#71c9b3f4c62f1bff24982a179be64e6d03df0e16"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "num-traits",
  "rkyv",
  "thiserror",
@@ -3365,7 +3387,7 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "finite-wasm",
- "indexmap",
+ "indexmap 1.9.3",
  "libc",
  "memoffset 0.6.5",
  "more-asserts",
@@ -3557,7 +3579,7 @@ checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
 dependencies = [
  "crc32fast",
  "hashbrown 0.12.3",
- "indexmap",
+ "indexmap 1.9.3",
  "memchr",
 ]
 
@@ -3758,7 +3780,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.3.5",
  "smallvec",
- "windows-targets 0.48.0",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -3786,23 +3808,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 1.9.3",
 ]
 
 [[package]]
 name = "phf"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928c6535de93548188ef63bb7c4036bd415cd8f36ad25af44b9789b2ee72a48c"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
 dependencies = [
  "phf_shared",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1fb5f6f826b772a8d4c0394209441e7d37cbbb967ae9c7e0e8134365c9ee676"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
  "siphasher",
 ]
@@ -3824,7 +3846,7 @@ checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -3997,9 +4019,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.60"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]
@@ -4120,9 +4142,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -4610,14 +4632,14 @@ checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.97"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a"
+checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
 dependencies = [
  "itoa",
  "ryu",
@@ -4632,16 +4654,16 @@ checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.21"
+version = "0.9.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9d684e3ec7de3bf5466b32bd75303ac16f0736426e5a4e0d6e489559ce1249c"
+checksum = "452e67b9c20c37fa79df53201dc03839651086ed9bbe92b3ca585ca9fdaa7d85"
 dependencies = [
- "indexmap",
+ "indexmap 2.0.0",
  "itoa",
  "ryu",
  "serde",
@@ -4841,9 +4863,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4949,7 +4971,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -5159,17 +5181,17 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.10"
+version = "0.19.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
+checksum = "266f016b7f039eec8a1a80dfe6156b633d208b9fccca5e4db1d6775b0c4e34a7"
 dependencies = [
- "indexmap",
+ "indexmap 2.0.0",
  "toml_datetime",
  "winnow",
 ]
@@ -5225,7 +5247,7 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
  "rand 0.8.5",
@@ -5281,7 +5303,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -5433,9 +5455,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.3.4"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa2982af2eec27de306107c027578ff7f423d65f7250e40ce0fea8f45248b81"
+checksum = "d023da39d1fde5a8a3fe1f3e01ca9632ada0a63e9797de55a879d6e2236277be"
 
 [[package]]
 name = "valuable"
@@ -5473,16 +5495,18 @@ dependencies = [
 
 [[package]]
 name = "walrus"
-version = "0.19.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb08e48cde54c05f363d984bb54ce374f49e242def9468d2e1b6c2372d291f8"
+checksum = "cc27d837c587f863d99515dc8cae7cef1098bd1d99fa29373e3660c12766265e"
 dependencies = [
  "anyhow",
+ "gimli 0.26.2",
  "id-arena",
  "leb128",
  "log",
  "walrus-macro",
- "wasmparser 0.77.1",
+ "wasm-encoder 0.29.0",
+ "wasmparser 0.80.2",
 ]
 
 [[package]]
@@ -5545,7 +5569,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
  "wasm-bindgen-shared",
 ]
 
@@ -5567,7 +5591,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5583,6 +5607,15 @@ name = "wasm-encoder"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a584273ccc2d9311f1dd19dc3fb26054661fa3e373d53ede5d1144ba07a9acd"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18c41dbd92eaebf3612a39be316540b8377c871cb9bde6b064af962984912881"
 dependencies = [
  "leb128",
 ]
@@ -5673,7 +5706,7 @@ dependencies = [
  "digest 0.8.1",
  "errno 0.2.8",
  "hex",
- "indexmap",
+ "indexmap 1.9.3",
  "lazy_static",
  "libc",
  "nix",
@@ -5730,7 +5763,7 @@ version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1131dfac4d92947acef554a75b433122ca635414c23934f53434ec0efc5994d"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "rkyv",
  "thiserror",
 ]
@@ -5744,7 +5777,7 @@ dependencies = [
  "backtrace",
  "cc",
  "cfg-if 1.0.0",
- "indexmap",
+ "indexmap 1.9.3",
  "libc",
  "memoffset 0.6.5",
  "more-asserts",
@@ -5763,15 +5796,15 @@ checksum = "aeb1956b19469d1c5e63e459d29e7b5aa0f558d9f16fcef09736f8a265e6c10a"
 
 [[package]]
 name = "wasmparser"
-version = "0.77.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe3d5405e9ea6c1317a656d6e0820912d8b7b3607823a7596117c8f666daf6f"
-
-[[package]]
-name = "wasmparser"
 version = "0.78.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52144d4c78e5cf8b055ceab8e5fa22814ce4315d6002ad32cfd914f37c12fd65"
+
+[[package]]
+name = "wasmparser"
+version = "0.80.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449167e2832691a1bff24cde28d2804e90e09586a448c8e76984792c44334a6b"
 
 [[package]]
 name = "wasmparser"
@@ -5779,7 +5812,7 @@ version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ea896273ea99b15132414be1da01ab0d8836415083298ecaffbe308eaac87a"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "url",
 ]
 
@@ -5789,7 +5822,7 @@ version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ef3b717afc67f848f412d4f02c127dd3e35a0eecd58c684580414df4fde01d3"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "url",
 ]
 
@@ -5799,7 +5832,7 @@ version = "0.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29e3ac9b780c7dda0cac7a52a5d6d2d6707cc6e3451c9db209b6c758f40d7acb"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "semver 1.0.17",
 ]
 
@@ -5822,7 +5855,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "cfg-if 1.0.0",
- "indexmap",
+ "indexmap 1.9.3",
  "libc",
  "log",
  "object 0.29.0",
@@ -5878,7 +5911,7 @@ dependencies = [
  "anyhow",
  "cranelift-entity",
  "gimli 0.26.2",
- "indexmap",
+ "indexmap 1.9.3",
  "log",
  "object 0.29.0",
  "serde",
@@ -5940,7 +5973,7 @@ dependencies = [
  "anyhow",
  "cc",
  "cfg-if 1.0.0",
- "indexmap",
+ "indexmap 1.9.3",
  "libc",
  "log",
  "mach",
@@ -6037,7 +6070,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -6070,7 +6103,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -6090,9 +6123,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
  "windows_aarch64_gnullvm 0.48.0",
  "windows_aarch64_msvc 0.48.0",
@@ -6222,7 +6255,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,90 @@
+[workspace.package]
+authors = ["Aurora Labs <hello@aurora.dev>"]
+edition = "2021"
+homepage = "https://github.com/aurora-is-near/aurora-engine"
+repository = "https://github.com/aurora-is-near/aurora-engine"
+license = "CC0-1.0"
+readme = "README.md"
+publish = false
+
+[workspace.dependencies]
+aurora-engine = { path = "engine", default-features = false }
+aurora-engine-precompiles = { path = "engine-precompiles", default-features = false }
+aurora-engine-sdk = { path = "engine-sdk", default-features = false }
+aurora-engine-transactions = { path = "engine-transactions", default-features = false }
+aurora-engine-types = { path = "engine-types", default-features = false }
+aurora-engine-modexp = { path = "engine-modexp", default-features = false }
+aurora-engine-test-doubles = { path = "engine-test-doubles" }
+engine-standalone-storage = { path = "engine-standalone-storage" }
+engine-standalone-tracing = { path = "engine-standalone-tracing", default-features = false, features = ["impl-serde"] }
+
+base64 = { version = "0.21", default-features = false, features = ["alloc"] }
+bitflags = { version = "1", default-features = false }
+bn = { version = "0.5", package = "zeropool-bn", default-features = false }
+borsh = { version = "0.10", default-features = false }
+borsh-compat = { version = "0.9", package = "borsh", default-features = false }
+bstr = "1"
+byte-slice-cast = { version = "1", default-features = false }
+criterion = "0.5"
+digest = "0.10"
+ethabi = { version = "18", default-features = false }
+evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.0-aurora", default-features = false }
+evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.0-aurora", default-features = false, features = ["std"] }
+evm-gasometer = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.0-aurora", default-features = false, features = ["std", "tracing"] }
+evm-runtime = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.0-aurora", default-features = false, features = ["std", "tracing"] }
+git2 = "0.17"
+hex = { version = "0.4", default-features = false, features = ["alloc"] }
+ibig = { version = "0.3", default-features = false, features = ["num-traits"] }
+libsecp256k1 = { version = "0.7", default-features = false }
+near-crypto = "0.16"
+near-primitives = "0.16"
+near-primitives-core = "0.16"
+near-sdk-sim = { git = "https://github.com/aurora-is-near/near-sdk-rs.git", rev = "cc4d4aaf2e1f7297aa060b342ca3ef3ff8e67003" }
+near-vm-errors = "0.16"
+near-vm-logic = "0.16"
+near-vm-runner = { version = "0.16", default-features = false, features = [ "wasmer2_vm", "wasmtime_vm" ] }
+num = { version = "0.4", default-features = false, features = ["alloc"] }
+postgres = "0.19"
+primitive-types = { version = "0.12", default-features = false, features = ["rlp", "serde_no_std"] }
+rand = "0.8"
+ripemd = { version = "0.1", default-features = false }
+rlp = { version = "0.5", default-features = false }
+rocksdb = { version = "0.19", default-features = false }
+serde = { version = "1", default-features = false, features = ["alloc", "derive"] }
+serde_json = { version = "1", default-features = false, features = ["alloc"] }
+sha2 = { version = "0.10", default-features = false }
+sha3 = { version = "0.10", default-features = false }
+tempfile = "3"
+test-case = "3.1"
+walrus = "0.20"
+wee_alloc = { version = "0.4", default-features = false }
+
+
+[workspace]
+resolver = "2"
+members = [
+    "engine",
+    "engine-test-doubles",
+    "engine-modexp",
+    "engine-precompiles",
+    "engine-sdk",
+    "engine-standalone-storage",
+    "engine-standalone-tracing",
+    "engine-tests",
+    "engine-transactions",
+    "engine-types",
+]
+
+exclude = [
+    "etc/tests/state-migration-test",
+    "etc/tests/ft-receiver",
+    "etc/tests/benchmark-contract",
+    "etc/tests/self-contained-5bEgfRQ",
+    "etc/tests/fibonacci",
+    "etc/tests/modexp-bench",
+    "etc/xcc-router",
+]
+
 [profile.release]
 opt-level = 3
 debug = false
@@ -26,27 +113,3 @@ rpath = false
 # it to actually happen when running tests with --release
 lto = true
 opt-level = 3
-
-[workspace]
-resolver = "2"
-members = [
-    "engine",
-    "engine-test-doubles",
-    "engine-modexp",
-    "engine-precompiles",
-    "engine-sdk",
-    "engine-standalone-storage",
-    "engine-standalone-tracing",
-    "engine-tests",
-    "engine-transactions",
-    "engine-types",
-]
-exclude = [
-    "etc/tests/state-migration-test",
-    "etc/tests/ft-receiver",
-    "etc/tests/benchmark-contract",
-    "etc/tests/self-contained-5bEgfRQ",
-    "etc/tests/fibonacci",
-    "etc/tests/modexp-bench",
-    "etc/xcc-router",
-]

--- a/engine-modexp/Cargo.toml
+++ b/engine-modexp/Cargo.toml
@@ -1,23 +1,19 @@
 [package]
 name = "aurora-engine-modexp"
 version = "1.0.0"
-authors = ["Aurora Labs <hello@aurora.dev>"]
-edition = "2021"
-description = ""
-documentation = ""
-readme = true
-homepage = "https://github.com/aurora-is-near/aurora-engine"
-repository = "https://github.com/aurora-is-near/aurora-engine"
-license = "CC0-1.0"
-publish = false
+authors.workspace = true
+edition.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+publish.workspace = true
 autobenches = false
 
 [dependencies]
-ibig = { version = "0.3.6", default-features = false, features = ["num-traits"] }
-num = { version = "0.4.0", default-features = false, features = ["alloc"] }
-hex = { version = "0.4", default-features = false, features = ["alloc"] }
-
-[dev-dependencies]
+hex.workspace = true
+num.workspace = true
+ibig.workspace = true
 
 [features]
 default = ["std"]

--- a/engine-precompiles/Cargo.toml
+++ b/engine-precompiles/Cargo.toml
@@ -1,36 +1,34 @@
 [package]
 name = "aurora-engine-precompiles"
 version = "1.0.0"
-authors = ["Aurora Labs <hello@aurora.dev>"]
-edition = "2021"
-description = ""
-documentation = ""
-readme = true
-homepage = "https://github.com/aurora-is-near/aurora-engine"
-repository = "https://github.com/aurora-is-near/aurora-engine"
-license = "CC0-1.0"
-publish = false
+authors.workspace = true
+edition.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+publish.workspace = true
 autobenches = false
 
 [dependencies]
-aurora-engine-modexp = { path = "../engine-modexp", default-features = false }
-aurora-engine-types = { path = "../engine-types", default-features = false }
-aurora-engine-sdk = { path = "../engine-sdk", default-features = false }
-bn = { version = "0.5.11", package = "zeropool-bn", default-features = false }
-evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.0-aurora", default-features = false }
-libsecp256k1 = { version = "0.7.0", default-features = false, features = ["static-context", "hmac"] }
-num = { version = "0.4.0", default-features = false, features = ["alloc"] }
-ripemd = { version = "0.1.1", default-features = false }
-sha2 = { version = "0.10.2", default-features = false }
-sha3 = { version = "0.10.2", default-features = false }
-ethabi = { version = "18.0", default-features = false }
-hex = { version = "0.4", default-features = false, features = ["alloc"] }
+aurora-engine-modexp.workspace = true
+aurora-engine-sdk.workspace = true
+aurora-engine-types.workspace = true
+bn.workspace = true
+ethabi.workspace = true
+evm.workspace = true
+hex.workspace = true
+libsecp256k1 = { workspace = true, features = ["static-context", "hmac"] }
+num.workspace = true
+ripemd.workspace = true
+sha2.workspace = true
+sha3.workspace = true
 
 [dev-dependencies]
-aurora-engine-test-doubles = { path = "../engine-test-doubles" }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-rand = "0.8.5"
+aurora-engine-test-doubles.workspace = true
+rand.workspace = true
+serde = { workspace = true, default-features = true, features = ["derive"] }
+serde_json = { workspace = true, default-features = true }
 
 [features]
 default = ["std"]

--- a/engine-precompiles/Cargo.toml
+++ b/engine-precompiles/Cargo.toml
@@ -27,8 +27,8 @@ sha3.workspace = true
 [dev-dependencies]
 aurora-engine-test-doubles.workspace = true
 rand.workspace = true
-serde = { workspace = true, default-features = true, features = ["derive"] }
-serde_json = { workspace = true, default-features = true }
+serde.workspace = true
+serde_json.workspace = true
 
 [features]
 default = ["std"]

--- a/engine-sdk/Cargo.toml
+++ b/engine-sdk/Cargo.toml
@@ -1,23 +1,20 @@
 [package]
 name = "aurora-engine-sdk"
 version = "1.0.0"
-authors = ["Aurora Labs <hello@aurora.dev>"]
-edition = "2021"
-description = ""
-documentation = ""
-readme = true
-homepage = "https://github.com/aurora-is-near/aurora-engine"
-repository = "https://github.com/aurora-is-near/aurora-engine"
-license = "CC0-1.0"
-publish = false
+authors.workspace = true
+edition.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+publish.workspace = true
 autobenches = false
 
 [dependencies]
-aurora-engine-types = { path = "../engine-types", default-features = false }
-
-base64 = { version = "0.21", default-features = false, features = [ "alloc" ] }
-sha2 = { version = "0.10", default-features = false }
-sha3 = { version = "0.10", default-features = false }
+aurora-engine-types.workspace = true
+base64.workspace = true
+sha2.workspace = true
+sha3.workspace = true
 
 [features]
 std = ["aurora-engine-types/std", "sha3/std", "sha2/std", "base64/std" ]

--- a/engine-standalone-storage/Cargo.toml
+++ b/engine-standalone-storage/Cargo.toml
@@ -21,11 +21,11 @@ aurora-engine-precompiles = { workspace = true, features = ["std"] }
 aurora-engine-sdk = { workspace = true, features = ["std"] }
 aurora-engine-transactions = { workspace = true, features = ["std"] }
 evm-core.workspace = true
-hex = { workspace = true, default-features = true }
+hex = { workspace = true, features = ["std"] }
 rocksdb.workspace = true
 postgres.workspace = true
-serde = { workspace = true, default-features = true }
-serde_json = { workspace = true, default-features = true }
+serde = { workspace = true, features = ["std"] }
+serde_json = { workspace = true, features = ["std"] }
 
 [features]
 default = ["snappy", "lz4", "zstd", "zlib"]

--- a/engine-standalone-storage/Cargo.toml
+++ b/engine-standalone-storage/Cargo.toml
@@ -1,31 +1,31 @@
 [package]
 name = "engine-standalone-storage"
 version = "0.1.0"
-edition = "2021"
-authors = ["Aurora Labs <hello@aurora.dev>"]
+authors.workspace = true
+edition.workspace = true
 description = "Aurora engine standalone storage library. Provides the storage backend used by the standalone engine."
-homepage = "https://github.com/aurora-is-near/aurora-engine"
-repository = "https://github.com/aurora-is-near/aurora-engine"
-license = "CC0-1.0"
-publish = false
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+publish.workspace = true
 autobenches = false
 
 [lib]
 crate-type = ["lib"]
 
 [dependencies]
-aurora-engine = { path = "../engine", default-features = false, features = ["std"] }
-aurora-engine-types = { path = "../engine-types", default-features = false, features = ["std"] }
-aurora-engine-modexp = { path = "../engine-modexp", default-features = false, features = ["std"] }
-aurora-engine-sdk = { path = "../engine-sdk", default-features = false, features = ["std"] }
-aurora-engine-transactions = { path = "../engine-transactions", default-features = false, features = ["std"] }
-aurora-engine-precompiles = { path = "../engine-precompiles", default-features = false, features = ["std"] }
-evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.0-aurora", default-features = false }
-hex = "0.4.3"
-rocksdb = { version = "0.19.0", default-features = false }
-postgres = "0.19.2"
-serde = "1.0.130"
-serde_json = "1.0.72"
+aurora-engine = { workspace = true, features = ["std"] }
+aurora-engine-types = { workspace = true, features = ["std"] }
+aurora-engine-modexp = { workspace = true, features = ["std"] }
+aurora-engine-precompiles = { workspace = true, features = ["std"] }
+aurora-engine-sdk = { workspace = true, features = ["std"] }
+aurora-engine-transactions = { workspace = true, features = ["std"] }
+evm-core.workspace = true
+hex = { workspace = true, default-features = true }
+rocksdb.workspace = true
+postgres.workspace = true
+serde = { workspace = true, default-features = true }
+serde_json = { workspace = true, default-features = true }
 
 [features]
 default = ["snappy", "lz4", "zstd", "zlib"]

--- a/engine-standalone-tracing/Cargo.toml
+++ b/engine-standalone-tracing/Cargo.toml
@@ -1,26 +1,26 @@
 [package]
 name = "engine-standalone-tracing"
 version = "0.1.0"
-edition = "2021"
-authors = ["Aurora Labs <hello@aurora.dev>"]
+edition.workspace = true
+authors.workspace = true
 description = "Aurora engine standalone tracing library. Provides functions and types for extracing geth-like traces from standalone engine execution."
-homepage = "https://github.com/aurora-is-near/aurora-engine"
-repository = "https://github.com/aurora-is-near/aurora-engine"
-license = "CC0-1.0"
-publish = false
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+publish.workspace = true
 autobenches = false
 
 [lib]
 crate-type = ["lib"]
 
 [dependencies]
-aurora-engine-types = { path = "../engine-types", default-features = false, features = ["std"] }
-evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.0-aurora", default-features = false, features = ["std"] }
-evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.0-aurora", default-features = false, features = ["std", "tracing"] }
-evm-runtime = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.0-aurora", default-features = false, features = ["std", "tracing"] }
-evm-gasometer = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.0-aurora", default-features = false, features = ["std", "tracing"] }
-hex = { version = "0.4", default-features = false, features = ["std"] }
-serde = { version = "1", features = ["derive"], optional = true }
+aurora-engine-types = { workspace = true, features = ["std"] }
+evm-core.workspace = true
+evm = { workspace = true, features = ["std", "tracing"] }
+evm-runtime.workspace = true
+evm-gasometer.workspace = true
+hex = { workspace = true, features = ["std"] }
+serde = { workspace = true, default-features = true, features = ["derive"], optional = true }
 
 [features]
 default = []

--- a/engine-standalone-tracing/Cargo.toml
+++ b/engine-standalone-tracing/Cargo.toml
@@ -20,7 +20,7 @@ evm = { workspace = true, features = ["std", "tracing"] }
 evm-runtime.workspace = true
 evm-gasometer.workspace = true
 hex = { workspace = true, features = ["std"] }
-serde = { workspace = true, default-features = true, features = ["derive"], optional = true }
+serde = { workspace = true, features = ["std"], optional = true }
 
 [features]
 default = []

--- a/engine-test-doubles/Cargo.toml
+++ b/engine-test-doubles/Cargo.toml
@@ -1,22 +1,19 @@
 [package]
 name = "aurora-engine-test-doubles"
 version = "1.0.0"
-authors = ["Aurora Labs <hello@aurora.dev>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 description = "Contains implementations of engine traits suitable for using in tests"
-documentation = ""
-readme = true
-homepage = "https://github.com/aurora-is-near/aurora-engine"
-repository = "https://github.com/aurora-is-near/aurora-engine"
-license = "GPL-3.0"
-publish = false
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+publish.workspace = true
 autobenches = false
 
 [dependencies]
-aurora-engine-types = { path = "../engine-types", default-features = false, features = ["std"] }
-aurora-engine-sdk = { path = "../engine-sdk" }
-evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.0-aurora", default-features = false, features = ["std", "tracing"] }
-evm-runtime = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.0-aurora", default-features = false, features = ["std", "tracing"] }
-evm-gasometer = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.0-aurora", default-features = false, features = ["std", "tracing"] }
-
-[dev-dependencies]
+aurora-engine-types = { workspace = true, features = ["std"] }
+aurora-engine-sdk.workspace = true
+evm = { workspace = true, features = ["std", "tracing"] }
+evm-gasometer.workspace = true
+evm-runtime.workspace = true

--- a/engine-tests/Cargo.toml
+++ b/engine-tests/Cargo.toml
@@ -1,54 +1,50 @@
 [package]
 name = "aurora-engine-tests"
 version = "1.0.0"
-authors = ["Aurora Labs <hello@aurora.dev>"]
-edition = "2021"
-description = ""
-documentation = ""
-readme = true
-homepage = "https://github.com/aurora-is-near/aurora-engine"
-repository = "https://github.com/aurora-is-near/aurora-engine"
-license = "GPL-3.0"
-publish = false
+authors.workspace = true
+edition.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+publish.workspace = true
 autobenches = false
 
-[dependencies]
-
 [dev-dependencies]
-aurora-engine = { path = "../engine", default-features = false, features = ["std", "tracing", "impl-serde"] }
-aurora-engine-precompiles = { path = "../engine-precompiles", default-features = false, features = ["std"] }
-aurora-engine-sdk = { path = "../engine-sdk", default-features = false, features = ["std"] }
-aurora-engine-modexp = { path = "../engine-modexp", default-features = false, features = ["std"] }
-aurora-engine-test-doubles = { path = "../engine-test-doubles", default-features = false }
-aurora-engine-transactions = { path = "../engine-transactions", default-features = false, features = ["std", "impl-serde"] }
-aurora-engine-types = { path = "../engine-types", default-features = false, features = ["std", "impl-serde"] }
-borsh = { version = "0.10", default-features = false }
-bstr = "1.0.1"
-byte-slice-cast = { version = "1.0", default-features = false }
-criterion = "0.4.0"
-engine-standalone-storage = { path = "../engine-standalone-storage" }
-engine-standalone-tracing = { path = "../engine-standalone-tracing", default-features = false, features = ["impl-serde"] }
-ethabi = "18.0"
-evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.0-aurora", default-features = false, features = ["std", "tracing"] }
-evm-gasometer = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.0-aurora", default-features = false, features = ["std", "tracing"] }
-evm-runtime = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.0-aurora", default-features = false, features = ["std", "tracing"] }
-git2 = "0.17"
-hex = { version = "0.4.3", default-features = false }
-libsecp256k1 = { version = "0.7.0", default-features = false }
-near-crypto = "0.16"
-near-primitives = "0.16"
-near-primitives-core = "0.16"
-near-sdk-sim = { git = "https://github.com/aurora-is-near/near-sdk-rs.git", rev = "cc4d4aaf2e1f7297aa060b342ca3ef3ff8e67003" }
-near-vm-errors = "0.16"
-near-vm-logic = "0.16"
-near-vm-runner = { version = "0.16", default-features = false, features = [ "wasmer2_vm", "wasmtime_vm" ] }
-rand = "0.8.5"
-rlp = { version = "0.5.0", default-features = false }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-sha3 = { version = "0.10.2", default-features = false }
-tempfile = "3"
-walrus = "0.19"
+aurora-engine = { workspace = true, features = ["std", "tracing", "impl-serde"] }
+aurora-engine-modexp = { workspace = true, features = ["std"] }
+aurora-engine-precompiles = { workspace = true, features = ["std"] }
+aurora-engine-sdk = { workspace = true, features = ["std"] }
+aurora-engine-test-doubles.workspace = true
+aurora-engine-transactions = { workspace = true, features = ["std", "impl-serde"] }
+aurora-engine-types = { workspace = true, features = ["std", "impl-serde"] }
+borsh.workspace = true
+bstr.workspace = true
+byte-slice-cast.workspace = true
+criterion.workspace = true
+engine-standalone-storage.workspace = true
+engine-standalone-tracing.workspace = true
+ethabi = { workspace = true, default-features = true }
+evm = { workspace = true, features = ["std", "tracing"] }
+evm-gasometer.workspace = true
+evm-runtime.workspace = true
+git2.workspace = true
+hex.workspace = true
+libsecp256k1.workspace = true
+near-crypto.workspace = true
+near-primitives-core.workspace = true
+near-primitives.workspace = true
+near-sdk-sim.workspace = true
+near-vm-errors.workspace = true
+near-vm-logic.workspace = true
+near-vm-runner.workspace = true
+rand.workspace = true
+rlp.workspace = true
+serde = { workspace = true, default-features = true , features = ["derive"] }
+serde_json = { workspace = true, default-features = true }
+sha3.workspace = true
+tempfile.workspace = true
+walrus.workspace = true
 
 [features]
 mainnet-test = []

--- a/engine-tests/Cargo.toml
+++ b/engine-tests/Cargo.toml
@@ -24,7 +24,7 @@ byte-slice-cast.workspace = true
 criterion.workspace = true
 engine-standalone-storage.workspace = true
 engine-standalone-tracing.workspace = true
-ethabi = { workspace = true, default-features = true }
+ethabi = { workspace = true, features = ["full-serde"] }
 evm = { workspace = true, features = ["std", "tracing"] }
 evm-gasometer.workspace = true
 evm-runtime.workspace = true
@@ -40,8 +40,8 @@ near-vm-logic.workspace = true
 near-vm-runner.workspace = true
 rand.workspace = true
 rlp.workspace = true
-serde = { workspace = true, default-features = true , features = ["derive"] }
-serde_json = { workspace = true, default-features = true }
+serde.workspace = true
+serde_json.workspace = true
 sha3.workspace = true
 tempfile.workspace = true
 walrus.workspace = true

--- a/engine-transactions/Cargo.toml
+++ b/engine-transactions/Cargo.toml
@@ -1,27 +1,25 @@
 [package]
 name = "aurora-engine-transactions"
 version = "1.0.0"
-authors = ["Aurora Labs <hello@aurora.dev>"]
-edition = "2021"
-description = ""
-documentation = ""
-readme = true
-homepage = "https://github.com/aurora-is-near/aurora-engine"
-repository = "https://github.com/aurora-is-near/aurora-engine"
-license = "CC0-1.0"
-publish = false
+authors.workspace = true
+edition.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+publish.workspace = true
 autobenches = false
 
 [dependencies]
-aurora-engine-types = { path = "../engine-types", default-features = false }
-aurora-engine-sdk = { path = "../engine-sdk", default-features = false }
-aurora-engine-precompiles = { path = "../engine-precompiles", default-features = false }
-evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.0-aurora", default-features = false }
-rlp = { version = "0.5.0", default-features = false }
-serde = { version = "1", default-features = false, features = ["alloc", "derive"], optional = true }
+aurora-engine-precompiles.workspace = true
+aurora-engine-sdk.workspace = true
+aurora-engine-types.workspace = true
+evm.workspace = true
+rlp.workspace = true
+serde = { workspace = true, optional = true }
 
 [dev-dependencies]
-hex = { version = "0.4", default-features = false, features = ["alloc"] }
+hex.workspace = true
 
 [features]
 std = ["aurora-engine-types/std", "aurora-engine-sdk/std", "aurora-engine-precompiles/std", "evm/std", "rlp/std"]

--- a/engine-types/Cargo.toml
+++ b/engine-types/Cargo.toml
@@ -1,29 +1,27 @@
 [package]
 name = "aurora-engine-types"
 version = "1.0.0"
-authors = ["Aurora Labs <hello@aurora.dev>"]
-edition = "2021"
-description = ""
-documentation = ""
-readme = true
-homepage = "https://github.com/aurora-is-near/aurora-engine"
-repository = "https://github.com/aurora-is-near/aurora-engine"
-license = "CC0-1.0"
-publish = false
 autobenches = false
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+readme.workspace = true
+publish.workspace = true
 
 [dependencies]
-base64 = { version = "0.21", default-features = false, features = [ "alloc" ] }
-borsh = { version = "0.10", default-features = false }
-borsh-compat = { version = "0.9", package = "borsh", default-features = false, optional = true }
-hex = { version = "0.4", default-features = false, features = ["alloc"] }
-primitive-types = { version = "0.12", default-features = false, features = ["rlp", "serde_no_std"] }
-rlp = { version = "0.5.0", default-features = false }
-serde = { version = "1", default-features = false, features = ["alloc", "derive"] }
-serde_json = { version = "1", default-features = false, features = ["alloc"] }
+base64.workspace = true
+borsh-compat = { workspace = true, optional = true }
+borsh.workspace = true
+hex.workspace = true
+primitive-types.workspace = true
+rlp.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]
-rand = "0.8.5"
+rand.workspace = true
 
 [features]
 default = ["std"]

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,42 +1,40 @@
 [package]
 name = "aurora-engine"
 version = "2.9.2"
-authors = ["Aurora Labs <hello@aurora.dev>"]
-edition = "2021"
-description = ""
-documentation = ""
-readme = true
-homepage = "https://github.com/aurora-is-near/aurora-engine"
-repository = "https://github.com/aurora-is-near/aurora-engine"
-license = "CC0-1.0"
-publish = false
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+readme.workspace = true
+publish.workspace = true
 autobenches = false
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-aurora-engine-types = { path = "../engine-types", default-features = false }
-aurora-engine-sdk = { path = "../engine-sdk", default-features = false }
-aurora-engine-modexp = { path = "../engine-modexp", default-features = false }
-aurora-engine-precompiles = { path = "../engine-precompiles", default-features = false }
-aurora-engine-transactions = { path = "../engine-transactions", default-features = false }
-bitflags = { version = "1.3", default-features = false }
-byte-slice-cast = { version = "1.0", default-features = false }
-ethabi = { version = "18.0", default-features = false }
-evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.0-aurora", default-features = false }
-hex = { version = "0.4", default-features = false, features = ["alloc"] }
-rlp = { version = "0.5.0", default-features = false }
-serde = { version = "1", default-features = false, features = ["alloc", "derive"] }
-serde_json = { version = "1", default-features = false, features = ["alloc"] }
+aurora-engine-modexp.workspace = true
+aurora-engine-precompiles.workspace = true
+aurora-engine-transactions.workspace = true
+aurora-engine-types.workspace = true
+aurora-engine-sdk.workspace = true
+bitflags.workspace = true
+byte-slice-cast.workspace = true
+ethabi.workspace = true
+evm.workspace = true
+hex.workspace = true
+rlp.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wee_alloc = { version = "0.4.5", default-features = false }
+wee_alloc.workspace = true
 
 [dev-dependencies]
-aurora-engine-test-doubles = { path = "../engine-test-doubles" }
-test-case = "3.1"
-digest = "0.10"
+aurora-engine-test-doubles.workspace = true
+digest.workspace = true
+test-case.workspace = true
 
 [features]
 default = ["std"]


### PR DESCRIPTION
## Description

The PR adds the possibility to define crate versions used in all crates in the monorepo in `workspace.depdndencies` section of the main `Cargo.toml` file.