### PR TITLE
Feat(standalone): logic for parsing TransactionKind from raw Near data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1556,6 +1556,7 @@ dependencies = [
  "rocksdb",
  "serde",
  "serde_json",
+ "strum 0.25.0",
 ]
 
 [[package]]
@@ -3129,7 +3130,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "prometheus",
  "serde",
- "strum",
+ "strum 0.24.1",
  "thiserror",
  "tokio",
  "tracing",
@@ -3163,7 +3164,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smart-default",
- "strum",
+ "strum 0.24.1",
  "thiserror",
 ]
 
@@ -3193,7 +3194,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smart-default",
- "strum",
+ "strum 0.24.1",
  "thiserror",
 ]
 
@@ -3228,7 +3229,7 @@ dependencies = [
  "serde_with",
  "serde_yaml",
  "smart-default",
- "strum",
+ "strum 0.24.1",
  "thiserror",
  "time 0.3.23",
  "tracing",
@@ -3248,7 +3249,7 @@ dependencies = [
  "num-rational 0.3.2",
  "serde",
  "sha2 0.10.7",
- "strum",
+ "strum 0.24.1",
 ]
 
 [[package]]
@@ -3266,7 +3267,7 @@ dependencies = [
  "serde",
  "serde_repr",
  "sha2 0.10.7",
- "strum",
+ "strum 0.24.1",
 ]
 
 [[package]]
@@ -3287,7 +3288,7 @@ dependencies = [
  "serde_repr",
  "serde_with",
  "sha2 0.10.7",
- "strum",
+ "strum 0.24.1",
  "thiserror",
 ]
 
@@ -3480,7 +3481,7 @@ dependencies = [
  "near-account-id 0.15.0",
  "near-rpc-error-macro 0.15.0",
  "serde",
- "strum",
+ "strum 0.24.1",
 ]
 
 [[package]]
@@ -3493,7 +3494,7 @@ dependencies = [
  "near-account-id 0.17.0",
  "near-rpc-error-macro 0.17.0",
  "serde",
- "strum",
+ "strum 0.24.1",
  "thiserror",
 ]
 
@@ -5220,7 +5221,16 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.24.3",
+]
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros 0.25.1",
 ]
 
 [[package]]
