### PR TITLE
Fix(modexp): re-enable Aurora implementation

### DIFF
--- a/engine-modexp/Cargo.toml
+++ b/engine-modexp/Cargo.toml
@@ -13,9 +13,9 @@ autobenches = false
 [dependencies]
 hex.workspace = true
 num.workspace = true
-ibig.workspace = true
+ibig = { workspace = true, optional = true }
 
 [features]
 default = ["std"]
-std = ["num/std", "ibig/std", "hex/std"]
-bench = []
+std = ["num/std", "hex/std"]
+bench = ["ibig"]

--- a/engine-modexp/src/lib.rs
+++ b/engine-modexp/src/lib.rs
@@ -21,7 +21,7 @@ pub struct AuroraModExp;
 
 impl ModExpAlgorithm for AuroraModExp {
     fn modexp(base: &[u8], exp: &[u8], modulus: &[u8]) -> Vec<u8> {
-        modexp_ibig(base, exp, modulus)
+        modexp(base, exp, modulus)
     }
 }
 
@@ -37,6 +37,7 @@ pub fn modexp(base: &[u8], exp: &[u8], modulus: &[u8]) -> Vec<u8> {
     result.to_big_endian()
 }
 
+#[cfg(feature = "bench")]
 pub fn modexp_ibig(base: &[u8], exp: &[u8], modulus: &[u8]) -> Vec<u8> {
     use num::Zero;
 

--- a/engine-tests/src/tests/modexp.rs
+++ b/engine-tests/src/tests/modexp.rs
@@ -128,18 +128,18 @@ fn bench_modexp_standalone() {
 
     // These contracts run the modexp precompile in an infinite loop using strategically selecting
     // input that can take a long time to run with some modexp implementations. It should be
-    // possible to  burn 30M EVM gas (the GAS_LIMIT for this transactions) within 1 second.
+    // possible to burn 30M EVM gas (the GAS_LIMIT for these transactions) within 1 second.
     // This test checks this is case for these specially chosen modexp inputs.
     do_bench(
         &mut standalone,
         &mut signer,
         "../etc/tests/modexp-bench/res/evm_contract_1.hex",
     );
-    /*do_bench( // TODO: re-enable this in the future
+    do_bench(
         &mut standalone,
         &mut signer,
         "../etc/tests/modexp-bench/res/evm_contract_2.hex",
-    );*/
+    );
 }
 
 #[test]

--- a/engine-tests/src/tests/repro.rs
+++ b/engine-tests/src/tests/repro.rs
@@ -126,7 +126,7 @@ fn repro_Emufid2() {
         block_timestamp: 1_662_118_048_636_713_538,
         input_path: "src/tests/res/input_Emufid2.hex",
         evm_gas_used: 1_156_364,
-        near_gas_used: 285,
+        near_gas_used: 296,
     });
 }
 


### PR DESCRIPTION
## Description

With the improvements from #809 merged, we can start using the Aurora implementation of modexp.

## Performance / NEAR gas cost considerations

There is a gas cost increase in one of the repro tests. This must mean the `ibig` implementation of modexp is faster for the case used in that transaction. But using the Aurora implementation of modexp is still an improvement because the worst-case performance of the Aurora implementation is better than `ibig`, as exemplified in the `bench_modexp_standalone` test.

## Testing

Existing tests.
