### PR TITLE
fix: push0 should increment program counter by 1 instead of 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-engine"
-version = "2.9.2"
+version = "2.10.0"
 dependencies = [
  "aurora-engine-modexp",
  "aurora-engine-precompiles",
@@ -1720,7 +1720,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "evm"
 version = "0.39.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.0-aurora#fcc538cc1f7f91156ef66564a8ac032a82bd4b9e"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.0-aurora#c5cdf0c9bf8da9f6baeb1e5b4a52a2a3405e123f"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -1740,7 +1740,7 @@ dependencies = [
 [[package]]
 name = "evm-core"
 version = "0.39.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.0-aurora#fcc538cc1f7f91156ef66564a8ac032a82bd4b9e"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.0-aurora#c5cdf0c9bf8da9f6baeb1e5b4a52a2a3405e123f"
 dependencies = [
  "parity-scale-codec 3.6.3",
  "primitive-types 0.12.1",
@@ -1751,7 +1751,7 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.39.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.0-aurora#fcc538cc1f7f91156ef66564a8ac032a82bd4b9e"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.0-aurora#c5cdf0c9bf8da9f6baeb1e5b4a52a2a3405e123f"
 dependencies = [
  "environmental",
  "evm-core",
@@ -1762,7 +1762,7 @@ dependencies = [
 [[package]]
 name = "evm-runtime"
 version = "0.39.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.0-aurora#fcc538cc1f7f91156ef66564a8ac032a82bd4b9e"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.0-aurora#c5cdf0c9bf8da9f6baeb1e5b4a52a2a3405e123f"
 dependencies = [
  "auto_impl",
  "environmental",

--- a/engine-tests/src/tests/sanity.rs
+++ b/engine-tests/src/tests/sanity.rs
@@ -714,7 +714,7 @@ fn test_tx_support_shanghai() {
                 data: hex::decode(data).unwrap(),
             }
         })
-        .unwrap();
+        .expect("Should be able to execute EVM bytecode including PUSH0");
 
     assert!(result.status.is_ok());
 }

--- a/engine-tests/src/tests/sanity.rs
+++ b/engine-tests/src/tests/sanity.rs
@@ -695,6 +695,27 @@ fn test_eth_transfer_incorrect_nonce() {
 }
 
 #[test]
+fn test_shanghai_contract() {
+    let (mut runner, mut source_account, _) = initialize_transfer();
+
+    // Panicked with `EvmFatal(Other("internal error: entered unreachable code [engine/src/engine.rs:148:54]"))`
+    let result = runner
+        .submit_with_signer(&mut source_account, |nonce| {
+            aurora_engine_transactions::legacy::TransactionLegacy {
+                nonce,
+                gas_price: 0.into(),
+                gas_limit: u64::MAX.into(),
+                to: None,
+                value: Wei::zero(),
+                data: hex::decode("6080604052348015600e575f80fd5b50607480601a5f395ff3fe6080604052348015600e575f80fd5b50600436106026575f3560e01c8063919840ad14602a575b5f80fd5b600560405190815260200160405180910390f3fea2646970667358221220cb01b9b9c75e5cd079a1980af2fe4397d2029888d12737d74cbbc10e0de65bd364736f6c63430008150033").unwrap(),
+            }
+        })
+        .unwrap();
+
+    println!("{result:?}");
+}
+
+#[test]
 fn test_eth_transfer_not_enough_gas() {
     let (mut runner, mut source_account, dest_address) = initialize_transfer();
     let source_address = utils::address_from_secret_key(&source_account.secret_key);

--- a/engine-tests/src/tests/sanity.rs
+++ b/engine-tests/src/tests/sanity.rs
@@ -695,10 +695,14 @@ fn test_eth_transfer_incorrect_nonce() {
 }
 
 #[test]
-fn test_shanghai_contract() {
+fn test_tx_support_shanghai() {
     let (mut runner, mut source_account, _) = initialize_transfer();
+    // Encoded EVM transaction with parameter: `evmVersion: 'shanghai'`.
+    let data = "6080604052348015600e575f80fd5b50607480601a5f395ff3fe6080604052348015600e575\
+    f80fd5b50600436106026575f3560e01c8063919840ad14602a575b5f80fd5b600560405190815260200160\
+    405180910390f3fea2646970667358221220cb01b9b9c75e5cd079a1980af2fe4397d2029888d12737d74cb\
+    bc10e0de65bd364736f6c63430008150033";
 
-    // Panicked with `EvmFatal(Other("internal error: entered unreachable code [engine/src/engine.rs:148:54]"))`
     let result = runner
         .submit_with_signer(&mut source_account, |nonce| {
             aurora_engine_transactions::legacy::TransactionLegacy {
@@ -707,12 +711,12 @@ fn test_shanghai_contract() {
                 gas_limit: u64::MAX.into(),
                 to: None,
                 value: Wei::zero(),
-                data: hex::decode("6080604052348015600e575f80fd5b50607480601a5f395ff3fe6080604052348015600e575f80fd5b50600436106026575f3560e01c8063919840ad14602a575b5f80fd5b600560405190815260200160405180910390f3fea2646970667358221220cb01b9b9c75e5cd079a1980af2fe4397d2029888d12737d74cbbc10e0de65bd364736f6c63430008150033").unwrap(),
+                data: hex::decode(data).unwrap(),
             }
         })
         .unwrap();
 
-    println!("{result:?}");
+    assert!(result.status.is_ok());
 }
 
 #[test]


### PR DESCRIPTION
## Description

The PR bumps the `sputnikvm` version, which contains a bugfix of the `shanghai` implementation.

## Testing

Added test which validates EVM transaction created with parameter: `evmVersion: 'shanghai'`.