@@ -5234,6 +5244,19 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6069ca09d878a33f883cc06aaa9718ede171841d3832450354410b718b097232"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.26",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ serde = { version = "1", default-features = false, features = ["alloc", "derive"
 serde_json = { version = "1", default-features = false, features = ["alloc"] }
 sha2 = { version = "0.10", default-features = false }
 sha3 = { version = "0.10", default-features = false }
+strum = { version = "0.25", features = ["derive"] }
 tempfile = "3"
 tokio = { version = "1", default-features = false, features = ["macros"] }
 test-case = "3.1"

--- a/engine-standalone-storage/Cargo.toml
+++ b/engine-standalone-storage/Cargo.toml
@@ -26,6 +26,7 @@ rocksdb.workspace = true
 postgres.workspace = true
 serde = { workspace = true, features = ["std"] }
 serde_json = { workspace = true, features = ["std"] }
+strum.workspace = true
 
 [features]
 default = ["snappy", "lz4", "zstd", "zlib"]

--- a/engine-standalone-storage/src/sync/mod.rs
+++ b/engine-standalone-storage/src/sync/mod.rs
@@ -146,7 +146,7 @@ pub fn parse_transaction_kind(
             TransactionKind::NewConnector(args)
         }
         TransactionKindTag::NewEngine => {
-            let args = parameters::NewCallArgs::try_from_slice(&bytes).ok()?;
+            let args = parameters::NewCallArgs::deserialize(&bytes).ok()?;
             TransactionKind::NewEngine(args)
         }
         TransactionKindTag::FactoryUpdate => TransactionKind::FactoryUpdate(bytes),

--- a/engine-standalone-storage/src/sync/types.rs
+++ b/engine-standalone-storage/src/sync/types.rs
@@ -10,6 +10,7 @@ use aurora_engine_types::{
     H256, U256,
 };
 use std::borrow::Cow;
+use strum::EnumString;
 
 /// Type describing the format of messages sent to the storage layer for keeping
 /// it in sync with the blockchain.
@@ -404,6 +405,122 @@ impl TransactionKind {
                 aurora_engine::engine::get_nonce(&io, from)
             })
             .result
+    }
+}
+
+#[derive(EnumString)]
+pub enum TransactionKindTag {
+    #[strum(serialize = "submit")]
+    Submit,
+    #[strum(serialize = "call")]
+    Call,
+    #[strum(serialize = "pause_precompiles")]
+    PausePrecompiles,
+    #[strum(serialize = "resume_precompiles")]
+    ResumePrecompiles,
+    #[strum(serialize = "deploy_code")]
+    Deploy,
+    #[strum(serialize = "deploy_erc20_token")]
+    DeployErc20,
+    #[strum(serialize = "ft_on_transfer")]
+    FtOnTransfer,
+    #[strum(serialize = "deposit")]
+    Deposit,
+    #[strum(serialize = "ft_transfer_call")]
+    FtTransferCall,
+    #[strum(serialize = "finish_deposit")]
+    FinishDeposit,
+    #[strum(serialize = "ft_resolve_transfer")]
+    ResolveTransfer,
+    #[strum(serialize = "ft_transfer")]
+    FtTransfer,
+    #[strum(serialize = "withdraw")]
+    Withdraw,
+    #[strum(serialize = "storage_deposit")]
+    StorageDeposit,
+    #[strum(serialize = "storage_unregister")]
+    StorageUnregister,
+    #[strum(serialize = "storage_withdraw")]
+    StorageWithdraw,
+    #[strum(serialize = "set_paused_flags")]
+    SetPausedFlags,
+    #[strum(serialize = "register_relayer")]
+    RegisterRelayer,
+    #[strum(serialize = "refund_on_error")]
+    RefundOnError,
+    #[strum(serialize = "set_eth_connector_contract_data")]
+    SetConnectorData,
+    #[strum(serialize = "new_eth_connector")]
+    NewConnector,
+    #[strum(serialize = "new")]
+    NewEngine,
+    #[strum(serialize = "factory_update")]
+    FactoryUpdate,
+    #[strum(serialize = "factory_update_address_version")]
+    FactoryUpdateAddressVersion,
+    #[strum(serialize = "factory_set_wnear_address")]
+    FactorySetWNearAddress,
+    #[strum(serialize = "set_owner")]
+    SetOwner,
+    #[strum(serialize = "submit_with_args")]
+    SubmitWithArgs,
+    #[strum(serialize = "set_upgrade_delay_blocks")]
+    SetUpgradeDelayBlocks,
+    #[strum(serialize = "fund_xcc_sub_account")]
+    FundXccSubAccound,
+    #[strum(serialize = "pause_contract")]
+    PauseContract,
+    #[strum(serialize = "resume_contract")]
+    ResumeContract,
+    #[strum(serialize = "set_key_manager")]
+    SetKeyManager,
+    #[strum(serialize = "add_relayer_key")]
+    AddRelayerKey,
+    #[strum(serialize = "remove_relayer_key")]
+    RemoveRelayerKey,
+    Unknown,
+}
+
+/// Used to make sure `TransactionKindTag` is kept in sync with `TransactionKind`
+impl From<&TransactionKind> for TransactionKindTag {
+    fn from(tx: &TransactionKind) -> Self {
+        match tx {
+            TransactionKind::Submit(_) => Self::Submit,
+            TransactionKind::Call(_) => Self::Call,
+            TransactionKind::PausePrecompiles(_) => Self::PausePrecompiles,
+            TransactionKind::ResumePrecompiles(_) => Self::ResumePrecompiles,
+            TransactionKind::Deploy(_) => Self::Deploy,
+            TransactionKind::DeployErc20(_) => Self::DeployErc20,
+            TransactionKind::FtOnTransfer(_) => Self::FtOnTransfer,
+            TransactionKind::Deposit(_) => Self::Deposit,
+            TransactionKind::FtTransferCall(_) => Self::FtTransferCall,
+            TransactionKind::FinishDeposit(_) => Self::FinishDeposit,
+            TransactionKind::ResolveTransfer(_, _) => Self::ResolveTransfer,
+            TransactionKind::FtTransfer(_) => Self::FtTransfer,
+            TransactionKind::Withdraw(_) => Self::Withdraw,
+            TransactionKind::StorageDeposit(_) => Self::StorageDeposit,
+            TransactionKind::StorageUnregister(_) => Self::StorageUnregister,
+            TransactionKind::StorageWithdraw(_) => Self::StorageWithdraw,
+            TransactionKind::SetPausedFlags(_) => Self::SetPausedFlags,
+            TransactionKind::RegisterRelayer(_) => Self::RegisterRelayer,
+            TransactionKind::RefundOnError(_) => Self::RefundOnError,
+            TransactionKind::SetConnectorData(_) => Self::SetConnectorData,
+            TransactionKind::NewConnector(_) => Self::NewConnector,
+            TransactionKind::NewEngine(_) => Self::NewEngine,
+            TransactionKind::FactoryUpdate(_) => Self::FactoryUpdate,
+            TransactionKind::FactoryUpdateAddressVersion(_) => Self::FactoryUpdateAddressVersion,
+            TransactionKind::FactorySetWNearAddress(_) => Self::FactorySetWNearAddress,
+            TransactionKind::SetOwner(_) => Self::SetOwner,
+            TransactionKind::SubmitWithArgs(_) => Self::SubmitWithArgs,
+            TransactionKind::SetUpgradeDelayBlocks(_) => Self::SetUpgradeDelayBlocks,
+            TransactionKind::FundXccSubAccound(_) => Self::FundXccSubAccound,
+            TransactionKind::PauseContract => Self::PauseContract,
+            TransactionKind::ResumeContract => Self::ResumeContract,
+            TransactionKind::SetKeyManager(_) => Self::SetKeyManager,
+            TransactionKind::AddRelayerKey(_) => Self::AddRelayerKey,
+            TransactionKind::RemoveRelayerKey(_) => Self::RemoveRelayerKey,
+            TransactionKind::Unknown => Self::Unknown,
+        }
     }
 }
 

--- a/engine-standalone-storage/src/sync/types.rs
+++ b/engine-standalone-storage/src/sync/types.rs
@@ -408,7 +408,7 @@ impl TransactionKind {
     }
 }
 
