### PR TITLE
Feat: core hashchain logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-engine"
-version = "2.10.1"
+version = "2.10.2"
 dependencies = [
  "aurora-engine-modexp",
  "aurora-engine-precompiles",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,6 +348,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "aurora-engine-hashchain"
+version = "1.0.0"
+dependencies = [
+ "aurora-engine-sdk",
+ "aurora-engine-types",
+ "fixed-hash 0.8.0",
+ "impl-serde",
+]
+
+[[package]]
 name = "aurora-engine-modexp"
 version = "1.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,11 @@ evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.0-
 evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.0-aurora", default-features = false, features = ["std"] }
 evm-gasometer = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.0-aurora", default-features = false, features = ["std", "tracing"] }
 evm-runtime = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.0-aurora", default-features = false, features = ["std", "tracing"] }
+fixed-hash = { version = "0.8.0", default-features = false}
 git2 = "0.17"
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 ibig = { version = "0.3", default-features = false, features = ["num-traits"] }
+impl-serde = { version = "0.4.0", default-features = false}
 lazy_static = "1"
 libsecp256k1 = { version = "0.7", default-features = false }
 near-crypto = "0.17"
@@ -71,6 +73,7 @@ workspaces = "0.7"
 resolver = "2"
 members = [
     "engine",
+    "engine-hashchain",
     "engine-test-doubles",
     "engine-modexp",
     "engine-precompiles",

--- a/engine-hashchain/Cargo.toml
+++ b/engine-hashchain/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "aurora-engine-hashchain"
+version = "1.0.0"
+authors.workspace = true
+edition.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+publish.workspace = true
+autobenches = false
+
+[dependencies]
+aurora-engine-types.workspace = true
+aurora-engine-sdk.workspace = true
+fixed-hash.workspace = true
+impl-serde.workspace = true
+
+[features]
+default = ["std"]
+std = ["aurora-engine-types/std", "aurora-engine-sdk/std", "fixed-hash/std", "impl-serde/std"]
+borsh-compat = ["aurora-engine-types/borsh-compat", "aurora-engine-sdk/borsh-compat"]

--- a/engine-hashchain/src/bloom.rs
+++ b/engine-hashchain/src/bloom.rs
@@ -42,8 +42,7 @@ impl Bloom {
         let hash = keccak(input);
         let mut ptr = 0;
 
-        for i in 0..BLOOM_BITS {
-            let _ = i;
+        for _ in 0..BLOOM_BITS {
             let mut index = 0;
             for _ in 0..bloom_bytes {
                 index = (index << 8) | hash[ptr] as usize;

--- a/engine-hashchain/src/bloom.rs
+++ b/engine-hashchain/src/bloom.rs
@@ -1,0 +1,86 @@
+//! Based on Parity Common Eth Bloom implementation
+//! Link: <https://github.com/paritytech/parity-common/blob/master/ethbloom/src/lib.rs>
+//!
+//! Reimplemented here since there is a large mismatch in types and dependencies.
+#![allow(clippy::expl_impl_clone_on_copy)]
+
+use aurora_engine_sdk::keccak;
+use aurora_engine_types::borsh::{self, BorshDeserialize, BorshSerialize};
+use aurora_engine_types::parameters::engine::ResultLog;
+use fixed_hash::construct_fixed_hash;
+use impl_serde::impl_fixed_hash_serde;
+
+const BLOOM_SIZE: usize = 256;
+const BLOOM_BITS: u32 = 3;
+
+construct_fixed_hash! {
+    /// Bloom hash type with 256 bytes (2048 bits) size.
+    #[derive(BorshSerialize, BorshDeserialize)]
+    pub struct Bloom(BLOOM_SIZE);
+}
+
+impl_fixed_hash_serde!(Bloom, BLOOM_SIZE);
+
+/// Returns log2.
+const fn log2(x: usize) -> u32 {
+    if x <= 1 {
+        return 0;
+    }
+
+    let n = x.leading_zeros();
+    usize::BITS - n
+}
+
+impl Bloom {
+    /// Add a new element to the bloom filter
+    #[allow(clippy::as_conversions)]
+    pub fn accrue(&mut self, input: &[u8]) {
+        let m = self.0.len();
+        let bloom_bits = m * 8;
+        let mask = bloom_bits - 1;
+        let bloom_bytes = (log2(bloom_bits) + 7) / 8;
+        let hash = keccak(input);
+        let mut ptr = 0;
+
+        for i in 0..BLOOM_BITS {
+            let _ = i;
+            let mut index = 0;
+            for _ in 0..bloom_bytes {
+                index = (index << 8) | hash[ptr] as usize;
+                ptr += 1;
+            }
+            index &= mask;
+            self.0[m - 1 - index / 8] |= 1 << (index % 8);
+        }
+    }
+
+    /// Merge two bloom filters
+    pub fn accrue_bloom(&mut self, bloom: &Self) {
+        for i in 0..BLOOM_SIZE {
+            self.0[i] |= bloom.0[i];
+        }
+    }
+}
+
+#[must_use]
+pub fn get_logs_bloom(logs: &[ResultLog]) -> Bloom {
+    let mut logs_bloom = Bloom::default();
+
+    for log in logs {
+        logs_bloom.accrue_bloom(&get_log_bloom(log));
+    }
+
+    logs_bloom
+}
+
+#[must_use]
+pub fn get_log_bloom(log: &ResultLog) -> Bloom {
+    let mut log_bloom = Bloom::default();
+
+    log_bloom.accrue(log.address.as_bytes());
+    for topic in &log.topics {
+        log_bloom.accrue(&topic[..]);
+    }
+
+    log_bloom
+}

--- a/engine-hashchain/src/error.rs
+++ b/engine-hashchain/src/error.rs
@@ -1,0 +1,33 @@
+pub const ERR_STATE_NOT_FOUND: &[u8; 19] = b"ERR_STATE_NOT_FOUND";
+pub const ERR_STATE_SERIALIZATION_FAILED: &[u8; 26] = b"ERR_STATE_SERIALIZE_FAILED";
+pub const ERR_STATE_CORRUPTED: &[u8; 19] = b"ERR_STATE_CORRUPTED";
+pub const ERR_BLOCK_HEIGHT_INCORRECT: &[u8; 26] = b"ERR_BLOCK_HEIGHT_INCORRECT";
+pub const ERR_REQUIRES_FEATURE_INTEGRATION_TEST: &[u8; 37] =
+    b"ERR_REQUIRES_FEATURE_INTEGRATION_TEST";
+
+#[derive(Debug)]
+/// Blockchain Hashchain Error
+pub enum BlockchainHashchainError {
+    /// The state is missing from storage, need to initialize with contract `new` method.
+    NotFound,
+    /// The state serialized had failed.
+    SerializationFailed,
+    /// The state is corrupted, possibly due to failed state migration.
+    DeserializationFailed,
+    /// The block height is incorrect regarding the current block height.
+    BlockHeightIncorrect,
+    /// Some functionality requires integration-test feature.
+    RequiresFeatureIntegrationTest,
+}
+
+impl AsRef<[u8]> for BlockchainHashchainError {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            Self::NotFound => ERR_STATE_NOT_FOUND,
+            Self::SerializationFailed => ERR_STATE_SERIALIZATION_FAILED,
+            Self::DeserializationFailed => ERR_STATE_CORRUPTED,
+            Self::BlockHeightIncorrect => ERR_BLOCK_HEIGHT_INCORRECT,
+            Self::RequiresFeatureIntegrationTest => ERR_REQUIRES_FEATURE_INTEGRATION_TEST,
+        }
+    }
+}

--- a/engine-hashchain/src/hashchain.rs
+++ b/engine-hashchain/src/hashchain.rs
@@ -1,0 +1,289 @@
+use crate::{bloom::Bloom, error::BlockchainHashchainError, merkle::StreamCompactMerkleTree};
+use aurora_engine_sdk::keccak;
+use aurora_engine_types::{
+    account_id::AccountId,
+    borsh::{self, maybestd::io, BorshDeserialize, BorshSerialize},
+    types::RawH256,
+    Cow, Vec,
+};
+
+/// Blockchain Hashchain.
+/// Continually keeps track of the previous block hashchain through the blocks heights.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Hashchain {
+    chain_id: [u8; 32],
+    contract_account_id: AccountId,
+    current_block_height: u64,
+    previous_block_hashchain: RawH256,
+    block_hashchain_computer: BlockHashchainComputer,
+}
+
+impl Hashchain {
+    #[must_use]
+    pub fn new(
+        chain_id: [u8; 32],
+        contract_account_id: AccountId,
+        current_block_height: u64,
+        previous_block_hashchain: RawH256,
+    ) -> Self {
+        Self {
+            chain_id,
+            contract_account_id,
+            current_block_height,
+            previous_block_hashchain,
+            block_hashchain_computer: BlockHashchainComputer::new(),
+        }
+    }
+
+    /// Adds a transaction if the indicated block height is equal to the current block height.
+    /// Returns an error in other case.
+    pub fn add_block_tx(
+        &mut self,
+        block_height: u64,
+        method_name: &str,
+        input: &[u8],
+        output: &[u8],
+        log_bloom: &Bloom,
+    ) -> Result<(), BlockchainHashchainError> {
+        if block_height != self.current_block_height {
+            return Err(BlockchainHashchainError::BlockHeightIncorrect);
+        }
+
+        self.block_hashchain_computer
+            .add_tx(method_name, input, output, log_bloom);
+
+        Ok(())
+    }
+
+    /// Moves to the indicated block height if it is bigger than the current block height:
+    /// -Updates the previous block hashchain computing the hash.
+    /// -Updates the current block height.
+    /// -Clears the transactions.
+    /// -Clears the transactions.
+    /// Returns an error in other case.
+    pub fn move_to_block(
+        &mut self,
+        next_block_height: u64,
+    ) -> Result<(), BlockchainHashchainError> {
+        if next_block_height <= self.current_block_height {
+            return Err(BlockchainHashchainError::BlockHeightIncorrect);
+        }
+
+        while self.current_block_height < next_block_height {
+            self.previous_block_hashchain = self.block_hashchain_computer.compute_block_hashchain(
+                &self.chain_id,
+                self.contract_account_id.as_bytes(),
+                self.current_block_height,
+                self.previous_block_hashchain,
+            );
+
+            self.block_hashchain_computer.clear_txs();
+            self.current_block_height += 1;
+        }
+
+        Ok(())
+    }
+
+    /// Gets the current block height of the structure.
+    #[must_use]
+    pub const fn get_current_block_height(&self) -> u64 {
+        self.current_block_height
+    }
+
+    /// Gets the previous block hashchain of the structure.
+    #[must_use]
+    pub const fn get_previous_block_hashchain(&self) -> RawH256 {
+        self.previous_block_hashchain
+    }
+
+    pub fn get_logs_bloom(&self) -> &Bloom {
+        &self.block_hashchain_computer.txs_logs_bloom
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.block_hashchain_computer.is_empty()
+    }
+
+    pub fn try_serialize(&self) -> Result<Vec<u8>, io::Error> {
+        let serializable: BorshableHashchain = self.into();
+        serializable.try_to_vec()
+    }
+
+    pub fn try_deserialize(bytes: &[u8]) -> Result<Self, io::Error> {
+        let serializable = BorshableHashchain::try_from_slice(bytes)?;
+        Self::try_from(serializable)
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct HashchainBuilder {
+    chain_id: [u8; 32],
+    contract_account_id: AccountId,
+    current_block_height: u64,
+    previous_block_hashchain: RawH256,
+}
+
+impl HashchainBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_chain_id(mut self, chain_id: [u8; 32]) -> Self {
+        self.chain_id = chain_id;
+        self
+    }
+
+    pub fn with_u64_chain_id(self, chain_id: u64) -> Self {
+        self.with_chain_id(aurora_engine_types::types::u256_to_arr(&chain_id.into()))
+    }
+
+    pub fn with_account_id(mut self, id: AccountId) -> Self {
+        self.contract_account_id = id;
+        self
+    }
+
+    pub fn with_current_block_height(mut self, height: u64) -> Self {
+        self.current_block_height = height;
+        self
+    }
+
+    pub fn with_previous_hashchain(mut self, hashchain: RawH256) -> Self {
+        self.previous_block_hashchain = hashchain;
+        self
+    }
+
+    pub fn build(self) -> Hashchain {
+        Hashchain::new(
+            self.chain_id,
+            self.contract_account_id,
+            self.current_block_height,
+            self.previous_block_hashchain,
+        )
+    }
+}
+
+/// Representation of the hashchain that can be serialized/deserialized to/from bytes.
+/// This struct is intentionally separate from `Hashchain` because then the business logic
+/// is not bogged down with details of serialization (for example this data type is an enum
+/// to allow for easy changes to the serialized form in the future).
+#[derive(Debug, BorshDeserialize, BorshSerialize)]
+enum BorshableHashchain<'a> {
+    V1 {
+        chain_id: Cow<'a, [u8; 32]>,
+        contract_account_id: Cow<'a, str>,
+        current_block_height: u64,
+        previous_block_hashchain: Cow<'a, RawH256>,
+        block_hashchain_computer: Cow<'a, BlockHashchainComputer>,
+    },
+}
+
+impl<'a> From<&'a Hashchain> for BorshableHashchain<'a> {
+    fn from(value: &'a Hashchain) -> Self {
+        Self::V1 {
+            chain_id: Cow::Borrowed(&value.chain_id),
+            contract_account_id: Cow::Borrowed(value.contract_account_id.as_ref()),
+            current_block_height: value.current_block_height,
+            previous_block_hashchain: Cow::Borrowed(&value.previous_block_hashchain),
+            block_hashchain_computer: Cow::Borrowed(&value.block_hashchain_computer),
+        }
+    }
+}
+
+impl<'a> TryFrom<BorshableHashchain<'a>> for Hashchain {
+    type Error = io::Error;
+
+    fn try_from(value: BorshableHashchain<'a>) -> Result<Self, Self::Error> {
+        match value {
+            BorshableHashchain::V1 {
+                chain_id,
+                contract_account_id,
+                current_block_height,
+                previous_block_hashchain,
+                block_hashchain_computer,
+            } => Ok(Self {
+                chain_id: chain_id.into_owned(),
+                contract_account_id: AccountId::new(&contract_account_id)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, format!("{e:?}")))?,
+                current_block_height,
+                previous_block_hashchain: previous_block_hashchain.into_owned(),
+                block_hashchain_computer: block_hashchain_computer.into_owned(),
+            }),
+        }
+    }
+}
+
+/// Block Hashchain Computer.
+/// The order of operations should be:
+/// 1. Create the `BlockHashchainComputer` one time.
+/// 2. Add transactions of the current block.
+/// 3. Compute the block hashchain for the current block once all the transactions were added.
+/// 4. Clear the transactions of the current block.
+/// 5. Go back to step 2 for the next block.
+#[derive(BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
+struct BlockHashchainComputer {
+    pub txs_logs_bloom: Bloom,
+    pub txs_merkle_tree: StreamCompactMerkleTree,
+}
+
+impl BlockHashchainComputer {
+    pub fn new() -> Self {
+        Self {
+            txs_logs_bloom: Bloom::default(),
+            txs_merkle_tree: StreamCompactMerkleTree::new(),
+        }
+    }
+
+    /// Adds a transaction.
+    #[allow(clippy::as_conversions)]
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn add_tx(&mut self, method_name: &str, input: &[u8], output: &[u8], log_bloom: &Bloom) {
+        let data = [
+            &(method_name.len() as u32).to_be_bytes(),
+            method_name.as_bytes(),
+            &(input.len() as u32).to_be_bytes(),
+            input,
+            &(output.len() as u32).to_be_bytes(),
+            output,
+        ]
+        .concat();
+
+        let tx_hash = keccak(&data).0;
+
+        self.txs_logs_bloom.accrue_bloom(log_bloom);
+        self.txs_merkle_tree.add(tx_hash);
+    }
+
+    /// Computes the block hashchain.
+    pub fn compute_block_hashchain(
+        &self,
+        chain_id: &[u8; 32],
+        contract_account_id: &[u8],
+        current_block_height: u64,
+        previous_block_hashchain: RawH256,
+    ) -> RawH256 {
+        let txs_hash = self.txs_merkle_tree.compute_hash();
+
+        let data = [
+            chain_id,
+            contract_account_id,
+            &current_block_height.to_be_bytes(),
+            &previous_block_hashchain,
+            &txs_hash,
+            self.txs_logs_bloom.as_bytes(),
+        ]
+        .concat();
+
+        keccak(&data).0
+    }
+
+    /// Clears the transactions added.
+    pub fn clear_txs(&mut self) {
+        self.txs_logs_bloom = Bloom::default();
+        self.txs_merkle_tree.clear();
+    }
+
+    /// Checks no transactions have been added.
+    pub fn is_empty(&self) -> bool {
+        self.txs_merkle_tree.is_empty()
+    }
+}

