### PR TITLE
feat: remove owner requirement on deploying a staged upgrade

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,9 +18,7 @@ jobs:
       - name: Clone the repository
         uses: actions/checkout@v3
       - name: Restore cache
-        run: |
-          cache-util restore cargo_git cargo_registry yarn_cache rocksdb:/root/rocksdb
-          cache-util restore aurora-engine-target@tests@${{ hashFiles('**/Cargo.lock') }}:target
+        run: cache-util restore cargo_git cargo_registry yarn_cache rocksdb:/root/rocksdb
       - name: Preparing rocksdb library
         run: scripts/ci/build_rocksdb.sh
       - name: Build contracts
@@ -40,9 +38,7 @@ jobs:
       - name: Test testnet
         run: cargo make --profile testnet test-workspace
       - name: Save cache
-        run: |
-          cache-util save cargo_git cargo_registry yarn_cache
-          cache-util msave aurora-engine-target@tests@${{ hashFiles('**/Cargo.lock') }}:target
+        run: cache-util save cargo_git cargo_registry yarn_cache
 
   test_modexp:
     name: Test modexp suite (mainnet, testnet)

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -233,7 +233,6 @@ mod contract {
         let mut io = Runtime;
         let state = state::get_state(&io).sdk_unwrap();
         require_running(&state);
-        require_owner_only(&state, &io.predecessor_account_id());
         let index = internal_get_upgrade_index();
         if io.block_height() <= index {
             sdk::panic_utf8(errors::ERR_NOT_ALLOWED_TOO_EARLY);


### PR DESCRIPTION
## Description

Given that there are precautions to remove a staged upgrade, and only the owner or DAO can stage an upgrade, removing the owner's requirement of deploying the upgrade is safe.

## Additional Information

We started running into a potential issue where it may be too costly for the DAO to deploy future Engine releases. While there is currently no issue to stage a release, a deployment may, in fact be a bit too costly. The DAO almost hit this limit previously as 280 Tgas was the gas required via the DAO. Additionally, this reduces the DAO votes by 1 as now they only have to vote on an upgrade which needs to be staged.

This should be done as a patch release on the master branch prior to any further deployments.