### PR TITLE
Chore: Update to SputnikVM version 0.38.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1731,7 +1731,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "evm"
 version = "0.39.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.0-aurora#c5cdf0c9bf8da9f6baeb1e5b4a52a2a3405e123f"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.2-aurora#f981a072ab7b0690dbb4575251cc4bd8c5f4998b"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -1751,7 +1751,7 @@ dependencies = [
 [[package]]
 name = "evm-core"
 version = "0.39.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.0-aurora#c5cdf0c9bf8da9f6baeb1e5b4a52a2a3405e123f"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.2-aurora#f981a072ab7b0690dbb4575251cc4bd8c5f4998b"
 dependencies = [
  "parity-scale-codec 3.6.3",
  "primitive-types 0.12.1",
@@ -1762,7 +1762,7 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.39.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.0-aurora#c5cdf0c9bf8da9f6baeb1e5b4a52a2a3405e123f"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.2-aurora#f981a072ab7b0690dbb4575251cc4bd8c5f4998b"
 dependencies = [
  "environmental",
  "evm-core",
@@ -1773,7 +1773,7 @@ dependencies = [
 [[package]]
 name = "evm-runtime"
 version = "0.39.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.0-aurora#c5cdf0c9bf8da9f6baeb1e5b4a52a2a3405e123f"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.2-aurora#f981a072ab7b0690dbb4575251cc4bd8c5f4998b"
 dependencies = [
  "auto_impl",
  "environmental",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,10 @@ byte-slice-cast = { version = "1", default-features = false }
 criterion = "0.5"
 digest = "0.10"
 ethabi = { version = "18", default-features = false }
-evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.0-aurora", default-features = false }
-evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.0-aurora", default-features = false, features = ["std"] }
-evm-gasometer = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.0-aurora", default-features = false, features = ["std", "tracing"] }
-evm-runtime = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.0-aurora", default-features = false, features = ["std", "tracing"] }
+evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.2-aurora", default-features = false }
+evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.2-aurora", default-features = false, features = ["std"] }
+evm-gasometer = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.2-aurora", default-features = false, features = ["std", "tracing"] }
+evm-runtime = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.2-aurora", default-features = false, features = ["std", "tracing"] }
 fixed-hash = { version = "0.8.0", default-features = false}
 git2 = "0.17"
 hex = { version = "0.4", default-features = false, features = ["alloc"] }

--- a/engine-precompiles/src/promise_result.rs
+++ b/engine-precompiles/src/promise_result.rs
@@ -15,7 +15,7 @@ pub mod costs {
     use crate::prelude::types::EthGas;
 
     /// This cost is always charged for calling this precompile.
-    pub const PROMISE_RESULT_BASE_COST: EthGas = EthGas::new(105);
+    pub const PROMISE_RESULT_BASE_COST: EthGas = EthGas::new(111);
     /// This is the cost per byte of promise result data.
     pub const PROMISE_RESULT_BYTE_COST: EthGas = EthGas::new(1);
 }


### PR DESCRIPTION
## Description

Updates to the latest version of the Aurora fork of SpunikVM. The previous version had a bug in the implementation of the `returndatacopy` opcode.

## Performance / NEAR gas cost considerations

For some reason this also causes the EVM gas cost of the promise results precompile to increase. I am not sure why, but it's only a small increase (recall that any EVM transaction must spend at least 21000 gas), so I think's ok.

## Testing

Added an additional test for `returndatacopy`.