--- a/engine-hashchain/src/hashchain.rs
+++ b/engine-hashchain/src/hashchain.rs
@@ -234,15 +234,13 @@ impl BlockHashchainComputer {
     }
 
     /// Adds a transaction.
-    #[allow(clippy::as_conversions)]
-    #[allow(clippy::cast_possible_truncation)]
     pub fn add_tx(&mut self, method_name: &str, input: &[u8], output: &[u8], log_bloom: &Bloom) {
         let data = [
-            &(method_name.len() as u32).to_be_bytes(),
+            &saturating_cast(method_name.len()).to_be_bytes(),
             method_name.as_bytes(),
-            &(input.len() as u32).to_be_bytes(),
+            &saturating_cast(input.len()).to_be_bytes(),
             input,
-            &(output.len() as u32).to_be_bytes(),
+            &saturating_cast(output.len()).to_be_bytes(),
             output,
         ]
         .concat();
@@ -286,4 +284,8 @@ impl BlockHashchainComputer {
     pub fn is_empty(&self) -> bool {
         self.txs_merkle_tree.is_empty()
     }
+}
+
+fn saturating_cast(x: usize) -> u32 {
+    x.try_into().unwrap_or(u32::MAX)
 }

--- a/engine-hashchain/src/lib.rs
+++ b/engine-hashchain/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod bloom;
+pub mod error;
+pub mod hashchain;
+pub mod merkle;
+#[cfg(test)]
+mod tests;

--- a/engine-hashchain/src/merkle.rs
+++ b/engine-hashchain/src/merkle.rs
@@ -56,7 +56,7 @@ impl StreamCompactMerkleTree {
                 };
 
                 self.subtrees.pop();
-                // Unwrap is stafe since `index >= 1`
+                // Unwrap is safe since `index >= 1`
                 *(self.subtrees.last_mut().unwrap()) = father_subtree;
 
                 index -= 1;

--- a/engine-hashchain/src/merkle.rs
+++ b/engine-hashchain/src/merkle.rs
@@ -1,0 +1,367 @@
+use aurora_engine_sdk::keccak;
+use aurora_engine_types::{
+    borsh::{self, BorshDeserialize, BorshSerialize},
+    types::RawH256,
+    Vec,
+};
+
+/// Stream Compact Merkle Tree.
+/// It can be feed by a stream of hashes (leaves) adding them to the right of the tree.
+/// Internally, compacts full binary subtrees maintaining only the growing branch.
+/// Space used is O(log n) where n is the number of leaf hashes added. It is usually less.
+#[derive(BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
+pub struct StreamCompactMerkleTree {
+    /// Complete binary merkle subtrees.
+    /// Left subtrees are strictly higher (bigger).
+    /// Subtrees are compacted right to left when two consecutives have same height.
+    subtrees: Vec<CompactMerkleSubtree>,
+}
+
+impl StreamCompactMerkleTree {
+    pub const fn new() -> Self {
+        Self {
+            subtrees: Vec::new(),
+        }
+    }
+
+    /// Returns `true` if no data has been added to the tree.
+    pub fn is_empty(&self) -> bool {
+        self.subtrees.is_empty()
+    }
+
+    /// Adds a leaf hash to the right of the tree.
+    /// For n leaves hashes added, a single call to this function is O(log n),
+    /// but the amortized time per each of the n calls is O(1).
+    pub fn add(&mut self, leaf_hash: RawH256) {
+        let leaf_subtree = CompactMerkleSubtree {
+            height: 1,
+            hash: leaf_hash,
+        };
+        self.subtrees.push(leaf_subtree);
+
+        // compact subtrees from right to left
+        let mut index = self.subtrees.len() - 1;
+
+        while index >= 1 {
+            debug_assert_eq!(index, self.subtrees.len() - 1);
+
+            let right_subtree = &self.subtrees[index];
+            let left_subtree = &self.subtrees[index - 1];
+
+            // same height means they are siblings so we can compact them
+            if left_subtree.height == right_subtree.height {
+                let father_subtree = CompactMerkleSubtree {
+                    height: left_subtree.height + 1,
+                    hash: keccak(&[left_subtree.hash, right_subtree.hash].concat()).0,
+                };
+
+                self.subtrees.pop();
+                self.subtrees.pop();
+                self.subtrees.push(father_subtree);
+
+                index -= 1;
+            }
+            // all remaining subtrees have different heights so we can't compact anything else
+            else {
+                debug_assert!(self
+                    .subtrees
+                    .iter()
+                    .zip(self.subtrees.iter().skip(1))
+                    .all(|(left, right)| left.height > right.height));
+                break;
+            }
+        }
+    }
+
+    /// Computes the hash of the Merkle Tree.
+    /// For n leaves hashes added, this function is O(log n).
+    pub fn compute_hash(&self) -> RawH256 {
+        if self.subtrees.is_empty() {
+            return [0; 32];
+        }
+
+        // compute hash compacting or duplicating subtrees hashes from right to left
+        let mut index = &self.subtrees.len() - 1;
+        let mut right_subtree = CompactMerkleSubtree {
+            ..self.subtrees[index]
+        };
+
+        while index >= 1 {
+            let left_subtree = &self.subtrees[index - 1];
+
+            // same height means they are siblings so we can compact hashes
+            if left_subtree.height == right_subtree.height {
+                right_subtree.hash = keccak(&[left_subtree.hash, right_subtree.hash].concat()).0;
+                index -= 1;
+            }
+            // left_subtree is higher so we need to duplicate right_subtree to grow up (standard mechanism for unbalanced merkle trees)
+            else {
+                right_subtree.hash = keccak(&[right_subtree.hash, right_subtree.hash].concat()).0;
+            }
+
+            right_subtree.height += 1;
+        }
+
+        right_subtree.hash
+    }
+
+    /// Clears the structure leaving it empty.
+    pub fn clear(&mut self) {
+        self.subtrees.clear();
+    }
+}
+
+impl Default for StreamCompactMerkleTree {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Compact Merkle Subtree.
+/// For leaves, this represents only the leaf node with height 1 and the hash of the leaf.
+/// For bigger subtrees, this represents the entire balanced subtree with its height and merkle hash.
+#[derive(BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
+struct CompactMerkleSubtree {
+    /// Height of the subtree.
+    pub height: u8,
+
+    /// Merkle tree hash of the subtree.
+    pub hash: RawH256,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_tree() {
+        let merkle_tree = StreamCompactMerkleTree::new();
+
+        let merkle_tree_hash = merkle_tree.compute_hash();
+
+        assert_eq!(merkle_tree.subtrees.len(), 0);
+        assert_eq!(merkle_tree_hash, [0; 32]);
+    }
+
+    #[test]
+    fn one_leaf_tree() {
+        let one_hash = hash(1);
+
+        let mut merkle_tree = StreamCompactMerkleTree::new();
+        merkle_tree.add(one_hash);
+
+        let merkle_tree_hash = merkle_tree.compute_hash();
+
+        assert_eq!(merkle_tree.subtrees.len(), 1);
+        assert_eq!(merkle_tree.subtrees[0].hash, one_hash);
+        assert_eq!(merkle_tree_hash, one_hash);
+    }
+
+    #[test]
+    fn two_leaf_tree() {
+        let one_hash = hash(1);
+        let two_hash = hash(2);
+
+        let expected_merkle_tree_hash = keccak(&[one_hash, two_hash].concat()).0;
+
+        let mut merkle_tree = StreamCompactMerkleTree::new();
+        merkle_tree.add(one_hash);
+        merkle_tree.add(two_hash);
+
+        let merkle_tree_hash = merkle_tree.compute_hash();
+
+        assert_eq!(
+            merkle_tree.subtrees.len(),
+            1,
+            "1 and 2 should be compacted."
+        );
+        assert_eq!(merkle_tree.subtrees[0].hash, expected_merkle_tree_hash);
+        assert_eq!(merkle_tree_hash, expected_merkle_tree_hash);
+    }
+
+    #[test]
+    fn three_leaf_tree() {
+        let one_hash = hash(1);
+        let two_hash = hash(2);
+        let three_hash = hash(3);
+
+        let expected_left_subtree_hash = hash_concatenation(one_hash, two_hash);
+        let expected_right_subtree_hash_computation = hash_concatenation(three_hash, three_hash);
+        let expected_merkle_tree_hash = hash_concatenation(
+            expected_left_subtree_hash,
+            expected_right_subtree_hash_computation,
+        );
+
+        let mut merkle_tree = StreamCompactMerkleTree::new();
+        merkle_tree.add(one_hash);
+        merkle_tree.add(two_hash);
+        merkle_tree.add(three_hash);
+
+        let merkle_tree_hash = merkle_tree.compute_hash();
+
+        assert_eq!(
+            merkle_tree.subtrees.len(),
+            2,
+            "1 and 2 should be compacted; 3 should be alone."
+        );
+        assert_eq!(merkle_tree.subtrees[0].hash, expected_left_subtree_hash);
+        assert_eq!(
+            merkle_tree.subtrees[1].hash, three_hash,
+            "3 should be alone."
+        );
+        assert_eq!(merkle_tree_hash, expected_merkle_tree_hash);
+    }
+
+    #[test]
+    fn four_leaf_tree() {
+        let one_hash = hash(1);
+        let two_hash = hash(2);
+        let three_hash = hash(3);
+        let four_hash = hash(4);
+
+        let expected_left_subtree_hash = hash_concatenation(one_hash, two_hash);
+        let expected_right_subtree_hash = hash_concatenation(three_hash, four_hash);
+        let expected_merkle_tree_hash =
+            hash_concatenation(expected_left_subtree_hash, expected_right_subtree_hash);
+
+        let mut merkle_tree = StreamCompactMerkleTree::new();
+        merkle_tree.add(one_hash);
+        merkle_tree.add(two_hash);
+        merkle_tree.add(three_hash);
+        merkle_tree.add(four_hash);
+
+        let merkle_tree_hash = merkle_tree.compute_hash();
+
+        assert_eq!(merkle_tree.subtrees.len(), 1, "1 and 2 should be compacted, 3 and 4 also, and then both resulting should be compacted too.");
+        assert_eq!(merkle_tree.subtrees[0].hash, expected_merkle_tree_hash);
+        assert_eq!(merkle_tree_hash, expected_merkle_tree_hash);
+    }
+
+    #[test]
+    fn five_leaf_tree() {
+        let one_hash = hash(1);
+        let two_hash = hash(2);
+        let three_hash = hash(3);
+        let four_hash = hash(4);
+        let five_hash = hash(5);
+
+        let expected_left_left_subtree_hash = hash_concatenation(one_hash, two_hash);
+        let expected_left_right_subtree_hash = hash_concatenation(three_hash, four_hash);
+        let expected_left_subtree_hash = hash_concatenation(
+            expected_left_left_subtree_hash,
+            expected_left_right_subtree_hash,
+        );
+
+        let expected_right_left_subtree_hash_computation = hash_concatenation(five_hash, five_hash);
+        let expected_right_subtree_hash_computation = hash_concatenation(
+            expected_right_left_subtree_hash_computation,
+            expected_right_left_subtree_hash_computation,
+        );
+
+        let expected_merkle_tree_hash = hash_concatenation(
+            expected_left_subtree_hash,
+            expected_right_subtree_hash_computation,
+        );
+
+        let mut merkle_tree = StreamCompactMerkleTree::new();
+        merkle_tree.add(one_hash);
+        merkle_tree.add(two_hash);
+        merkle_tree.add(three_hash);
+        merkle_tree.add(four_hash);
+        merkle_tree.add(five_hash);
+
+        let merkle_tree_hash = merkle_tree.compute_hash();
+
+        assert_eq!(
+            merkle_tree.subtrees.len(),
+            2,
+            "1, 2, 3 and 4 should be compacted; 5 is alone."
+        );
+        assert_eq!(merkle_tree.subtrees[0].hash, expected_left_subtree_hash);
+        assert_eq!(merkle_tree.subtrees[1].hash, five_hash);
+        assert_eq!(merkle_tree_hash, expected_merkle_tree_hash);
+    }
+
+    #[test]
+    fn seven_leaf_tree() {
+        let one_hash = hash(1);
+        let two_hash = hash(2);
+        let three_hash = hash(3);
+        let four_hash = hash(4);
+        let five_hash = hash(5);
+        let six_hash = hash(6);
+        let seven_hash = hash(7);
+
+        let expected_left_left_subtree_hash = hash_concatenation(one_hash, two_hash);
+        let expected_left_right_subtree_hash = hash_concatenation(three_hash, four_hash);
+        let expected_left_subtree_hash = hash_concatenation(
+            expected_left_left_subtree_hash,
+            expected_left_right_subtree_hash,
+        );
+
+        let expected_right_left_subtree_hash = hash_concatenation(five_hash, six_hash);
+        let expected_right_right_subtree_hash_computation =
+            hash_concatenation(seven_hash, seven_hash);
+        let expected_right_subtree_hash_computation = hash_concatenation(
+            expected_right_left_subtree_hash,
+            expected_right_right_subtree_hash_computation,
+        );
+
+        let expected_merkle_tree_hash = hash_concatenation(
+            expected_left_subtree_hash,
+            expected_right_subtree_hash_computation,
+        );
+
+        let mut merkle_tree = StreamCompactMerkleTree::new();
+        merkle_tree.add(one_hash);
+        merkle_tree.add(two_hash);
+        merkle_tree.add(three_hash);
+        merkle_tree.add(four_hash);
+        merkle_tree.add(five_hash);
+        merkle_tree.add(six_hash);
+        merkle_tree.add(seven_hash);
+
+        let merkle_tree_hash = merkle_tree.compute_hash();
+
+        assert_eq!(
+            merkle_tree.subtrees.len(),
+            3,
+            "1, 2, 3 and 4 should be compacted; 5 and 6 too; 7 is alone."
+        );
+        assert_eq!(merkle_tree.subtrees[0].hash, expected_left_subtree_hash);
+        assert_eq!(
+            merkle_tree.subtrees[1].hash,
+            expected_right_left_subtree_hash
+        );
+        assert_eq!(merkle_tree.subtrees[2].hash, seven_hash);
+        assert_eq!(merkle_tree_hash, expected_merkle_tree_hash);
+    }
+
+    #[test]
+    fn clear_tree() {
+        let one_hash = hash(1);
+
+        let mut merkle_tree = StreamCompactMerkleTree::new();
+        assert_eq!(merkle_tree.subtrees.len(), 0);
+        assert_eq!(merkle_tree.compute_hash(), [0; 32]);
+        assert_eq!(merkle_tree.subtrees.len(), 0);
+
+        merkle_tree.add(one_hash);
+        assert_eq!(merkle_tree.subtrees.len(), 1);
+        assert_eq!(merkle_tree.compute_hash(), one_hash);
+        assert_eq!(merkle_tree.subtrees.len(), 1);
+
+        merkle_tree.clear();
+        assert_eq!(merkle_tree.subtrees.len(), 0);
+        assert_eq!(merkle_tree.compute_hash(), [0; 32]);
+        assert_eq!(merkle_tree.subtrees.len(), 0);
+    }
+
+    fn hash(number: u16) -> RawH256 {
+        keccak(&number.to_be_bytes()).0
+    }
+
+    fn hash_concatenation(hash_left: RawH256, hash_right: RawH256) -> RawH256 {
+        keccak(&[hash_left, hash_right].concat()).0
+    }
+}

--- a/engine-hashchain/src/merkle.rs
+++ b/engine-hashchain/src/merkle.rs
@@ -56,8 +56,8 @@ impl StreamCompactMerkleTree {
                 };
 
                 self.subtrees.pop();
-                self.subtrees.pop();
-                self.subtrees.push(father_subtree);
+                // Unwrap is stafe since `index >= 1`
+                *(self.subtrees.last_mut().unwrap()) = father_subtree;
 
                 index -= 1;
             }

--- a/engine-hashchain/src/tests.rs
+++ b/engine-hashchain/src/tests.rs
@@ -1,0 +1,181 @@
+use crate::{
+    bloom::Bloom,
+    hashchain::{Hashchain, HashchainBuilder},
+};
+use aurora_engine_types::account_id::AccountId;
+
+#[test]
+fn test_add_tx() {
+    let mut hashchain = HashchainBuilder::default()
+        .with_current_block_height(2)
+        .build();
+
+    // Adding a transaction at a lower height than the current height is not allowed
+    let add_tx_result = hashchain.add_block_tx(1, "foo", &[], &[], &Bloom::default());
+    assert!(add_tx_result.is_err());
+    assert!(hashchain.is_empty());
+    assert_eq!(hashchain.get_logs_bloom(), &Bloom::default());
+
+    // Adding a transaction at a higher height than the current height is not allowed
+    let add_tx_result = hashchain.add_block_tx(3, "foo", &[], &[], &Bloom::default());
+    assert!(add_tx_result.is_err());
+    assert!(hashchain.is_empty());
+    assert_eq!(hashchain.get_logs_bloom(), &Bloom::default());
+
+    // Adding a transaction at the current height works
+    let add_tx_result = hashchain.add_block_tx(2, "foo", &[], &[], &Bloom::default());
+    assert!(add_tx_result.is_ok());
+    assert!(!hashchain.is_empty());
+    assert_eq!(hashchain.get_logs_bloom(), &Bloom::default());
+}
+
+#[test]
+fn test_move_to_block_fail() {
+    let mut hashchain = HashchainBuilder::default()
+        .with_current_block_height(2)
+        .build();
+
+    // Cannot move to a height lower than the current height
+    let move_to_block_result = hashchain.move_to_block(1);
+    assert!(move_to_block_result.is_err());
+
+    // Cannot move to the same height as the current height
+    let move_to_block_result = hashchain.move_to_block(2);
+    assert!(move_to_block_result.is_err());
+}
+
+#[test]
+fn test_move_to_block_success() {
+    let chain_id = [1; 32];
+    let contract_account_id: AccountId = "aurora".parse().unwrap();
+    let initial_hashchain = aurora_engine_sdk::keccak(b"seed");
+
+    let method_name = "foo";
+    let input = b"foo_input";
+    let output = b"foo_output";
+    let bloom = {
+        let mut buf = Bloom::default();
+        buf.0[0] = 1;
+        buf
+    };
+
+    let tx_hash = aurora_engine_sdk::keccak(
+        &[
+            &len_be_bytes(method_name.as_bytes()),
+            method_name.as_bytes(),
+            &len_be_bytes(input),
+            input,
+            &len_be_bytes(output),
+            output,
+        ]
+        .concat(),
+    );
+
+    let block_height_2: u64 = 2;
+    let block_height_3 = block_height_2 + 1;
+    let block_height_4 = block_height_3 + 1;
+
+    let expected_hashchain_2 = aurora_engine_sdk::keccak(
+        &[
+            &chain_id,
+            contract_account_id.as_bytes(),
+            &block_height_2.to_be_bytes(),
+            initial_hashchain.as_bytes(),
+            tx_hash.as_bytes(),
+            bloom.as_bytes(),
+        ]
+        .concat(),
+    );
+
+    let expected_hashchain_3 = aurora_engine_sdk::keccak(
+        &[
+            &chain_id,
+            contract_account_id.as_bytes(),
+            &block_height_3.to_be_bytes(),
+            expected_hashchain_2.as_bytes(),
+            &[0; 32],
+            Bloom::default().as_bytes(),
+        ]
+        .concat(),
+    );
+
+    let expected_hashchain_4 = aurora_engine_sdk::keccak(
+        &[
+            &chain_id,
+            contract_account_id.as_bytes(),
+            &block_height_4.to_be_bytes(),
+            expected_hashchain_3.as_bytes(),
+            &[0; 32],
+            Bloom::default().as_bytes(),
+        ]
+        .concat(),
+    );
+
+    let mut hashchain = HashchainBuilder::default()
+        .with_account_id(contract_account_id)
+        .with_chain_id(chain_id)
+        .with_current_block_height(block_height_2)
+        .with_previous_hashchain(initial_hashchain.0)
+        .build();
+
+    hashchain
+        .add_block_tx(block_height_2, method_name, input, output, &bloom)
+        .expect("Should add tx");
+    assert_eq!(
+        hashchain.get_previous_block_hashchain(),
+        initial_hashchain.0
+    );
+
+    // Move to next height, capturing the hashchain that includes the previously added transaction
+    hashchain
+        .move_to_block(block_height_3)
+        .expect("Should move to next block height");
+    assert_eq!(
+        hashchain.get_previous_block_hashchain(),
+        expected_hashchain_2.0
+    );
+    assert!(
+        hashchain.is_empty(),
+        "Hashchain should be clear after moving to the next block"
+    );
+    assert_eq!(hashchain.get_logs_bloom(), &Bloom::default());
+
+    // Should still work even if we skip a height
+    hashchain
+        .move_to_block(block_height_4 + 1)
+        .expect("Should be able to skip a block height");
+    assert_eq!(
+        hashchain.get_previous_block_hashchain(),
+        expected_hashchain_4.0
+    );
+    assert_eq!(hashchain.get_current_block_height(), block_height_4 + 1,);
+}
+
+#[test]
+fn test_serialization_round_trip() {
+    let bloom = {
+        let mut bloom = Bloom::default();
+        bloom.accrue(&[0xde, 0xad, 0xbe, 0xef]);
+        bloom
+    };
+
+    let mut hashchain = HashchainBuilder::default()
+        .with_account_id("aurora".parse().unwrap())
+        .with_u64_chain_id(123456)
+        .with_previous_hashchain([8; 32])
+        .build();
+
+    hashchain
+        .add_block_tx(0, "foo", b"input", b"output", &bloom)
+        .unwrap();
+
+    let serialized = hashchain.try_serialize().unwrap();
+    let round_trip = Hashchain::try_deserialize(&serialized).unwrap();
+
+    assert_eq!(round_trip, hashchain);
+}
+
+fn len_be_bytes(arr: &[u8]) -> [u8; 4] {
+    let len = arr.len();
+    u32::try_from(len).unwrap().to_be_bytes()
+}


### PR DESCRIPTION
## Description

This PR continues the effort of merging #705 in multiple pieces.

This PR introduces the core hashchain logic as a library crate. The reasons to factor the code in this way are:

1. Allows this PR to be safely merged because it has no impact on existing engine code
2. The same core logic will be reusable between components that will perform the hashchain computation in the future, namely: Aurora Engine smart contract, standalone engine, Borealis Refiner.

In the next PR I'll pull in the changes from #705 which actually introduce the hashchain calculation into the Aurora Engine smart contract and standalone engine.

## Performance / NEAR gas cost considerations

N/A

## Testing

New hashchain tests