### PR TITLE
Fix(standalone): Do not eagerly commit transactions to the DB

### DIFF
--- a/engine-standalone-storage/src/sync/mod.rs
+++ b/engine-standalone-storage/src/sync/mod.rs
@@ -1,3 +1,4 @@
+use crate::engine_state::EngineStateAccess;
 use aurora_engine::parameters::SubmitArgs;
 use aurora_engine::pausables::{
     EnginePrecompilesPauser, PausedPrecompilesManager, PrecompileFlags,
@@ -266,7 +267,7 @@ pub fn consume_message<M: ModExpAlgorithm + 'static>(
                         &block_metadata,
                         engine_account_id,
                         io,
-                        |x| x.get_transaction_diff(),
+                        EngineStateAccess::get_transaction_diff,
                     )
                 })
                 .result;
@@ -299,7 +300,7 @@ pub fn execute_transaction_message<M: ModExpAlgorithm + 'static>(
             &block_metadata,
             engine_account_id,
             io,
-            |x| x.get_transaction_diff(),
+            EngineStateAccess::get_transaction_diff,
         )
     });
     let (tx_hash, diff, maybe_result) = result.result;

--- a/engine-tests/src/tests/standalone/sync.rs
+++ b/engine-tests/src/tests/standalone/sync.rs
@@ -67,6 +67,7 @@ fn test_consume_deposit_message() {
         sync::ConsumeMessageOutcome::TransactionIncluded(outcome) => outcome,
         other => panic!("Unexpected outcome {other:?}"),
     };
+    outcome.commit(&mut runner.storage).unwrap();
 
     let finish_deposit_args = match outcome.maybe_result.unwrap().unwrap() {
         sync::TransactionExecutionResult::Promise(promise_args) => {
@@ -99,6 +100,7 @@ fn test_consume_deposit_message() {
         sync::ConsumeMessageOutcome::TransactionIncluded(outcome) => outcome,
         other => panic!("Unexpected outcome {other:?}"),
     };
+    outcome.commit(&mut runner.storage).unwrap();
 
     let ft_on_transfer_args = match outcome.maybe_result.unwrap().unwrap() {
         sync::TransactionExecutionResult::Promise(promise_args) => {
@@ -120,11 +122,12 @@ fn test_consume_deposit_message() {
         promise_data: Vec::new(),
     };
 
-    sync::consume_message::<AuroraModExp>(
+    let outcome = sync::consume_message::<AuroraModExp>(
         &mut runner.storage,
         sync::types::Message::Transaction(Box::new(transaction_message)),
     )
     .unwrap();
+    outcome.commit(&mut runner.storage).unwrap();
 
     assert_eq!(runner.get_balance(&recipient_address), deposit_amount);
 
@@ -150,11 +153,12 @@ fn test_consume_deploy_message() {
         promise_data: Vec::new(),
     };
 
-    sync::consume_message::<AuroraModExp>(
+    let outcome = sync::consume_message::<AuroraModExp>(
         &mut runner.storage,
         sync::types::Message::Transaction(Box::new(transaction_message)),
     )
     .unwrap();
+    outcome.commit(&mut runner.storage).unwrap();
 
     let diff = runner
         .storage
@@ -203,11 +207,12 @@ fn test_consume_deploy_erc20_message() {
     };
 
     // Deploy ERC-20 (this would be the flow for bridging a new NEP-141 to Aurora)
-    sync::consume_message::<AuroraModExp>(
+    let outcome = sync::consume_message::<AuroraModExp>(
         &mut runner.storage,
         sync::types::Message::Transaction(Box::new(transaction_message)),
     )
     .unwrap();
+    outcome.commit(&mut runner.storage).unwrap();
 
     let erc20_address = runner
         .storage
@@ -241,11 +246,12 @@ fn test_consume_deploy_erc20_message() {
     };
 
     // Mint new tokens (via ft_on_transfer flow, same as the bridge)
-    sync::consume_message::<AuroraModExp>(
+    let outcome = sync::consume_message::<AuroraModExp>(
         &mut runner.storage,
         sync::types::Message::Transaction(Box::new(transaction_message)),
     )
     .unwrap();
+    outcome.commit(&mut runner.storage).unwrap();
 
     // Check balance is correct
     let deployed_token = ERC20(
@@ -297,11 +303,12 @@ fn test_consume_ft_on_transfer_message() {
         promise_data: Vec::new(),
     };
 
-    sync::consume_message::<AuroraModExp>(
+    let outcome = sync::consume_message::<AuroraModExp>(
         &mut runner.storage,
         sync::types::Message::Transaction(Box::new(transaction_message)),
     )
     .unwrap();
+    outcome.commit(&mut runner.storage).unwrap();
 
     assert_eq!(
         runner.get_balance(&dest_address).raw().low_u128(),
@@ -341,11 +348,12 @@ fn test_consume_call_message() {
         promise_data: Vec::new(),
     };
 
-    sync::consume_message::<AuroraModExp>(
+    let outcome = sync::consume_message::<AuroraModExp>(
         &mut runner.storage,
         sync::types::Message::Transaction(Box::new(transaction_message)),
     )
     .unwrap();
+    outcome.commit(&mut runner.storage).unwrap();
 
     assert_eq!(runner.get_balance(&recipient_address), transfer_amount);
     assert_eq!(
@@ -391,11 +399,12 @@ fn test_consume_submit_message() {
         promise_data: Vec::new(),
     };
 
-    sync::consume_message::<AuroraModExp>(
+    let outcome = sync::consume_message::<AuroraModExp>(
         &mut runner.storage,
         sync::types::Message::Transaction(Box::new(transaction_message)),
     )
     .unwrap();
+    outcome.commit(&mut runner.storage).unwrap();
 
     assert_eq!(runner.get_balance(&recipient_address), transfer_amount);
     assert_eq!(


### PR DESCRIPTION
## Description

The [Borealis refiner](https://github.com/aurora-is-near/borealis-engine-lib/tree/main/refiner-lib) was experiencing a performance issue where it would become very slow at processing blocks. Profiling revealed the reason was increasing time to look up the `ENGINE_STATE` key when replaying transactions (this replay is necessary to correctly process batch transactions on Near). After some investigation, we realized the cause of this slow lookup was due to that key being constantly written and deleted by every transaction. The reason for this churn is because the Engine logic was changed to automatically migrate its state, but of course old transactions did not have that logic and therefore the replay would compute an incorrect state diff relative to what is reported in the Near block. In such cases the replay changes to the DB are deleted and the correct diff from the Near block is used instead.

To avoid this DB churn, this PR changes the standalone engine so that it will not commit to the DB right away when consuming a block. Instead it is now up to clients of the standalone engine to commit the changes themselves (after performing any validation). A PR on Borealis Refiner will make that change there after this PR is merged.

Note this does not address the larger issue of replay accuracy. In theory the Borealis Refiner should use the code that existed at the time when replaying an old transaction. However, this is not so easy to accomplish which is why we are proposing this solution instead. It is an immediate fix to the performance issue that can keep the Refiner running while we address the more fundamental problem.

## Performance / NEAR gas cost considerations

No impact to on-chain Aurora contract; changes to standalone only.

## Testing

Updates to existing tests