### PR TITLE
ci: use semver regular expression for tag

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2,7 +2,7 @@
 on:
   push:
     tags:
-      - '*'
+      - '[0-9]+.[0-9]+.[0-9]+'
 name: Build
 jobs:
   release:


### PR DESCRIPTION
## Description

The PR adds regular expression for validating tags which correspond semver rules. E.g. `2.10.1`. Only such tags will be triggered a build flow.