### PR TITLE
Chore: Update to SputnikVM version 0.38.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1731,7 +1731,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "evm"
 version = "0.39.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.2-aurora#f981a072ab7b0690dbb4575251cc4bd8c5f4998b"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.3-aurora#4e2d27d8ff8e5a50a43ed49d86282decce9d39f9"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -1751,7 +1751,7 @@ dependencies = [
 [[package]]
 name = "evm-core"
 version = "0.39.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.2-aurora#f981a072ab7b0690dbb4575251cc4bd8c5f4998b"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.3-aurora#4e2d27d8ff8e5a50a43ed49d86282decce9d39f9"
 dependencies = [
  "parity-scale-codec 3.6.3",
  "primitive-types 0.12.1",
@@ -1762,7 +1762,7 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.39.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.2-aurora#f981a072ab7b0690dbb4575251cc4bd8c5f4998b"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.3-aurora#4e2d27d8ff8e5a50a43ed49d86282decce9d39f9"
 dependencies = [
  "environmental",
  "evm-core",
@@ -1773,7 +1773,7 @@ dependencies = [
 [[package]]
 name = "evm-runtime"
 version = "0.39.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.2-aurora#f981a072ab7b0690dbb4575251cc4bd8c5f4998b"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.3-aurora#4e2d27d8ff8e5a50a43ed49d86282decce9d39f9"
 dependencies = [
  "auto_impl",
  "environmental",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1731,7 +1731,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "evm"
 version = "0.39.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.0-aurora#c5cdf0c9bf8da9f6baeb1e5b4a52a2a3405e123f"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.2-aurora#f981a072ab7b0690dbb4575251cc4bd8c5f4998b"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -1751,7 +1751,7 @@ dependencies = [
 [[package]]
 name = "evm-core"
 version = "0.39.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.0-aurora#c5cdf0c9bf8da9f6baeb1e5b4a52a2a3405e123f"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.2-aurora#f981a072ab7b0690dbb4575251cc4bd8c5f4998b"
 dependencies = [
  "parity-scale-codec 3.6.3",
  "primitive-types 0.12.1",
@@ -1762,7 +1762,7 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.39.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.0-aurora#c5cdf0c9bf8da9f6baeb1e5b4a52a2a3405e123f"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.2-aurora#f981a072ab7b0690dbb4575251cc4bd8c5f4998b"
 dependencies = [
  "environmental",
  "evm-core",
@@ -1773,7 +1773,7 @@ dependencies = [
 [[package]]
 name = "evm-runtime"
 version = "0.39.0"
-source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.0-aurora#c5cdf0c9bf8da9f6baeb1e5b4a52a2a3405e123f"
+source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.38.2-aurora#f981a072ab7b0690dbb4575251cc4bd8c5f4998b"
 dependencies = [
  "auto_impl",
  "environmental",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,10 @@ byte-slice-cast = { version = "1", default-features = false }
 criterion = "0.5"
 digest = "0.10"
 ethabi = { version = "18", default-features = false }
-evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.2-aurora", default-features = false }
-evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.2-aurora", default-features = false, features = ["std"] }
-evm-gasometer = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.2-aurora", default-features = false, features = ["std", "tracing"] }
-evm-runtime = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.2-aurora", default-features = false, features = ["std", "tracing"] }
+evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.3-aurora", default-features = false }
+evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.3-aurora", default-features = false, features = ["std"] }
+evm-gasometer = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.3-aurora", default-features = false, features = ["std", "tracing"] }
+evm-runtime = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.3-aurora", default-features = false, features = ["std", "tracing"] }
 fixed-hash = { version = "0.8.0", default-features = false}
 git2 = "0.17"
 hex = { version = "0.4", default-features = false, features = ["alloc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,10 @@ byte-slice-cast = { version = "1", default-features = false }
 criterion = "0.5"
 digest = "0.10"
 ethabi = { version = "18", default-features = false }
-evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.0-aurora", default-features = false }
-evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.0-aurora", default-features = false, features = ["std"] }
-evm-gasometer = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.0-aurora", default-features = false, features = ["std", "tracing"] }
-evm-runtime = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.0-aurora", default-features = false, features = ["std", "tracing"] }
+evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.2-aurora", default-features = false }
+evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.2-aurora", default-features = false, features = ["std"] }
+evm-gasometer = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.2-aurora", default-features = false, features = ["std", "tracing"] }
+evm-runtime = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.2-aurora", default-features = false, features = ["std", "tracing"] }
 fixed-hash = { version = "0.8.0", default-features = false}
 git2 = "0.17"
 hex = { version = "0.4", default-features = false, features = ["alloc"] }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -342,7 +342,7 @@ args = [
     "--release",
     "--features",
     "${CARGO_FEATURES_TEST}",
-    "bench_modexp_standalone",
+    "bench_m",
     "--",
     "--ignored",
 ]

--- a/engine-precompiles/src/promise_result.rs
+++ b/engine-precompiles/src/promise_result.rs
@@ -15,7 +15,7 @@ pub mod costs {
     use crate::prelude::types::EthGas;
 
     /// This cost is always charged for calling this precompile.
-    pub const PROMISE_RESULT_BASE_COST: EthGas = EthGas::new(105);
+    pub const PROMISE_RESULT_BASE_COST: EthGas = EthGas::new(111);
     /// This is the cost per byte of promise result data.
     pub const PROMISE_RESULT_BYTE_COST: EthGas = EthGas::new(1);
 }

--- a/engine-tests/src/tests/one_inch.rs
+++ b/engine-tests/src/tests/one_inch.rs
@@ -39,7 +39,7 @@ fn test_1inch_liquidity_protocol() {
     let (result, profile, pool) =
         helper.create_pool(&pool_factory, token_a.0.address, token_b.0.address);
     assert!(result.gas_used >= 4_500_000); // more than 4.5M EVM gas used
-    assert_gas_bound(profile.all_gas(), 20);
+    assert_gas_bound(profile.all_gas(), 18);
 
     // Approve giving ERC-20 tokens to the pool
     helper.approve_erc20_tokens(&token_a, pool.address());
@@ -101,7 +101,7 @@ fn test_1_inch_limit_order_deploy() {
     // more than 3.5 million Ethereum gas used
     assert!(result.gas_used > 3_500_000);
     // less than 10 NEAR Tgas used
-    assert_gas_bound(profile.all_gas(), 10);
+    assert_gas_bound(profile.all_gas(), 8);
     // at least 45% of which is from wasm execution
     let wasm_fraction = 100 * profile.wasm_gas() / profile.all_gas();
     assert!(

--- a/engine-tests/src/tests/repro.rs
+++ b/engine-tests/src/tests/repro.rs
@@ -26,7 +26,7 @@ fn repro_GdASJ3KESs() {
         block_timestamp: 1_645_717_564_644_206_730,
         input_path: "src/tests/res/input_GdASJ3KESs.hex",
         evm_gas_used: 706_713,
-        near_gas_used: 121,
+        near_gas_used: 120,
     });
 }
 
@@ -51,7 +51,7 @@ fn repro_8ru7VEA() {
         block_timestamp: 1_648_829_935_343_349_589,
         input_path: "src/tests/res/input_8ru7VEA.hex",
         evm_gas_used: 1_732_181,
-        near_gas_used: 220,
+        near_gas_used: 219,
     });
 }
 
@@ -71,7 +71,7 @@ fn repro_FRcorNv() {
         block_timestamp: 1_650_960_438_774_745_116,
         input_path: "src/tests/res/input_FRcorNv.hex",
         evm_gas_used: 1_239_721,
-        near_gas_used: 179,
+        near_gas_used: 177,
     });
 }
 
@@ -88,7 +88,7 @@ fn repro_5bEgfRQ() {
         block_timestamp: 1_651_073_772_931_594_646,
         input_path: "src/tests/res/input_5bEgfRQ.hex",
         evm_gas_used: 6_414_105,
-        near_gas_used: 654,
+        near_gas_used: 648,
     });
 }
 
@@ -106,7 +106,7 @@ fn repro_D98vwmi() {
         block_timestamp: 1_651_753_443_421_003_245,
         input_path: "src/tests/res/input_D98vwmi.hex",
         evm_gas_used: 1_035_348,
-        near_gas_used: 180,
+        near_gas_used: 179,
     });
 }
 

--- a/engine-tests/src/tests/sanity.rs
+++ b/engine-tests/src/tests/sanity.rs
@@ -57,8 +57,8 @@ fn bench_memory_get_standalone() {
         "Infinite loops in the EVM run out of gas"
     );
     assert!(
-        duration < 2.0,
-        "Must complete this task in under 2s (in release build). Time taken: {duration} s",
+        duration < 8.0,
+        "Must complete this task in under 8s (in release build). Time taken: {duration} s",
     );
 }
 

--- a/engine-tests/src/tests/sanity.rs
+++ b/engine-tests/src/tests/sanity.rs
@@ -17,8 +17,9 @@ const INITIAL_NONCE: u64 = 0;
 const TRANSFER_AMOUNT: Wei = Wei::new_u64(123);
 const GAS_PRICE: u64 = 10;
 
+#[ignore]
 #[test]
-fn test_memory_get_performance() {
+fn bench_memory_get_standalone() {
     let (mut runner, mut signer, _) = initialize_transfer();
 
     // This EVM program is an infinite loop which causes a large amount of memory to be
@@ -50,14 +51,14 @@ fn test_memory_get_performance() {
         .unwrap()
         .submit_transaction(&signer.secret_key, tx)
         .unwrap();
-    let duration = start.elapsed().as_secs();
+    let duration = start.elapsed().as_secs_f32();
     assert!(
         matches!(result.status, TransactionStatus::OutOfGas),
         "Infinite loops in the EVM run out of gas"
     );
     assert!(
-        duration < 5,
-        "Must complete this task in under 5s (even in debug build)"
+        duration < 2.0,
+        "Must complete this task in under 2s (in release build). Time taken: {duration} s",
     );
 }
 


### PR DESCRIPTION
## Description

Updates to the latest version of SputnikVM. There are two improvements:

- A fix to a bug in the `returndatacopy` op code implementation.
- An improvement in performance of accessing the EVM memory.

## Performance / NEAR gas cost considerations

Several gas costs went down a little due to the improved performance in accessing the EVM memory.

For some reason this also causes the EVM gas cost of the promise results precompile to increase. I am not sure why, but it's only a small increase (recall that any EVM transaction must spend at least 21000 gas), so I think's ok.

## Testing

New regression test for the `returndatacopy` bug.
New regression test for the EVM memory performance.