-#[derive(EnumString)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, EnumString)]
 pub enum TransactionKindTag {
     #[strum(serialize = "submit")]
     Submit,

--- a/engine-tests/src/tests/contract_call.rs
+++ b/engine-tests/src/tests/contract_call.rs
@@ -2,7 +2,7 @@ use crate::prelude::{parameters::SubmitResult, vec, Address, Wei, H256, U256};
 use crate::utils::solidity::exit_precompile::{
     Tester, TesterConstructor, DEST_ACCOUNT, DEST_ADDRESS,
 };
-use crate::utils::{self, AuroraRunner, Signer, ORIGIN};
+use crate::utils::{self, AuroraRunner, Signer, DEFAULT_AURORA_ACCOUNT_ID};
 
 fn setup_test() -> (AuroraRunner, Signer, Address, Tester) {
     let mut runner = AuroraRunner::new();
@@ -26,7 +26,12 @@ fn setup_test() -> (AuroraRunner, Signer, Address, Tester) {
         .into();
 
     runner
-        .mint(token, tester.contract.address, 1_000_000_000, ORIGIN)
+        .mint(
+            token,
+            tester.contract.address,
+            1_000_000_000,
+            DEFAULT_AURORA_ACCOUNT_ID,
+        )
         .unwrap();
 
     (runner, signer, token, tester)

--- a/engine-tests/src/tests/erc20_connector.rs
+++ b/engine-tests/src/tests/erc20_connector.rs
@@ -1,5 +1,5 @@
 use crate::prelude::{Address, Balance, Wei, WeiU256, U256};
-use crate::utils::{self, create_eth_transaction, AuroraRunner, ORIGIN};
+use crate::utils::{self, create_eth_transaction, AuroraRunner, DEFAULT_AURORA_ACCOUNT_ID};
 use aurora_engine::engine::EngineError;
 use aurora_engine::parameters::{CallArgs, FunctionCallArgsV2};
 use aurora_engine_transactions::legacy::LegacyEthSignedTransaction;
@@ -92,7 +92,11 @@ impl AuroraRunner {
 
     pub fn deploy_erc20_token(&mut self, nep141: &str) -> Address {
         let result = self
-            .make_call("deploy_erc20_token", ORIGIN, nep141.try_to_vec().unwrap())
+            .make_call(
+                "deploy_erc20_token",
+                DEFAULT_AURORA_ACCOUNT_ID,
+                nep141.try_to_vec().unwrap(),
+            )
             .unwrap();
 
         Vec::try_from_slice(&result.return_data.as_value().unwrap())
@@ -217,11 +221,11 @@ fn test_mint() {
     let mut runner = AuroraRunner::new();
     let token = runner.deploy_erc20_token("tt.testnet");
     let address = runner.create_account().address;
-    let balance = runner.balance_of(token, address, ORIGIN);
+    let balance = runner.balance_of(token, address, DEFAULT_AURORA_ACCOUNT_ID);
     assert_eq!(balance, U256::from(0));
     let amount = 10;
-    let _result = runner.mint(token, address, amount, ORIGIN);
-    let balance = runner.balance_of(token, address, ORIGIN);
+    let _result = runner.mint(token, address, amount, DEFAULT_AURORA_ACCOUNT_ID);
+    let balance = runner.balance_of(token, address, DEFAULT_AURORA_ACCOUNT_ID);
     assert_eq!(balance, U256::from(amount));
 }
 
@@ -230,11 +234,11 @@ fn test_mint_not_admin() {
     let mut runner = AuroraRunner::new();
     let token = runner.deploy_erc20_token("tt.testnet");
     let address = runner.create_account().address;
-    let balance = runner.balance_of(token, address, ORIGIN);
+    let balance = runner.balance_of(token, address, DEFAULT_AURORA_ACCOUNT_ID);
     assert_eq!(balance, U256::from(0));
     let amount = 10;
     runner.mint(token, address, amount, "not_admin").unwrap();
-    let balance = runner.balance_of(token, address, ORIGIN);
+    let balance = runner.balance_of(token, address, DEFAULT_AURORA_ACCOUNT_ID);
     assert_eq!(balance, U256::from(0));
 }
 
@@ -249,14 +253,14 @@ fn test_ft_on_transfer() {
     let amount = Balance::new(10);
     let recipient = runner.create_account().address;
 
-    let balance = runner.balance_of(token, recipient, ORIGIN);
+    let balance = runner.balance_of(token, recipient, DEFAULT_AURORA_ACCOUNT_ID);
     assert_eq!(balance, U256::from(0));
 
     let res = runner.ft_on_transfer(nep141, alice, alice, amount, &recipient.encode());
     // Transaction should succeed so return amount is 0
     assert_eq!(res, "\"0\"");
 
-    let balance = runner.balance_of(token, recipient, ORIGIN);
+    let balance = runner.balance_of(token, recipient, DEFAULT_AURORA_ACCOUNT_ID);
     assert_eq!(balance, U256::from(amount.as_u128()));
 }
 
@@ -294,7 +298,7 @@ fn test_relayer_charge_fee() {
     let relayer_balance = runner.get_balance(relayer);
     assert_eq!(relayer_balance, Wei::zero());
 
-    let balance = runner.balance_of(token, recipient, ORIGIN);
+    let balance = runner.balance_of(token, recipient, DEFAULT_AURORA_ACCOUNT_ID);
     assert_eq!(balance, U256::from(0));
 
     let fee_encoded = &mut [0; 32];
@@ -316,7 +320,7 @@ fn test_relayer_charge_fee() {
     let relayer_balance = runner.get_balance(relayer);
     assert_eq!(relayer_balance, Wei::new_u64(fee));
 
-    let balance = runner.balance_of(token, recipient, ORIGIN);
+    let balance = runner.balance_of(token, recipient, DEFAULT_AURORA_ACCOUNT_ID);
     assert_eq!(balance, U256::from(amount.as_u128()));
 }
 
@@ -331,31 +335,39 @@ fn test_transfer_erc20_token() {
     let to_transfer = 43;
 
     assert_eq!(
-        runner.balance_of(token, peer0.address, ORIGIN),
+        runner.balance_of(token, peer0.address, DEFAULT_AURORA_ACCOUNT_ID),
         U256::zero()
     );
     assert_eq!(
-        runner.balance_of(token, peer1.address, ORIGIN),
+        runner.balance_of(token, peer1.address, DEFAULT_AURORA_ACCOUNT_ID),
         U256::zero()
     );
 
-    runner.mint(token, peer0.address, to_mint, ORIGIN).unwrap();
+    runner
+        .mint(token, peer0.address, to_mint, DEFAULT_AURORA_ACCOUNT_ID)
+        .unwrap();
 
     assert_eq!(
-        runner.balance_of(token, peer0.address, ORIGIN),
+        runner.balance_of(token, peer0.address, DEFAULT_AURORA_ACCOUNT_ID),
         U256::from(to_mint)
     );
 
     runner
-        .transfer_erc20(token, peer0.secret_key, peer1.address, to_transfer, ORIGIN)
+        .transfer_erc20(
+            token,
+            peer0.secret_key,
+            peer1.address,
+            to_transfer,
+            DEFAULT_AURORA_ACCOUNT_ID,
+        )
         .unwrap();
     assert_eq!(
-        runner.balance_of(token, peer0.address, ORIGIN),
+        runner.balance_of(token, peer0.address, DEFAULT_AURORA_ACCOUNT_ID),
         U256::from(to_mint - to_transfer)
     );
 
     assert_eq!(
-        runner.balance_of(token, peer1.address, ORIGIN),
+        runner.balance_of(token, peer1.address, DEFAULT_AURORA_ACCOUNT_ID),
         U256::from(to_transfer)
     );
 }

--- a/engine-tests/src/tests/modexp.rs
+++ b/engine-tests/src/tests/modexp.rs
@@ -318,6 +318,8 @@ impl Default for ModExpBenchContext {
             std::fs::read(output_path).unwrap()
         };
 
+        // Standalone not relevant here because this is not an Aurora Engine instance
+        inner.standalone_runner = None;
         inner.wasm_config.limit_config.max_gas_burnt = u64::MAX;
         inner.code = ContractCode::new(bench_contract_bytes, None);
 

--- a/engine-tests/src/tests/pausable_precompiles.rs
+++ b/engine-tests/src/tests/pausable_precompiles.rs
@@ -1,7 +1,8 @@
 use crate::prelude::{Address, U256};
 use crate::utils::solidity::exit_precompile::{Tester, TesterConstructor};
 use crate::utils::{
-    self, AuroraRunner, Signer, ORIGIN, PAUSED_PRECOMPILES, PAUSE_PRECOMPILES, RESUME_PRECOMPILES,
+    self, AuroraRunner, Signer, DEFAULT_AURORA_ACCOUNT_ID, PAUSED_PRECOMPILES, PAUSE_PRECOMPILES,
+    RESUME_PRECOMPILES,
 };
 use aurora_engine::engine::EngineErrorKind;
 use aurora_engine::parameters::{PausePrecompilesCallArgs, TransactionStatus};
@@ -24,6 +25,7 @@ fn test_paused_precompile_is_shown_when_viewing() {
 
     let _res = runner.call(PAUSE_PRECOMPILES, CALLED_ACCOUNT_ID, input.clone());
     let result = runner
+        .one_shot()
         .call(PAUSED_PRECOMPILES, CALLED_ACCOUNT_ID, Vec::new())
         .unwrap();
     let output = result.return_data.as_value().unwrap();
@@ -130,7 +132,12 @@ fn setup_test() -> (AuroraRunner, Signer, Address, Tester) {
         .into();
 
     runner
-        .mint(token, tester.contract.address, 1_000_000_000, ORIGIN)
+        .mint(
+            token,
+            tester.contract.address,
+            1_000_000_000,
+            DEFAULT_AURORA_ACCOUNT_ID,
+        )
         .unwrap();
 
     (runner, signer, token, tester)

--- a/engine-tests/src/tests/pause_contract.rs
+++ b/engine-tests/src/tests/pause_contract.rs
@@ -73,7 +73,9 @@ fn test_pause_contract() {
     .unwrap();
 
     // contract is running by default, gets and sets should work
-    let result = runner.call("get_upgrade_delay_blocks", &aurora_account_id, vec![]);
+    let result = runner
+        .one_shot()
+        .call("get_upgrade_delay_blocks", &aurora_account_id, vec![]);
     assert!(result.is_ok());
 
     let result = runner.call("set_upgrade_delay_blocks", &aurora_account_id, set.clone());
@@ -84,7 +86,9 @@ fn test_pause_contract() {
     assert!(result.is_ok());
 
     // contract is paused, gets should still work but sets should fail
-    let result = runner.call("get_upgrade_delay_blocks", &aurora_account_id, vec![]);
+    let result = runner
+        .one_shot()
+        .call("get_upgrade_delay_blocks", &aurora_account_id, vec![]);
     assert!(result.is_ok());
 
     let result = runner.call("set_upgrade_delay_blocks", &aurora_account_id, set);
@@ -110,7 +114,9 @@ fn test_resume_contract() {
     assert!(result.is_ok());
 
     // contract is running again, gets and sets should work
-    let result = runner.call("get_upgrade_delay_blocks", &aurora_account_id, vec![]);
+    let result = runner
+        .one_shot()
+        .call("get_upgrade_delay_blocks", &aurora_account_id, vec![]);
     assert!(result.is_ok());
 
     let result = runner.call("set_upgrade_delay_blocks", &aurora_account_id, set);

--- a/engine-tests/src/tests/repro.rs
+++ b/engine-tests/src/tests/repro.rs
@@ -1,7 +1,6 @@
 //! A module containing tests which reproduce transactions sent to live networks.
 
-use crate::utils::{standalone, ORIGIN};
-use crate::utils::{AuroraRunner, ExecutionProfile};
+use crate::utils::{standalone, AuroraRunner, ExecutionProfile};
 use aurora_engine::parameters::SubmitResult;
 use aurora_engine_types::borsh::{BorshDeserialize, BorshSerialize};
 use engine_standalone_storage::json_snapshot;
@@ -143,6 +142,7 @@ fn repro_common(context: &ReproContext) {
     let snapshot = json_snapshot::types::JsonSnapshot::load_from_file(snapshot_path).unwrap();
 
     let mut runner = AuroraRunner::default();
+    runner.standalone_runner = None; // Turn off standalone here, validated separately below
     runner.wasm_config.limit_config.max_gas_burnt = 3_000_000_000_000_000;
     runner.context.storage_usage = 1_000_000_000;
     runner.consume_json_snapshot(snapshot.clone());
@@ -167,10 +167,6 @@ fn repro_common(context: &ReproContext) {
 
     // Also validate the SubmitResult in the standalone engine
     let mut standalone = standalone::StandaloneRunner::default();
-    standalone
-        .storage
-        .set_engine_account_id(&ORIGIN.parse().unwrap())
-        .unwrap();
     json_snapshot::initialize_engine_state(&mut standalone.storage, snapshot).unwrap();
     let standalone_result = standalone
         .submit_raw("submit", &runner.context, &[])

--- a/engine-tests/src/tests/repro.rs
+++ b/engine-tests/src/tests/repro.rs
@@ -141,8 +141,10 @@ fn repro_common(context: &ReproContext) {
 
     let snapshot = json_snapshot::types::JsonSnapshot::load_from_file(snapshot_path).unwrap();
 
-    let mut runner = AuroraRunner::default();
-    runner.standalone_runner = None; // Turn off standalone here, validated separately below
+    let mut runner = AuroraRunner {
+        standalone_runner: None, // Turn off standalone here, validated separately below
+        ..Default::default()
+    };
     runner.wasm_config.limit_config.max_gas_burnt = 3_000_000_000_000_000;
     runner.context.storage_usage = 1_000_000_000;
     runner.consume_json_snapshot(snapshot.clone());

--- a/engine-tests/src/tests/sanity.rs
+++ b/engine-tests/src/tests/sanity.rs
@@ -44,8 +44,10 @@ fn test_total_supply_accounting() {
         constructor.deployed_at(contract_address)
     };
 
-    let get_total_supply = |runner: &mut utils::AuroraRunner| -> Wei {
-        let result = runner.call("ft_total_eth_supply_on_aurora", "aurora", Vec::new());
+    let get_total_supply = |runner: &utils::AuroraRunner| -> Wei {
+        let result = runner
+            .one_shot()
+            .call("ft_total_eth_supply_on_aurora", "aurora", Vec::new());
         let amount: u128 = String::from_utf8(result.unwrap().return_data.as_value().unwrap())
             .unwrap()
             .replace('"', "")
@@ -897,9 +899,10 @@ fn test_block_hash() {
 
 #[test]
 fn test_block_hash_api() {
-    let mut runner = utils::deploy_runner();
+    let runner = utils::deploy_runner();
     let block_height: u64 = 10;
     let outcome = runner
+        .one_shot()
         .call(
             "get_block_hash",
             "any.near",
@@ -941,9 +944,12 @@ fn test_block_hash_contract() {
 
 #[test]
 fn test_ft_metadata() {
-    let mut runner = utils::deploy_runner();
+    let runner = utils::deploy_runner();
     let account_id: String = runner.context.signer_account_id.clone().into();
-    let outcome = runner.call("ft_metadata", &account_id, Vec::new()).unwrap();
+    let outcome = runner
+        .one_shot()
+        .call("ft_metadata", &account_id, Vec::new())
+        .unwrap();
     let metadata =
         serde_json::from_slice::<FungibleTokenMetadata>(&outcome.return_data.as_value().unwrap())
             .unwrap();
@@ -1009,6 +1015,7 @@ fn test_set_owner() {
 
     // get owner to see if the owner_id property has changed
     let outcome = runner
+        .one_shot()
         .call("get_owner", &aurora_account_id, vec![])
         .unwrap();
 
@@ -1064,7 +1071,9 @@ fn test_set_upgrade_delay_blocks() {
     assert!(result.is_ok());
 
     // get upgrade_delay_blocks to see if the upgrade_delay_blocks property has changed
-    let result = runner.call("get_upgrade_delay_blocks", &aurora_account_id, vec![]);
+    let result = runner
+        .one_shot()
+        .call("get_upgrade_delay_blocks", &aurora_account_id, vec![]);
 
     // check if the query goes through the standalone runner
     assert!(result.is_ok());

--- a/engine-tests/src/utils/standalone/mocks/mod.rs
+++ b/engine-tests/src/utils/standalone/mocks/mod.rs
@@ -32,10 +32,7 @@ pub fn insert_block(storage: &mut Storage, block_height: u64) {
 }
 
 pub fn default_env(block_height: u64) -> aurora_engine_sdk::env::Fixed {
-    let aurora_id: AccountId = utils::AuroraRunner::default()
-        .aurora_account_id
-        .parse()
-        .unwrap();
+    let aurora_id: AccountId = utils::DEFAULT_AURORA_ACCOUNT_ID.parse().unwrap();
     aurora_engine_sdk::env::Fixed {
         signer_account_id: aurora_id.clone(),
         current_account_id: aurora_id.clone(),

--- a/engine-tests/src/utils/standalone/mod.rs
+++ b/engine-tests/src/utils/standalone/mod.rs
@@ -346,14 +346,16 @@ fn unwrap_result(
 
 impl Default for StandaloneRunner {
     fn default() -> Self {
-        let (storage_dir, storage) = storage::create_db();
+        let (storage_dir, mut storage) = storage::create_db();
         let env = mocks::default_env(0);
-        let chain_id = utils::AuroraRunner::default().chain_id;
+        storage
+            .set_engine_account_id(&env.current_account_id)
+            .unwrap();
         Self {
             storage_dir,
             storage,
             env,
-            chain_id,
+            chain_id: utils::DEFAULT_CHAIN_ID,
             cumulative_diff: Diff::default(),
         }
     }

--- a/engine-tests/src/utils/standalone/mod.rs
+++ b/engine-tests/src/utils/standalone/mod.rs
@@ -1,13 +1,8 @@
 use aurora_engine::engine;
-use aurora_engine::parameters::{
-    CallArgs, DeployErc20TokenArgs, PausePrecompilesCallArgs, SetOwnerArgs,
-    SetUpgradeDelayBlocksArgs, SubmitArgs, SubmitResult, TransactionStatus,
-};
+use aurora_engine::parameters::{SubmitResult, TransactionStatus};
 use aurora_engine_modexp::AuroraModExp;
 use aurora_engine_sdk::env::{self, Env};
 use aurora_engine_transactions::legacy::{LegacyEthSignedTransaction, TransactionLegacy};
-use aurora_engine_types::borsh::BorshDeserialize;
-use aurora_engine_types::parameters::engine::RelayerKeyManagerArgs;
 use aurora_engine_types::types::{Address, NearGas, PromiseResult, Wei};
 use aurora_engine_types::{H256, U256};
 use engine_standalone_storage::{
@@ -202,195 +197,46 @@ impl StandaloneRunner {
         env.signer_account_id = ctx.signer_account_id.as_ref().parse().unwrap();
         env.prepaid_gas = NearGas::new(ctx.prepaid_gas);
 
+        let promise_data: Vec<_> = promise_results
+            .iter()
+            .map(|r| match r {
+                PromiseResult::Successful(bytes) => Some(bytes.clone()),
+                PromiseResult::Failed | PromiseResult::NotReady => None,
+            })
+            .collect();
+        let transaction_kind = engine_standalone_storage::sync::parse_transaction_kind(
+            method_name,
+            ctx.input.clone(),
+            &promise_data,
+        )
+        .expect("All method names must be known by standalone");
+
+        let transaction_hash = if let TransactionKind::SubmitWithArgs(args) = &transaction_kind {
+            aurora_engine_sdk::keccak(&args.tx_data)
+        } else {
+            aurora_engine_sdk::keccak(&ctx.input)
+        };
+
         let storage = &mut self.storage;
-        if method_name == utils::SUBMIT {
-            let transaction_bytes = &ctx.input;
-            Self::internal_submit_transaction(
-                transaction_bytes,
-                0,
-                storage,
-                &mut env,
-                &mut self.cumulative_diff,
-                promise_results,
-            )
-        } else if method_name == utils::SUBMIT_WITH_ARGS {
-            let submit_args = SubmitArgs::try_from_slice(&ctx.input).unwrap();
-            let transaction_hash = aurora_engine_sdk::keccak(&submit_args.tx_data);
-            let mut tx_msg =
-                Self::template_tx_msg(storage, &env, 0, transaction_hash, promise_results);
-            tx_msg.transaction = TransactionKind::SubmitWithArgs(submit_args);
+        let mut tx_msg = Self::template_tx_msg(storage, &env, 0, transaction_hash, promise_results);
+        tx_msg.transaction = transaction_kind;
 
-            let outcome =
-                sync::execute_transaction_message::<AuroraModExp>(storage, tx_msg).unwrap();
-            self.cumulative_diff.append(outcome.diff.clone());
-            storage::commit(storage, &outcome);
+        let outcome = sync::execute_transaction_message::<AuroraModExp>(storage, tx_msg).unwrap();
+        self.cumulative_diff.append(outcome.diff.clone());
+        storage::commit(storage, &outcome);
 
-            unwrap_result(outcome)
-        } else if method_name == utils::CALL {
-            let call_args = CallArgs::try_from_slice(&ctx.input).unwrap();
-            let transaction_hash = aurora_engine_sdk::keccak(&ctx.input);
-            let mut tx_msg =
-                Self::template_tx_msg(storage, &env, 0, transaction_hash, promise_results);
-            tx_msg.transaction = TransactionKind::Call(call_args);
-
-            let outcome =
-                sync::execute_transaction_message::<AuroraModExp>(storage, tx_msg).unwrap();
-            self.cumulative_diff.append(outcome.diff.clone());
-            storage::commit(storage, &outcome);
-
-            unwrap_result(outcome)
-        } else if method_name == utils::DEPLOY_ERC20 {
-            let deploy_args = DeployErc20TokenArgs::try_from_slice(&ctx.input).unwrap();
-            let transaction_hash = aurora_engine_sdk::keccak(&ctx.input);
-            let mut tx_msg =
-                Self::template_tx_msg(storage, &env, 0, transaction_hash, promise_results);
-            tx_msg.transaction = TransactionKind::DeployErc20(deploy_args);
-
-            let outcome =
-                sync::execute_transaction_message::<AuroraModExp>(storage, tx_msg).unwrap();
-            self.cumulative_diff.append(outcome.diff.clone());
-            storage::commit(storage, &outcome);
-
-            let sync::TransactionExecutionResult::DeployErc20(address) = outcome.maybe_result.unwrap().unwrap() else { unreachable!() };
-
-            Ok(SubmitResult::new(
+        match outcome.maybe_result.unwrap() {
+            Some(sync::TransactionExecutionResult::Submit(result)) => result,
+            Some(sync::TransactionExecutionResult::DeployErc20(address)) => Ok(SubmitResult::new(
                 TransactionStatus::Succeed(address.raw().as_ref().to_vec()),
                 0,
                 Vec::new(),
-            ))
-        } else if method_name == utils::RESUME_PRECOMPILES {
-            let input = &ctx.input[..];
-            let call_args = PausePrecompilesCallArgs::try_from_slice(input)
-                .expect("Unable to parse input as PausePrecompilesCallArgs");
-
-            let transaction_hash = aurora_engine_sdk::keccak(&ctx.input);
-            let mut tx_msg =
-                Self::template_tx_msg(storage, &env, 0, transaction_hash, promise_results);
-            tx_msg.transaction = TransactionKind::ResumePrecompiles(call_args);
-
-            let outcome =
-                sync::execute_transaction_message::<AuroraModExp>(storage, tx_msg).unwrap();
-            self.cumulative_diff.append(outcome.diff.clone());
-            storage::commit(storage, &outcome);
-
-            Ok(SubmitResult::new(
+            )),
+            _ => Ok(SubmitResult::new(
                 TransactionStatus::Succeed(Vec::new()),
                 0,
                 Vec::new(),
-            ))
-        } else if method_name == utils::PAUSE_PRECOMPILES {
-            let input = &ctx.input[..];
-            let call_args = PausePrecompilesCallArgs::try_from_slice(input)
-                .expect("Unable to parse input as PausePrecompilesCallArgs");
-
-            let transaction_hash = aurora_engine_sdk::keccak(&ctx.input);
-            let mut tx_msg =
-                Self::template_tx_msg(storage, &env, 0, transaction_hash, promise_results);
-            tx_msg.transaction = TransactionKind::PausePrecompiles(call_args);
-
-            let outcome =
-                sync::execute_transaction_message::<AuroraModExp>(storage, tx_msg).unwrap();
-            self.cumulative_diff.append(outcome.diff.clone());
-            storage::commit(storage, &outcome);
-
-            Ok(SubmitResult::new(
-                TransactionStatus::Succeed(Vec::new()),
-                0,
-                Vec::new(),
-            ))
-        } else if method_name == utils::SET_OWNER {
-            let input = &ctx.input[..];
-            let call_args =
-                SetOwnerArgs::try_from_slice(input).expect("Unable to parse input as SetOwnerArgs");
-
-            let transaction_hash = aurora_engine_sdk::keccak(&ctx.input);
-            let mut tx_msg =
-                Self::template_tx_msg(storage, &env, 0, transaction_hash, promise_results);
-            tx_msg.transaction = TransactionKind::SetOwner(call_args);
-
-            let outcome =
-                sync::execute_transaction_message::<AuroraModExp>(storage, tx_msg).unwrap();
-            self.cumulative_diff.append(outcome.diff.clone());
-            storage::commit(storage, &outcome);
-
-            Ok(SubmitResult::new(
-                TransactionStatus::Succeed(Vec::new()),
-                0,
-                Vec::new(),
-            ))
-        } else if method_name == utils::SET_UPGRADE_DELAY_BLOCKS {
-            let input = &ctx.input;
-            let call_args = SetUpgradeDelayBlocksArgs::try_from_slice(input)
-                .expect("Unable to parse input as SetUpgradeDelayBlocksArgs");
-
-            let transaction_hash = aurora_engine_sdk::keccak(&ctx.input);
-            let mut tx_msg =
-                Self::template_tx_msg(storage, &env, 0, transaction_hash, promise_results);
-            tx_msg.transaction = TransactionKind::SetUpgradeDelayBlocks(call_args);
-
-            let outcome =
-                sync::execute_transaction_message::<AuroraModExp>(storage, tx_msg).unwrap();
-            self.cumulative_diff.append(outcome.diff.clone());
-            storage::commit(storage, &outcome);
-
-            Ok(SubmitResult::new(
-                TransactionStatus::Succeed(Vec::new()),
-                0,
-                Vec::new(),
-            ))
-        } else if method_name == utils::PAUSE_CONTRACT {
-            let transaction_hash = aurora_engine_sdk::keccak(&ctx.input);
-            let mut tx_msg =
-                Self::template_tx_msg(storage, &env, 0, transaction_hash, promise_results);
-            tx_msg.transaction = TransactionKind::PauseContract;
-
-            let outcome =
-                sync::execute_transaction_message::<AuroraModExp>(storage, tx_msg).unwrap();
-            self.cumulative_diff.append(outcome.diff.clone());
-            storage::commit(storage, &outcome);
-
-            Ok(SubmitResult::new(
-                TransactionStatus::Succeed(Vec::new()),
-                0,
-                Vec::new(),
-            ))
-        } else if method_name == utils::RESUME_CONTRACT {
-            let transaction_hash = aurora_engine_sdk::keccak(&ctx.input);
-            let mut tx_msg =
-                Self::template_tx_msg(storage, &env, 0, transaction_hash, promise_results);
-            tx_msg.transaction = TransactionKind::ResumeContract;
-
-            let outcome =
-                sync::execute_transaction_message::<AuroraModExp>(storage, tx_msg).unwrap();
-            self.cumulative_diff.append(outcome.diff.clone());
-            storage::commit(storage, &outcome);
-
-            Ok(SubmitResult::new(
-                TransactionStatus::Succeed(Vec::new()),
-                0,
-                Vec::new(),
-            ))
-        } else if method_name == utils::SET_KEY_MANAGER {
-            let transaction_hash = aurora_engine_sdk::keccak(&ctx.input);
-            let call_args: RelayerKeyManagerArgs = serde_json::from_slice(&ctx.input)
-                .expect("Unable to parse input as RelayerKeyManagerArgs");
-
-            let mut tx_msg =
-                Self::template_tx_msg(storage, &env, 0, transaction_hash, promise_results);
-            tx_msg.transaction = TransactionKind::SetKeyManager(call_args);
-
-            let outcome =
-                sync::execute_transaction_message::<AuroraModExp>(storage, tx_msg).unwrap();
-            self.cumulative_diff.append(outcome.diff.clone());
-            storage::commit(storage, &outcome);
-
-            Ok(SubmitResult::new(
-                TransactionStatus::Succeed(Vec::new()),
-                0,
-                Vec::new(),
-            ))
-        } else {
-            panic!("Unsupported standalone method {method_name}");
+            )),
         }
     }
 


### PR DESCRIPTION
## Description

This is the first in a series of PRs that is meant to split up #705 . The idea is to merge the changes which are made in that PR in logical chunks until eventually the whole hashchain implementation is in. Doing the work in smaller pieces will both make it easier to review and prevent us from needing to maintain large, long-lived feature branches.

This first PR pulls in the transaction transaction parsing logic from [borealis-engine-lib](https://github.com/aurora-is-near/borealis-engine-lib) into this repo (in a future PR we will remove the duplicated code from borealis-engine-lib). The logic is used here to simplify how transactions are handled in tests because all transactions can automatically be passed to both the Near runtime (processed by the Engine as Wasm) and the standalone engine. In particular we remove the large `if` statement that was starting to get unwieldy.

This work is important both because it makes future tests easier to write and because it synchronizes the standalone and wasm engine instances in our tests (this latter point is a prerequisite for properly testing the hashchain).

Some notes about the PR:

1. I renamed the constant `ORIGIN` to `DEFAULT_AURORA_ACCOUNT_ID` because I felt the latter is a more descriptive name for what the constant represents.
2. The standalone engine is now present in `AuroraRunner` by default to make out testing more robust (for example tests will now automatically fail if a new state-mutating method is added to the Engine's `lib.rs` without also being added to the standalone implementation). This means there are a few places were I need to explicitly remove the standalone instance where `AuroraRunner` is used as something other than an Engine instance (modexp and xcc tests).
3. Some tests use view calls to inspect the Engine state and make assertions. These calls are not present in the standalone because it only cares about transactions that mutate the state. To make view calls in `AuroraRunner` it is now required to call `.one_shot()` before the calls. This essentially tells the testing framework that you are making a view call so no state modifications will be made and therefore we can ignore the standalone.