### PR TITLE
draft: refund on XCC token transfer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-engine"
-version = "2.9.2"
+version = "2.10.0"
 dependencies = [
  "aurora-engine-modexp",
  "aurora-engine-precompiles",
@@ -6639,6 +6639,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "xcc_router"
+version = "1.0.0"
+dependencies = [
+ "aurora-engine-sdk",
+ "aurora-engine-types",
+ "hex 0.4.3",
+ "near-sdk",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ members = [
     "engine-transactions",
     "engine-types",
     "engine-workspace",
+    "etc/xcc-router",
 ]
 
 exclude = [
@@ -89,7 +90,6 @@ exclude = [
     "etc/tests/self-contained-5bEgfRQ",
     "etc/tests/fibonacci",
     "etc/tests/modexp-bench",
-    "etc/xcc-router",
 ]
 
 [profile.release]

--- a/engine-precompiles/src/xcc.rs
+++ b/engine-precompiles/src/xcc.rs
@@ -135,9 +135,9 @@ impl<I: IO> HandleBasedPrecompile for CrossContractCall<I> {
             .map_err(|_| ExitError::Other(Cow::from(consts::ERR_INVALID_INPUT)))?;
         let (promise, attached_near) = match args {
             CrossContractCallArgs::Eager(call) => {
-                let call_gas = call.total_gas();
-                let attached_near = call.total_near();
-                let callback_count = call.promise_count() - 1;
+                let call_gas = call.args.total_gas();
+                let attached_near = call.args.total_near();
+                let callback_count = call.args.promise_count() - 1;
                 let router_exec_cost = costs::ROUTER_EXEC_BASE
                     + NearGas::new(callback_count * costs::ROUTER_EXEC_PER_CALLBACK.as_u64());
                 let promise = PromiseCreateArgs {
@@ -152,7 +152,7 @@ impl<I: IO> HandleBasedPrecompile for CrossContractCall<I> {
                 (promise, attached_near)
             }
             CrossContractCallArgs::Delayed(call) => {
-                let attached_near = call.total_near();
+                let attached_near = call.args.total_near();
                 let promise = PromiseCreateArgs {
                     target_account_id,
                     method: consts::ROUTER_SCHEDULE_NAME.into(),

--- a/engine-tests/src/tests/standalone/call_tracer.rs
+++ b/engine-tests/src/tests/standalone/call_tracer.rs
@@ -3,6 +3,7 @@ use crate::utils::solidity::erc20::{ERC20Constructor, ERC20};
 use crate::utils::{self, standalone, Signer};
 use aurora_engine_modexp::AuroraModExp;
 use aurora_engine_types::borsh::BorshSerialize;
+use aurora_engine_types::parameters::PromiseArgsWithSender;
 use aurora_engine_types::{
     parameters::{CrossContractCallArgs, PromiseArgs, PromiseCreateArgs},
     storage,
@@ -341,7 +342,10 @@ fn test_trace_precompiles_with_subcalls() {
         attached_balance: Yocto::new(1),
         attached_gas: NearGas::new(100_000_000_000_000),
     };
-    let xcc_args = CrossContractCallArgs::Delayed(PromiseArgs::Create(promise));
+    let xcc_args = CrossContractCallArgs::Delayed(PromiseArgsWithSender {
+        sender: signer_address,
+        args: PromiseArgs::Create(promise),
+    });
     let tx = aurora_engine_transactions::legacy::TransactionLegacy {
         nonce: signer.use_nonce().into(),
         gas_price: U256::zero(),

--- a/engine-types/src/parameters/promise.rs
+++ b/engine-types/src/parameters/promise.rs
@@ -10,6 +10,13 @@ use borsh_compat::{self as borsh, maybestd::io, BorshDeserialize, BorshSerialize
 
 #[must_use]
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
+pub struct PromiseArgsWithSender {
+    pub sender: [u8; 20],
+    pub args: PromiseArgs,
+}
+
+#[must_use]
+#[derive(Debug, BorshSerialize, BorshDeserialize)]
 pub enum PromiseArgs {
     Create(PromiseCreateArgs),
     Callback(PromiseWithCallbackArgs),
@@ -310,11 +317,11 @@ pub struct RefundCallArgs {
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 pub enum CrossContractCallArgs {
     /// The promise is to be executed immediately (as part of the same NEAR transaction as the EVM call).
-    Eager(PromiseArgs),
+    Eager(PromiseArgsWithSender),
     /// The promise is to be stored in the router contract, and can be executed in a future transaction.
     /// The purpose of this is to expand how much NEAR gas can be made available to a cross contract call.
     /// For example, if an expensive EVM call ends with a NEAR cross contract call, then there may not be
     /// much gas left to perform it. In this case, the promise could be `Delayed` (stored in the router)
     /// and executed in a separate transaction with a fresh 300 Tgas available for it.
-    Delayed(PromiseArgs),
+    Delayed(PromiseArgsWithSender),
 }

--- a/etc/xcc-router/Cargo.toml
+++ b/etc/xcc-router/Cargo.toml
@@ -16,7 +16,11 @@ panic = "abort"
 
 [dependencies]
 aurora-engine-types = { path = "../../engine-types", default-features = false, features = ["borsh-compat"] }
+hex = "0.4"
 near-sdk = "4.1"
+
+[dev-dependencies]
+aurora-engine-sdk = { workspace = true, features = ["std"] }
 
 [features]
 default = []

--- a/etc/xcc-router/src/lib.rs
+++ b/etc/xcc-router/src/lib.rs
@@ -1,10 +1,11 @@
 use aurora_engine_types::parameters::{
-    NearPromise, PromiseAction, PromiseArgs, PromiseCreateArgs, PromiseWithCallbackArgs,
-    SimpleNearPromise,
+    NearPromise, PromiseAction, PromiseArgs, PromiseArgsWithSender, PromiseCreateArgs,
+    PromiseWithCallbackArgs, SimpleNearPromise,
 };
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::collections::{LazyOption, LookupMap};
 use near_sdk::json_types::{U128, U64};
+use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::BorshStorageKey;
 use near_sdk::{
     env, near_bindgen, AccountId, Gas, PanicOnDefault, Promise, PromiseIndex, PromiseResult,
@@ -22,6 +23,29 @@ enum StorageKey {
     Map,
 }
 
+#[derive(Deserialize, Serialize)]
+#[serde(crate = "near_sdk::serde")]
+struct FtTransferCallArgs {
+    pub receiver_id: AccountId,
+    pub amount: U128,
+    pub memo: Option<String>,
+    pub msg: String,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(crate = "near_sdk::serde")]
+struct FtResolveTransferCallArgs {
+    pub sender: [u8; 20],
+    pub token_id: AccountId,
+    pub amount: U128,
+}
+
+// #[derive(Serialize)]
+// #[serde(crate = "near_sdk::serde")]
+// struct FtResolveTransferCallArgs {
+//     pub amount: U128,
+// }
+
 const CURRENT_VERSION: u32 = 1;
 
 const ERR_ILLEGAL_CALLER: &str = "ERR_ILLEGAL_CALLER";
@@ -34,6 +58,8 @@ const WNEAR_WITHDRAW_GAS: Gas = Gas(5_000_000_000_000);
 const WNEAR_REGISTER_GAS: Gas = Gas(5_000_000_000_000);
 /// Gas cost estimated from simulation tests.
 const REFUND_GAS: Gas = Gas(5_000_000_000_000);
+/// Gas cost estimated from simulation tests.
+const FT_RESOLVE_TRANSFER_CALL_GAS: Gas = Gas(15_000_000_000_000);
 /// Registration amount computed from FT token source code, see
 /// https://github.com/near/near-sdk-rs/blob/master/near-contract-standards/src/fungible_token/core_impl.rs#L50
 /// https://github.com/near/near-sdk-rs/blob/master/near-contract-standards/src/fungible_token/storage_impl.rs#L101
@@ -52,7 +78,7 @@ pub struct Router {
     /// This allows multiple promises to be scheduled before any of them are executed.
     nonce: LazyOption<u64>,
     /// The storage for the scheduled promises.
-    scheduled_promises: LookupMap<u64, PromiseArgs>,
+    scheduled_promises: LookupMap<u64, PromiseArgsWithSender>,
     /// Account ID for the wNEAR contract.
     wnear_account: AccountId,
 }
@@ -114,7 +140,7 @@ impl Router {
     /// The engine only calls this function when the special precompile in the EVM for NEAR cross
     /// contract calls is used by the address associated with the sub-account this router contract
     /// is deployed at.
-    pub fn execute(&self, #[serializer(borsh)] promise: PromiseArgs) {
+    pub fn execute(&self, #[serializer(borsh)] promise: PromiseArgsWithSender) {
         self.require_parent_caller();
 
         let promise_id = Router::promise_create(promise);
@@ -122,7 +148,7 @@ impl Router {
     }
 
     /// Similar security considerations here as for `execute`.
-    pub fn schedule(&mut self, #[serializer(borsh)] promise: PromiseArgs) {
+    pub fn schedule(&mut self, #[serializer(borsh)] promise: PromiseArgsWithSender) {
         self.require_parent_caller();
 
         let nonce = self.nonce.get().unwrap_or_default();
@@ -186,6 +212,37 @@ impl Router {
 
         Promise::new(parent).transfer(REFUND_AMOUNT)
     }
+
+    #[private]
+    pub fn ft_resolve_transfer_call(&self, sender: [u8; 20], token_id: AccountId, amount: U128) {
+        let used_amount = match env::promise_result(0) {
+            PromiseResult::Successful(value) => {
+                near_sdk::serde_json::from_slice::<U128>(&value).unwrap()
+            }
+            PromiseResult::Failed => 0.into(),
+            PromiseResult::NotReady => panic!(),
+        };
+        let unused_amount = U128(amount.0 - used_amount.0);
+        near_sdk::log!("amount {}", amount.0);
+        near_sdk::log!("used_amount {}", used_amount.0);
+        near_sdk::log!("unused_amount {}", unused_amount.0);
+        if unused_amount.0 > 0 {
+            let promise_idx = env::promise_create(
+                token_id,
+                "ft_transfer_call",
+                &near_sdk::serde_json::to_vec(&FtTransferCallArgs {
+                    receiver_id: self.parent.get().unwrap(),
+                    amount: unused_amount,
+                    msg: hex::encode(sender),
+                    memo: Some("refund".to_string()),
+                })
+                .unwrap(),
+                1u128,
+                WNEAR_REGISTER_GAS,
+            );
+            env::promise_return(promise_idx)
+        }
+    }
 }
 
 impl Router {
@@ -208,16 +265,18 @@ impl Router {
         }
     }
 
-    fn promise_create(promise: PromiseArgs) -> PromiseIndex {
-        match promise {
-            PromiseArgs::Create(call) => Self::base_promise_create(&call),
-            PromiseArgs::Callback(cb) => Self::cb_promise_create(&cb),
-            PromiseArgs::Recursive(p) => Self::recursive_promise_create(&p),
+    fn promise_create(promise: PromiseArgsWithSender) -> PromiseIndex {
+        near_sdk::log!("PROMISE {:?}", &promise);
+        near_sdk::log!("prepaid_gas {}", near_sdk::env::prepaid_gas().0);
+        match promise.args {
+            PromiseArgs::Create(call) => Self::base_promise_create(promise.sender, &call),
+            PromiseArgs::Callback(cb) => Self::cb_promise_create(promise.sender, &cb),
+            PromiseArgs::Recursive(p) => Self::recursive_promise_create(promise.sender, &p),
         }
     }
 
-    fn cb_promise_create(promise: &PromiseWithCallbackArgs) -> PromiseIndex {
-        let base = Self::base_promise_create(&promise.base);
+    fn cb_promise_create(sender: [u8; 20], promise: &PromiseWithCallbackArgs) -> PromiseIndex {
+        let base = Self::base_promise_create(sender, &promise.base);
         let promise = &promise.callback;
 
         env::promise_then(
@@ -230,20 +289,49 @@ impl Router {
         )
     }
 
-    fn base_promise_create(promise: &PromiseCreateArgs) -> PromiseIndex {
-        env::promise_create(
-            near_sdk::AccountId::new_unchecked(promise.target_account_id.to_string()),
+    fn base_promise_create(sender: [u8; 20], promise: &PromiseCreateArgs) -> PromiseIndex {
+        // let gas = if promise.method == "ft_transfer_call" {
+        //     (promise.attached_gas.as_u64() - FT_RESOLVE_TRANSFER_CALL_GAS.0).into()
+        // } else {
+        //     promise.attached_gas.as_u64().into()
+        // };
+
+        let account_id = near_sdk::AccountId::new_unchecked(promise.target_account_id.to_string());
+        let mut res = env::promise_create(
+            account_id.clone(),
             promise.method.as_str(),
             &promise.args,
             promise.attached_balance.as_u128(),
+            // gas,
             promise.attached_gas.as_u64().into(),
-        )
+        );
+
+        if promise.method == "ft_transfer_call" {
+            let FtTransferCallArgs { amount, .. } =
+                near_sdk::serde_json::from_slice::<FtTransferCallArgs>(&promise.args).unwrap();
+
+            res = env::promise_then(
+                res,
+                env::current_account_id(),
+                "ft_resolve_transfer_call",
+                &near_sdk::serde_json::to_vec(&FtResolveTransferCallArgs {
+                    sender,
+                    token_id: account_id,
+                    amount,
+                })
+                .unwrap(),
+                0,
+                FT_RESOLVE_TRANSFER_CALL_GAS,
+            );
+        }
+
+        res
     }
 
-    fn recursive_promise_create(promise: &NearPromise) -> PromiseIndex {
+    fn recursive_promise_create(sender: [u8; 20], promise: &NearPromise) -> PromiseIndex {
         match promise {
             NearPromise::Simple(x) => match x {
-                SimpleNearPromise::Create(call) => Self::base_promise_create(call),
+                SimpleNearPromise::Create(call) => Self::base_promise_create(sender, call),
                 SimpleNearPromise::Batch(batch) => {
                     let target =
                         near_sdk::AccountId::new_unchecked(batch.target_account_id.to_string());
@@ -253,7 +341,7 @@ impl Router {
                 }
             },
             NearPromise::Then { base, callback } => {
-                let base_index = Self::recursive_promise_create(base);
+                let base_index = Self::recursive_promise_create(sender, base);
                 match callback {
                     SimpleNearPromise::Create(call) => env::promise_then(
                         base_index,
@@ -275,7 +363,7 @@ impl Router {
             NearPromise::And(promises) => {
                 let indices: Vec<PromiseIndex> = promises
                     .iter()
-                    .map(Self::recursive_promise_create)
+                    .map(|p| Self::recursive_promise_create(sender, p))
                     .collect();
                 env::promise_and(&indices)
             }


### PR DESCRIPTION
## Motivation

I've been integrating the [Aurora SDK](https://github.com/aurora-is-near/aurora-contracts-sdk) in my orderbook implementation on Near (not yet open source) to do XCC from Aurora to Near, however there is one essential thing missing which are refunds on token transfers.

Imagine the following two scenarios:

Scenario 1:
- Solidity contract bridges ERC-20 from Aurora to Near
- XCC precompile sends `ft_transfer` or `ft_transfer_call` to FT contract
- receipt at FT contract fails (e.g. because XCC address did not pay storage deposit)
- FT are stuck in XCC address on Near

Scenario 2:
- Solidity contract bridges ERC-20 from Aurora to Near
- XCC precompile sends `ft_transfer_call` to FT contract
- FT contract sends `ft_on_transfer` to receiver contract (e.g. a DEX)
- receiver contract receipt fails (e.g. because of slippage)
- FT contract calls `ft_resolve_transfer` and does the refund to XCC address
- FT are stuck in XCC address on Near

Tokens being stuck without the possibility for a recovery is unacceptable for obvious reasons. Receipts can easily fail as you can see in scenario 2 where slippage constraint might not be met.

I have been in contact with @birchmd for quite a while to help me integrate Aurora SDK into the orderbook contract and everything works really good so far except the lack of refund. The orderbook I develop will be an upcoming product of Orderly Network. I really want to emphasize how essential a refund mechanism for bridged FT is. Without it you basically can't use Aurora SDK in DeFi.

## Solution

My solution is WIP and I need help to fully implement it.
Let me demonstrate the solution for the updated scenario 2:

- bridge, `ft_transfer_call`, `ft_on_transfer` receipt fail, `ft_resolve_transfer` refund to XCC
- XCC address calls `ft_transfer_call` to Aurora engine address to bridge FT back to EVM address

I stumbled across the following problems:

1. we don't know in the XCC contract what the EVM address is for the refund
  - (Solution): we need to extend the `PromiseCreateArgs` to also include the EVM sender address
2. it seems like the XCC account no longer gets created with my changes and all I can see is a revert of the Aurora tx, but the Near tx seems to succeed
  - no solution so far, but I am clearly missing a change to update the input of the Near call to also include the sender. Where do I need to look for this?

(As a side note I have some problems compiling rocksdb even though I have llvm and clang installed. Not sure what's the exact problem, but if I check out the most recent rocksdb from crates.io it can be compiled. Maybe worth looking into upgrading the dep?)

I know this is quite a drastic change and I haven't created a prior AIP. Please let me know what we need to do to get this implemented.