### PR TITLE
Feat(engine): Hashchain integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,7 @@ dependencies = [
 name = "aurora-engine"
 version = "3.0.0"
 dependencies = [
+ "aurora-engine-hashchain",
  "aurora-engine-modexp",
  "aurora-engine-precompiles",
  "aurora-engine-sdk",
@@ -339,6 +340,7 @@ dependencies = [
  "digest 0.10.7",
  "ethabi",
  "evm",
+ "function_name",
  "hex 0.4.3",
  "rlp",
  "serde",
@@ -1926,6 +1928,21 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "function_name"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1ab577a896d09940b5fe12ec5ae71f9d8211fff62c919c03a3750a9901e98a7"
+dependencies = [
+ "function_name-proc-macro",
+]
+
+[[package]]
+name = "function_name-proc-macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673464e1e314dd67a0fd9544abc99e8eb28d0c7e3b69b033bcff9b2d00b87333"
 
 [[package]]
 name = "funty"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,6 +417,7 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "aurora-engine",
+ "aurora-engine-hashchain",
  "aurora-engine-modexp",
  "aurora-engine-precompiles",
  "aurora-engine-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 
 [workspace.dependencies]
 aurora-engine = { path = "engine", default-features = false }
+aurora-engine-hashchain = { path = "engine-hashchain", default-features = false }
 aurora-engine-precompiles = { path = "engine-precompiles", default-features = false }
 aurora-engine-sdk = { path = "engine-sdk", default-features = false }
 aurora-engine-transactions = { path = "engine-transactions", default-features = false }
@@ -36,6 +37,7 @@ evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.
 evm-gasometer = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.3-aurora", default-features = false, features = ["std", "tracing"] }
 evm-runtime = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.38.3-aurora", default-features = false, features = ["std", "tracing"] }
 fixed-hash = { version = "0.8.0", default-features = false}
+function_name = "0.3.0"
 git2 = "0.17"
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 ibig = { version = "0.3", default-features = false, features = ["num-traits"] }

--- a/engine-hashchain/src/hashchain.rs
+++ b/engine-hashchain/src/hashchain.rs
@@ -3,6 +3,7 @@ use aurora_engine_sdk::keccak;
 use aurora_engine_types::{
     account_id::AccountId,
     borsh::{self, maybestd::io, BorshDeserialize, BorshSerialize},
+    format,
     types::RawH256,
     Cow, Vec,
 };

--- a/engine-hashchain/src/lib.rs
+++ b/engine-hashchain/src/lib.rs
@@ -1,6 +1,9 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 pub mod bloom;
 pub mod error;
 pub mod hashchain;
 pub mod merkle;
 #[cfg(test)]
 mod tests;
+pub mod wrapped_io;

--- a/engine-hashchain/src/wrapped_io.rs
+++ b/engine-hashchain/src/wrapped_io.rs
@@ -1,0 +1,116 @@
+//! This module contains `CachedIO`, a light wrapper over any IO instance
+//! which will cache the input read and output written by the underlying instance.
+//! It has no impact on the storage access functions of the trait.
+//! The purpose of this struct is to capture the input and output from the underlying
+//! IO instance for the purpose of passing it to `Hashchain::add_block_tx`.
+
+use aurora_engine_sdk::io::{StorageIntermediate, IO};
+use aurora_engine_types::Vec;
+use core::cell::RefCell;
+
+#[derive(Debug, Clone, Copy)]
+pub struct CachedIO<'cache, I> {
+    inner: I,
+    cache: &'cache RefCell<IOCache>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WrappedInput<T> {
+    Input(Vec<u8>),
+    Wrapped(T),
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct IOCache {
+    pub input: Vec<u8>,
+    pub output: Vec<u8>,
+}
+
+impl<'cache, I> CachedIO<'cache, I> {
+    pub fn new(io: I, cache: &'cache RefCell<IOCache>) -> Self {
+        Self { inner: io, cache }
+    }
+}
+
+impl IOCache {
+    pub fn set_input(&mut self, value: Vec<u8>) {
+        self.input = value;
+    }
+
+    pub fn set_output(&mut self, value: Vec<u8>) {
+        self.output = value;
+    }
+}
+
+impl<T: StorageIntermediate> StorageIntermediate for WrappedInput<T> {
+    fn len(&self) -> usize {
+        match self {
+            Self::Input(bytes) => bytes.len(),
+            Self::Wrapped(x) => x.len(),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        match self {
+            Self::Input(bytes) => bytes.is_empty(),
+            Self::Wrapped(x) => x.is_empty(),
+        }
+    }
+
+    fn copy_to_slice(&self, buffer: &mut [u8]) {
+        match self {
+            Self::Input(bytes) => buffer.copy_from_slice(bytes),
+            Self::Wrapped(x) => x.copy_to_slice(buffer),
+        }
+    }
+}
+
+impl<'cache, I: IO> IO for CachedIO<'cache, I> {
+    type StorageValue = WrappedInput<I::StorageValue>;
+
+    fn read_input(&self) -> Self::StorageValue {
+        let input = self.inner.read_input().to_vec();
+        self.cache.borrow_mut().set_input(input.clone());
+        WrappedInput::Input(input)
+    }
+
+    fn return_output(&mut self, value: &[u8]) {
+        self.cache.borrow_mut().set_output(value.to_vec());
+        self.inner.return_output(value);
+    }
+
+    fn read_storage(&self, key: &[u8]) -> Option<Self::StorageValue> {
+        self.inner.read_storage(key).map(WrappedInput::Wrapped)
+    }
+
+    fn storage_has_key(&self, key: &[u8]) -> bool {
+        self.inner.storage_has_key(key)
+    }
+
+    fn write_storage(&mut self, key: &[u8], value: &[u8]) -> Option<Self::StorageValue> {
+        self.inner
+            .write_storage(key, value)
+            .map(WrappedInput::Wrapped)
+    }
+
+    fn write_storage_direct(
+        &mut self,
+        key: &[u8],
+        value: Self::StorageValue,
+    ) -> Option<Self::StorageValue> {
+        match value {
+            WrappedInput::Wrapped(x) => self
+                .inner
+                .write_storage_direct(key, x)
+                .map(WrappedInput::Wrapped),
+            WrappedInput::Input(bytes) => self
+                .inner
+                .write_storage(key, &bytes)
+                .map(WrappedInput::Wrapped),
+        }
+    }
+
+    fn remove_storage(&mut self, key: &[u8]) -> Option<Self::StorageValue> {
+        self.inner.remove_storage(key).map(WrappedInput::Wrapped)
+    }
+}

--- a/engine-precompiles/src/promise_result.rs
+++ b/engine-precompiles/src/promise_result.rs
@@ -17,7 +17,7 @@ pub mod costs {
     /// This cost is always charged for calling this precompile.
     pub const PROMISE_RESULT_BASE_COST: EthGas = EthGas::new(111);
     /// This is the cost per byte of promise result data.
-    pub const PROMISE_RESULT_BYTE_COST: EthGas = EthGas::new(1);
+    pub const PROMISE_RESULT_BYTE_COST: EthGas = EthGas::new(2);
 }
 
 pub struct PromiseResult<H> {

--- a/engine-standalone-storage/src/sync/types.rs
+++ b/engine-standalone-storage/src/sync/types.rs
@@ -144,6 +144,7 @@ pub enum TransactionKind {
     AddRelayerKey(parameters::RelayerKeyArgs),
     /// Remove the relayer public function call access key
     RemoveRelayerKey(parameters::RelayerKeyArgs),
+    StartHashchain(parameters::StartHashchainArgs),
     /// Sentinel kind for cases where a NEAR receipt caused a
     /// change in Aurora state, but we failed to parse the Action.
     Unknown,
@@ -372,6 +373,7 @@ impl TransactionKind {
             Self::SetKeyManager(_) => Self::no_evm_execution("set_key_manager"),
             Self::AddRelayerKey(_) => Self::no_evm_execution("add_relayer_key"),
             Self::RemoveRelayerKey(_) => Self::no_evm_execution("remove_relayer_key"),
+            Self::StartHashchain(_) => Self::no_evm_execution("start_hashchain"),
         }
     }
 
@@ -480,6 +482,8 @@ pub enum TransactionKindTag {
     AddRelayerKey,
     #[strum(serialize = "remove_relayer_key")]
     RemoveRelayerKey,
+    #[strum(serialize = "start_hashchain")]
+    StartHashchain,
     Unknown,
 }
 
@@ -527,6 +531,7 @@ impl TransactionKind {
             Self::AddRelayerKey(args) | Self::RemoveRelayerKey(args) => {
                 args.try_to_vec().unwrap_or_default()
             }
+            Self::StartHashchain(args) => args.try_to_vec().unwrap_or_default(),
         }
     }
 }
@@ -569,6 +574,7 @@ impl From<&TransactionKind> for TransactionKindTag {
             TransactionKind::SetKeyManager(_) => Self::SetKeyManager,
             TransactionKind::AddRelayerKey(_) => Self::AddRelayerKey,
             TransactionKind::RemoveRelayerKey(_) => Self::RemoveRelayerKey,
+            TransactionKind::StartHashchain(_) => Self::StartHashchain,
             TransactionKind::Unknown => Self::Unknown,
         }
     }
@@ -748,6 +754,7 @@ enum BorshableTransactionKind<'a> {
     SetKeyManager(Cow<'a, parameters::RelayerKeyManagerArgs>),
     AddRelayerKey(Cow<'a, parameters::RelayerKeyArgs>),
     RemoveRelayerKey(Cow<'a, parameters::RelayerKeyArgs>),
+    StartHashchain(Cow<'a, parameters::StartHashchainArgs>),
 }
 
 impl<'a> From<&'a TransactionKind> for BorshableTransactionKind<'a> {
@@ -799,6 +806,7 @@ impl<'a> From<&'a TransactionKind> for BorshableTransactionKind<'a> {
             TransactionKind::SetKeyManager(x) => Self::SetKeyManager(Cow::Borrowed(x)),
             TransactionKind::AddRelayerKey(x) => Self::AddRelayerKey(Cow::Borrowed(x)),
             TransactionKind::RemoveRelayerKey(x) => Self::RemoveRelayerKey(Cow::Borrowed(x)),
+            TransactionKind::StartHashchain(x) => Self::StartHashchain(Cow::Borrowed(x)),
         }
     }
 }
@@ -871,6 +879,7 @@ impl<'a> TryFrom<BorshableTransactionKind<'a>> for TransactionKind {
             BorshableTransactionKind::RemoveRelayerKey(x) => {
                 Ok(Self::RemoveRelayerKey(x.into_owned()))
             }
+            BorshableTransactionKind::StartHashchain(x) => Ok(Self::StartHashchain(x.into_owned())),
         }
     }
 }

--- a/engine-tests/Cargo.toml
+++ b/engine-tests/Cargo.toml
@@ -12,6 +12,7 @@ autobenches = false
 
 [dev-dependencies]
 aurora-engine = { workspace = true, features = ["std", "tracing", "impl-serde"] }
+aurora-engine-hashchain = { workspace = true, features = ["std"] }
 aurora-engine-modexp = { workspace = true, features = ["std"] }
 aurora-engine-precompiles = { workspace = true, features = ["std"] }
 aurora-engine-sdk = { workspace = true, features = ["std"] }

--- a/engine-tests/src/tests/account_id_precompiles.rs
+++ b/engine-tests/src/tests/account_id_precompiles.rs
@@ -1,14 +1,10 @@
-use crate::utils::{self, standalone};
+use crate::utils;
 use aurora_engine::parameters::SubmitResult;
 
 #[test]
 fn test_account_id_precompiles() {
     let mut signer = utils::Signer::random();
     let mut runner = utils::deploy_runner();
-    let mut standalone = standalone::StandaloneRunner::default();
-
-    standalone.init_evm();
-    runner.standalone_runner = Some(standalone);
 
     let constructor = utils::solidity::ContractConstructor::compile_from_source(
         "src/tests/res",

--- a/engine-tests/src/tests/hashchain.rs
+++ b/engine-tests/src/tests/hashchain.rs
@@ -1,0 +1,111 @@
+use crate::utils;
+use aurora_engine::parameters::{StartHashchainArgs, SubmitResult, TransactionStatus};
+use aurora_engine_hashchain::bloom::Bloom;
+use aurora_engine_transactions::legacy::TransactionLegacy;
+use aurora_engine_types::{
+    borsh::BorshSerialize,
+    types::{Address, Wei},
+    H256, U256,
+};
+
+#[test]
+fn test_hashchain() {
+    let (mut runner, mut signer, _) = crate::tests::sanity::initialize_transfer();
+
+    // The tests initialize the hashchain with the default value.
+    let hc = get_latest_hashchain(&runner);
+    // Hashchain starts 2 heights lower than the current context height because
+    // at `hc.block_height + 1` the `start_hashchain` is submitted and at
+    // `hc.block_height + 2` the signer address is created in the EVM state.
+    assert_eq!(hc.block_height, runner.context.block_height - 2);
+    assert_eq!(hc.hashchain, hex::encode(H256::default()));
+
+    // Execute a transaction and the hashchain changes
+    let transaction = TransactionLegacy {
+        nonce: signer.use_nonce().into(),
+        gas_price: U256::zero(),
+        gas_limit: u64::MAX.into(),
+        to: Some(Address::from_array([1u8; 20])),
+        value: Wei::zero(),
+        data: Vec::new(),
+    };
+    let signed_transaction =
+        utils::sign_transaction(transaction, Some(runner.chain_id), &signer.secret_key);
+    let input = rlp::encode(&signed_transaction).to_vec();
+    let output = SubmitResult::new(TransactionStatus::Succeed(Vec::new()), 21_000, Vec::new())
+        .try_to_vec()
+        .unwrap();
+
+    let expected_hc = {
+        let start_hc_args = StartHashchainArgs {
+            block_height: hc.block_height,
+            block_hashchain: [0u8; 32],
+        };
+        let mut block_height = hc.block_height + 1;
+        let mut hc = aurora_engine_hashchain::hashchain::Hashchain::new(
+            aurora_engine_types::types::u256_to_arr(&runner.chain_id.into()),
+            runner.aurora_account_id.parse().unwrap(),
+            block_height,
+            H256::default().0,
+        );
+        // First transaction is always `start_hashchain`
+        hc.add_block_tx(
+            block_height,
+            "start_hashchain",
+            &start_hc_args.try_to_vec().unwrap(),
+            &[],
+            &Bloom::default(),
+        )
+        .unwrap();
+        // Skip a block height because at block_height + 1 there is no "real" transaction
+        // (that height is skipped when the signer address is directly inserted into the EVM state)
+        block_height += 2;
+        hc.move_to_block(block_height).unwrap();
+        // Insert the `submit` transaction we care about
+        hc.add_block_tx(block_height, "submit", &input, &output, &Bloom::default())
+            .unwrap();
+        hc.move_to_block(block_height + 1).unwrap();
+        hc.get_previous_block_hashchain()
+    };
+
+    runner
+        .evm_submit(&signed_transaction, "relay.aurora")
+        .unwrap();
+    // Need to submit a second transaction to trigger hashchain computation on
+    // the previous block (which contains the previous transaction)
+    runner
+        .submit_with_signer(&mut signer, |nonce| TransactionLegacy {
+            nonce,
+            gas_price: U256::zero(),
+            gas_limit: u64::MAX.into(),
+            to: None,
+            value: Wei::zero(),
+            data: Vec::new(),
+        })
+        .unwrap();
+
+    let hc = get_latest_hashchain(&runner);
+    assert_eq!(hc.block_height, runner.context.block_height - 1);
+    assert_eq!(hc.hashchain, hex::encode(expected_hc));
+}
+
+fn get_latest_hashchain(runner: &utils::AuroraRunner) -> HashchainView {
+    let outcome = runner
+        .one_shot()
+        .call("get_latest_hashchain", "any.near", Vec::new())
+        .unwrap();
+    let return_data = outcome.return_data.as_value().unwrap();
+    let result: HashchainViewResult = serde_json::from_slice(&return_data).unwrap();
+    result.result.unwrap()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+struct HashchainViewResult {
+    result: Option<HashchainView>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+struct HashchainView {
+    block_height: u64,
+    hashchain: String,
+}

--- a/engine-tests/src/tests/mod.rs
+++ b/engine-tests/src/tests/mod.rs
@@ -5,6 +5,7 @@ mod erc20;
 mod erc20_connector;
 mod eth_connector;
 mod ghsa_3p69_m8gg_fwmf;
+mod hashchain;
 #[cfg(feature = "meta-call")]
 mod meta_parsing;
 pub mod modexp;

--- a/engine-tests/src/tests/one_inch.rs
+++ b/engine-tests/src/tests/one_inch.rs
@@ -58,7 +58,7 @@ fn test_1inch_liquidity_protocol() {
         },
     );
     assert!(result.gas_used >= 302_000); // more than 302k EVM gas used
-    assert_gas_bound(profile.all_gas(), 22);
+    assert_gas_bound(profile.all_gas(), 23);
 
     // Same here
     helper.runner.context.block_timestamp += 10_000_000 * 1_000_000_000;
@@ -100,13 +100,13 @@ fn test_1_inch_limit_order_deploy() {
 
     // more than 3.5 million Ethereum gas used
     assert!(result.gas_used > 3_500_000);
-    // less than 10 NEAR Tgas used
-    assert_gas_bound(profile.all_gas(), 8);
+    // less than 9 NEAR Tgas used
+    assert_gas_bound(profile.all_gas(), 9);
     // at least 45% of which is from wasm execution
     let wasm_fraction = 100 * profile.wasm_gas() / profile.all_gas();
     assert!(
-        (50..=60).contains(&wasm_fraction),
-        "{wasm_fraction}% is not between 50% and 60%",
+        (45..=55).contains(&wasm_fraction),
+        "{wasm_fraction}% is not between 45% and 55%",
     );
 }
 

--- a/engine-tests/src/tests/prepaid_gas_precompile.rs
+++ b/engine-tests/src/tests/prepaid_gas_precompile.rs
@@ -1,4 +1,4 @@
-use crate::utils::{self, standalone};
+use crate::utils;
 use aurora_engine_precompiles::prepaid_gas;
 use aurora_engine_transactions::legacy::TransactionLegacy;
 use aurora_engine_types::{types::Wei, U256};
@@ -8,10 +8,10 @@ fn test_prepaid_gas_precompile() {
     const EXPECTED_VALUE: u64 = 157_277_246_352_223;
     let mut signer = utils::Signer::random();
     let mut runner = utils::deploy_runner();
-    let mut standalone = standalone::StandaloneRunner::default();
-
-    standalone.init_evm();
-    runner.standalone_runner = Some(standalone);
+    // The standalone runner gets the wrong answer because the prepaid gas is not
+    // captured in the `TransactionMessage` type.
+    // TODO: capture prepaid gas in `TransacitonMessage`
+    runner.standalone_runner = None;
 
     let transaction = TransactionLegacy {
         nonce: signer.use_nonce().into(),

--- a/engine-tests/src/tests/promise_results_precompile.rs
+++ b/engine-tests/src/tests/promise_results_precompile.rs
@@ -1,4 +1,4 @@
-use crate::utils::{self, standalone};
+use crate::utils;
 use aurora_engine_precompiles::promise_result::{self, costs};
 use aurora_engine_transactions::legacy::TransactionLegacy;
 use aurora_engine_types::borsh::BorshSerialize;
@@ -13,9 +13,6 @@ const NEAR_GAS_PER_EVM: u64 = 175_000_000;
 fn test_promise_results_precompile() {
     let mut signer = utils::Signer::random();
     let mut runner = utils::deploy_runner();
-
-    let mut standalone = standalone::StandaloneRunner::default();
-    standalone.init_evm();
 
     let promise_results = vec![
         PromiseResult::Successful(hex::decode("deadbeef").unwrap()),
@@ -36,12 +33,6 @@ fn test_promise_results_precompile() {
         .submit_transaction(&signer.secret_key, transaction)
         .unwrap();
 
-    let standalone_result = standalone
-        .submit_raw("submit", &runner.context, &promise_results)
-        .unwrap();
-
-    assert_eq!(result, standalone_result);
-
     assert_eq!(
         utils::unwrap_success(result),
         promise_results.try_to_vec().unwrap(),
@@ -51,11 +42,14 @@ fn test_promise_results_precompile() {
 #[test]
 fn test_promise_result_gas_cost() {
     let mut runner = utils::deploy_runner();
-    let mut standalone = standalone::StandaloneRunner::default();
-    standalone.init_evm();
-    runner.standalone_runner = Some(standalone);
     let mut signer = utils::Signer::random();
-    runner.context.block_height = aurora_engine::engine::ZERO_ADDRESS_FIX_HEIGHT + 1;
+    // Skip to later block height and re-init hashchain
+    let account_id = runner.aurora_account_id.clone();
+    utils::init_hashchain(
+        &mut runner,
+        &account_id,
+        Some(aurora_engine::engine::ZERO_ADDRESS_FIX_HEIGHT + 1),
+    );
 
     // Baseline transaction that does essentially nothing.
     let (_, baseline) = runner
@@ -127,13 +121,13 @@ fn test_promise_result_gas_cost() {
     let total_gas1 = y1 + baseline.all_gas();
     let total_gas2 = y2 + baseline.all_gas();
     assert!(
-        utils::within_x_percent(6, evm1, total_gas1 / NEAR_GAS_PER_EVM),
+        utils::within_x_percent(15, evm1, total_gas1 / NEAR_GAS_PER_EVM),
         "Incorrect EVM gas used. Expected: {} Actual: {}",
         evm1,
         total_gas1 / NEAR_GAS_PER_EVM
     );
     assert!(
-        utils::within_x_percent(6, evm2, total_gas2 / NEAR_GAS_PER_EVM),
+        utils::within_x_percent(15, evm2, total_gas2 / NEAR_GAS_PER_EVM),
         "Incorrect EVM gas used. Expected: {} Actual: {}",
         evm2,
         total_gas2 / NEAR_GAS_PER_EVM

--- a/engine-tests/src/tests/repro.rs
+++ b/engine-tests/src/tests/repro.rs
@@ -26,7 +26,7 @@ fn repro_GdASJ3KESs() {
         block_timestamp: 1_645_717_564_644_206_730,
         input_path: "src/tests/res/input_GdASJ3KESs.hex",
         evm_gas_used: 706_713,
-        near_gas_used: 120,
+        near_gas_used: 121,
     });
 }
 

--- a/engine-tests/src/tests/sanity.rs
+++ b/engine-tests/src/tests/sanity.rs
@@ -683,8 +683,8 @@ fn test_num_wasm_functions() {
         .unwrap();
     let num_functions = module.funcs.iter().count();
     assert!(
-        num_functions <= 1440,
-        "{num_functions} is not less than 1440",
+        num_functions <= 1445,
+        "{num_functions} is not less than 1445",
     );
 }
 

--- a/engine-tests/src/tests/uniswap.rs
+++ b/engine-tests/src/tests/uniswap.rs
@@ -38,7 +38,7 @@ fn test_uniswap_input_multihop() {
 
     let (_amount_out, _evm_gas, profile) = context.exact_input(&tokens, INPUT_AMOUNT.into());
 
-    assert_eq!(112, profile.all_gas() / 1_000_000_000_000);
+    assert_eq!(114, profile.all_gas() / 1_000_000_000_000);
 }
 
 #[test]

--- a/engine-tests/src/tests/xcc.rs
+++ b/engine-tests/src/tests/xcc.rs
@@ -27,7 +27,14 @@ fn test_xcc_eth_gas_cost() {
     let _res = runner.call("factory_update", DEFAULT_AURORA_ACCOUNT_ID, xcc_wasm_bytes);
     let mut signer = utils::Signer::random();
     let mut baseline_signer = utils::Signer::random();
-    runner.context.block_height = aurora_engine::engine::ZERO_ADDRESS_FIX_HEIGHT + 1;
+    // Skip to later block height and re-init hashchain
+    let account_id = runner.aurora_account_id.clone();
+    utils::init_hashchain(
+        &mut runner,
+        &account_id,
+        Some(aurora_engine::engine::ZERO_ADDRESS_FIX_HEIGHT + 1),
+    );
+
     // Need to use for engine's deployment!
     let wnear_erc20 = deploy_erc20(&mut runner, &mut signer);
     approve_erc20(

--- a/engine-tests/src/utils/standalone/mod.rs
+++ b/engine-tests/src/utils/standalone/mod.rs
@@ -203,6 +203,9 @@ impl StandaloneRunner {
         env.current_account_id = ctx.current_account_id.as_ref().parse().unwrap();
         env.signer_account_id = ctx.signer_account_id.as_ref().parse().unwrap();
         env.prepaid_gas = NearGas::new(ctx.prepaid_gas);
+        if ctx.random_seed.len() == 32 {
+            env.random_seed = H256::from_slice(&ctx.random_seed);
+        }
 
         let promise_data: Vec<_> = promise_results
             .iter()

--- a/engine-types/src/parameters/engine.rs
+++ b/engine-types/src/parameters/engine.rs
@@ -99,6 +99,13 @@ pub struct SubmitArgs {
     pub gas_token_address: Option<Address>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+#[cfg_attr(feature = "impl-serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct StartHashchainArgs {
+    pub block_height: u64,
+    pub block_hashchain: RawH256,
+}
+
 /// Borsh-encoded parameters for the `begin_chain` function.
 #[cfg(feature = "evm_bully")]
 #[derive(BorshSerialize, BorshDeserialize)]

--- a/engine-types/src/storage.rs
+++ b/engine-types/src/storage.rs
@@ -33,6 +33,7 @@ pub enum KeyPrefix {
     Erc20Nep141Map = 0x9,
     CrossContractCall = 0xa,
     RelayerFunctionCallKey = 0xb,
+    Hashchain = 0xc,
 }
 
 impl From<KeyPrefix> for u8 {
@@ -50,6 +51,7 @@ impl From<KeyPrefix> for u8 {
             KeyPrefix::Erc20Nep141Map => 0x9,
             KeyPrefix::CrossContractCall => 0xa,
             KeyPrefix::RelayerFunctionCallKey => 0xb,
+            KeyPrefix::Hashchain => 0xc,
         }
     }
 }

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -14,6 +14,7 @@ autobenches = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+aurora-engine-hashchain.workspace = true
 aurora-engine-modexp.workspace = true
 aurora-engine-precompiles.workspace = true
 aurora-engine-transactions.workspace = true
@@ -22,6 +23,7 @@ aurora-engine-sdk.workspace = true
 bitflags.workspace = true
 ethabi.workspace = true
 evm.workspace = true
+function_name.workspace = true
 hex.workspace = true
 rlp.workspace = true
 serde.workspace = true
@@ -37,9 +39,9 @@ test-case.workspace = true
 
 [features]
 default = ["std"]
-std = ["aurora-engine-types/std", "aurora-engine-sdk/std", "aurora-engine-precompiles/std", "aurora-engine-transactions/std", "ethabi/std", "evm/std", "hex/std", "rlp/std", "serde/std", "serde_json/std"]
+std = ["aurora-engine-types/std", "aurora-engine-hashchain/std", "aurora-engine-sdk/std", "aurora-engine-precompiles/std", "aurora-engine-transactions/std", "ethabi/std", "evm/std", "hex/std", "rlp/std", "serde/std", "serde_json/std"]
 contract = ["aurora-engine-sdk/contract", "aurora-engine-precompiles/contract"]
-borsh-compat = ["aurora-engine-types/borsh-compat", "aurora-engine-sdk/borsh-compat", "aurora-engine-precompiles/borsh-compat"]
+borsh-compat = ["aurora-engine-types/borsh-compat", "aurora-engine-hashchain/borsh-compat", "aurora-engine-sdk/borsh-compat", "aurora-engine-precompiles/borsh-compat"]
 evm_bully = []
 log = ["aurora-engine-sdk/log", "aurora-engine-precompiles/log"]
 tracing = ["evm/tracing"]

--- a/engine/src/contract_methods/admin.rs
+++ b/engine/src/contract_methods/admin.rs
@@ -9,17 +9,19 @@
 use crate::{
     connector::EthConnectorContract,
     contract_methods::{
-        predecessor_address, require_key_manager_only, require_owner_only, require_running,
-        ContractError,
+        predecessor_address, require_key_manager_only, require_owner_only, require_paused,
+        require_running, ContractError,
     },
     engine::{self, Engine},
     errors,
+    hashchain::with_hashchain,
     pausables::{
         Authorizer, EngineAuthorizer, EnginePrecompilesPauser, PausedPrecompilesChecker,
         PausedPrecompilesManager, PrecompileFlags,
     },
     state,
 };
+use aurora_engine_hashchain::{bloom::Bloom, hashchain::Hashchain};
 use aurora_engine_modexp::AuroraModExp;
 use aurora_engine_sdk::{
     env::Env,
@@ -28,10 +30,11 @@ use aurora_engine_sdk::{
     promise::PromiseHandler,
 };
 use aurora_engine_types::{
+    borsh::BorshDeserialize,
     parameters::{
         engine::{
             NewCallArgs, PausePrecompilesCallArgs, RelayerKeyArgs, RelayerKeyManagerArgs,
-            SetOwnerArgs, SetUpgradeDelayBlocksArgs,
+            SetOwnerArgs, SetUpgradeDelayBlocksArgs, StartHashchainArgs,
         },
         promise::{PromiseAction, PromiseBatchAction},
     },
@@ -39,19 +42,23 @@ use aurora_engine_types::{
     types::{Address, Yocto},
     vec,
 };
+use function_name::named;
 
 const CODE_KEY: &[u8; 4] = b"CODE";
 const CODE_STAGE_KEY: &[u8; 10] = b"CODE_STAGE";
 
-pub fn new<I: IO + Copy>(mut io: I) -> Result<(), ContractError> {
-    if state::get_state(&io).is_ok() {
-        return Err(b"ERR_ALREADY_INITIALIZED".into());
-    }
+#[named]
+pub fn new<I: IO + Copy, E: Env>(io: I, env: &E) -> Result<(), ContractError> {
+    with_hashchain(io, env, function_name!(), |mut io| {
+        if state::get_state(&io).is_ok() {
+            return Err(b"ERR_ALREADY_INITIALIZED".into());
+        }
 
-    let bytes = io.read_input().to_vec();
-    let args = NewCallArgs::deserialize(&bytes).map_err(|_| errors::ERR_BORSH_DESERIALIZE)?;
-    state::set_state(&mut io, &args.into())?;
-    Ok(())
+        let bytes = io.read_input().to_vec();
+        let args = NewCallArgs::deserialize(&bytes).map_err(|_| errors::ERR_BORSH_DESERIALIZE)?;
+        state::set_state(&mut io, &args.into())?;
+        Ok(())
+    })
 }
 
 pub fn get_version<I: IO>(mut io: I) -> Result<(), ContractError> {
@@ -67,21 +74,24 @@ pub fn get_owner<I: IO + Copy>(mut io: I) -> Result<(), ContractError> {
     Ok(())
 }
 
-pub fn set_owner<I: IO + Copy, E: Env>(mut io: I, env: &E) -> Result<(), ContractError> {
-    let mut state = state::get_state(&io)?;
+#[named]
+pub fn set_owner<I: IO + Copy, E: Env>(io: I, env: &E) -> Result<(), ContractError> {
+    with_hashchain(io, env, function_name!(), |mut io| {
+        let mut state = state::get_state(&io)?;
 
-    require_running(&state)?;
-    require_owner_only(&state, &env.predecessor_account_id())?;
+        require_running(&state)?;
+        require_owner_only(&state, &env.predecessor_account_id())?;
 
-    let args: SetOwnerArgs = io.read_input_borsh()?;
-    if state.owner_id == args.new_owner {
-        return Err(errors::ERR_SAME_OWNER.into());
-    }
+        let args: SetOwnerArgs = io.read_input_borsh()?;
+        if state.owner_id == args.new_owner {
+            return Err(errors::ERR_SAME_OWNER.into());
+        }
 
-    state.owner_id = args.new_owner;
-    state::set_state(&mut io, &state)?;
+        state.owner_id = args.new_owner;
+        state::set_state(&mut io, &state)?;
 
-    Ok(())
+        Ok(())
+    })
 }
 
 pub fn get_bridge_prover<I: IO + Copy>(mut io: I) -> Result<(), ContractError> {
@@ -101,17 +111,17 @@ pub fn get_upgrade_delay_blocks<I: IO + Copy>(mut io: I) -> Result<(), ContractE
     Ok(())
 }
 
-pub fn set_upgrade_delay_blocks<I: IO + Copy, E: Env>(
-    mut io: I,
-    env: &E,
-) -> Result<(), ContractError> {
-    let mut state = state::get_state(&io)?;
-    require_running(&state)?;
-    require_owner_only(&state, &env.predecessor_account_id())?;
-    let args: SetUpgradeDelayBlocksArgs = io.read_input_borsh()?;
-    state.upgrade_delay_blocks = args.upgrade_delay_blocks;
-    state::set_state(&mut io, &state)?;
-    Ok(())
+#[named]
+pub fn set_upgrade_delay_blocks<I: IO + Copy, E: Env>(io: I, env: &E) -> Result<(), ContractError> {
+    with_hashchain(io, env, function_name!(), |mut io| {
+        let mut state = state::get_state(&io)?;
+        require_running(&state)?;
+        require_owner_only(&state, &env.predecessor_account_id())?;
+        let args: SetUpgradeDelayBlocksArgs = io.read_input_borsh()?;
+        state.upgrade_delay_blocks = args.upgrade_delay_blocks;
+        state::set_state(&mut io, &state)?;
+        Ok(())
+    })
 }
 
 pub fn get_upgrade_index<I: IO + Copy>(mut io: I) -> Result<(), ContractError> {
@@ -120,46 +130,55 @@ pub fn get_upgrade_index<I: IO + Copy>(mut io: I) -> Result<(), ContractError> {
     Ok(())
 }
 
-pub fn stage_upgrade<I: IO + Copy, E: Env>(mut io: I, env: &E) -> Result<(), ContractError> {
-    let state = state::get_state(&io)?;
-    require_running(&state)?;
-    let delay_block_height = env.block_height() + state.upgrade_delay_blocks;
-    require_owner_only(&state, &env.predecessor_account_id())?;
-    io.read_input_and_store(&storage::bytes_to_key(KeyPrefix::Config, CODE_KEY));
-    io.write_storage(
-        &storage::bytes_to_key(KeyPrefix::Config, CODE_STAGE_KEY),
-        &delay_block_height.to_le_bytes(),
-    );
-    Ok(())
+#[named]
+pub fn stage_upgrade<I: IO + Copy, E: Env>(io: I, env: &E) -> Result<(), ContractError> {
+    with_hashchain(io, env, function_name!(), |mut io| {
+        let state = state::get_state(&io)?;
+        require_running(&state)?;
+        let delay_block_height = env.block_height() + state.upgrade_delay_blocks;
+        require_owner_only(&state, &env.predecessor_account_id())?;
+        io.read_input_and_store(&storage::bytes_to_key(KeyPrefix::Config, CODE_KEY));
+        io.write_storage(
+            &storage::bytes_to_key(KeyPrefix::Config, CODE_STAGE_KEY),
+            &delay_block_height.to_le_bytes(),
+        );
+        Ok(())
+    })
 }
 
+#[named]
 pub fn resume_precompiles<I: IO + Copy, E: Env>(io: I, env: &E) -> Result<(), ContractError> {
-    let state = state::get_state(&io)?;
-    require_running(&state)?;
-    let predecessor_account_id = env.predecessor_account_id();
+    with_hashchain(io, env, function_name!(), |io| {
+        let state = state::get_state(&io)?;
+        require_running(&state)?;
+        let predecessor_account_id = env.predecessor_account_id();
 
-    require_owner_only(&state, &predecessor_account_id)?;
+        require_owner_only(&state, &predecessor_account_id)?;
 
-    let args: PausePrecompilesCallArgs = io.read_input_borsh()?;
-    let flags = PrecompileFlags::from_bits_truncate(args.paused_mask);
-    let mut pauser = EnginePrecompilesPauser::from_io(io);
-    pauser.resume_precompiles(flags);
-    Ok(())
+        let args: PausePrecompilesCallArgs = io.read_input_borsh()?;
+        let flags = PrecompileFlags::from_bits_truncate(args.paused_mask);
+        let mut pauser = EnginePrecompilesPauser::from_io(io);
+        pauser.resume_precompiles(flags);
+        Ok(())
+    })
 }
 
+#[named]
 pub fn pause_precompiles<I: IO + Copy, E: Env>(io: I, env: &E) -> Result<(), ContractError> {
-    require_running(&state::get_state(&io)?)?;
-    let authorizer: EngineAuthorizer = engine::get_authorizer(&io);
+    with_hashchain(io, env, function_name!(), |io| {
+        require_running(&state::get_state(&io)?)?;
+        let authorizer: EngineAuthorizer = engine::get_authorizer(&io);
 
-    if !authorizer.is_authorized(&env.predecessor_account_id()) {
-        return Err(b"ERR_UNAUTHORIZED".into());
-    }
+        if !authorizer.is_authorized(&env.predecessor_account_id()) {
+            return Err(b"ERR_UNAUTHORIZED".into());
+        }
 
-    let args: PausePrecompilesCallArgs = io.read_input_borsh()?;
-    let flags = PrecompileFlags::from_bits_truncate(args.paused_mask);
-    let mut pauser = EnginePrecompilesPauser::from_io(io);
-    pauser.pause_precompiles(flags);
-    Ok(())
+        let args: PausePrecompilesCallArgs = io.read_input_borsh()?;
+        let flags = PrecompileFlags::from_bits_truncate(args.paused_mask);
+        let mut pauser = EnginePrecompilesPauser::from_io(io);
+        pauser.pause_precompiles(flags);
+        Ok(())
+    })
 }
 
 pub fn paused_precompiles<I: IO + Copy>(mut io: I) -> Result<(), ContractError> {
@@ -169,140 +188,193 @@ pub fn paused_precompiles<I: IO + Copy>(mut io: I) -> Result<(), ContractError> 
     Ok(())
 }
 
-pub fn pause_contract<I: IO + Copy, E: Env>(mut io: I, env: &E) -> Result<(), ContractError> {
-    let mut state = state::get_state(&io)?;
-    require_owner_only(&state, &env.predecessor_account_id())?;
-    if state.is_paused {
-        return Err(errors::ERR_PAUSED.into());
-    }
-    state.is_paused = true;
-    state::set_state(&mut io, &state)?;
-    Ok(())
+#[named]
+pub fn pause_contract<I: IO + Copy, E: Env>(io: I, env: &E) -> Result<(), ContractError> {
+    with_hashchain(io, env, function_name!(), |mut io| {
+        let mut state = state::get_state(&io)?;
+        require_owner_only(&state, &env.predecessor_account_id())?;
+        require_running(&state)?;
+        state.is_paused = true;
+        state::set_state(&mut io, &state)?;
+        Ok(())
+    })
 }
 
-pub fn resume_contract<I: IO + Copy, E: Env>(mut io: I, env: &E) -> Result<(), ContractError> {
+#[named]
+pub fn resume_contract<I: IO + Copy, E: Env>(io: I, env: &E) -> Result<(), ContractError> {
+    with_hashchain(io, env, function_name!(), |mut io| {
+        let mut state = state::get_state(&io)?;
+        require_owner_only(&state, &env.predecessor_account_id())?;
+        require_paused(&state)?;
+        state.is_paused = false;
+        state::set_state(&mut io, &state)?;
+        Ok(())
+    })
+}
+
+#[named]
+pub fn set_key_manager<I: IO + Copy, E: Env>(io: I, env: &E) -> Result<(), ContractError> {
+    with_hashchain(io, env, function_name!(), |mut io| {
+        let mut state = state::get_state(&io)?;
+
+        require_running(&state)?;
+        require_owner_only(&state, &env.predecessor_account_id())?;
+
+        let key_manager =
+            serde_json::from_slice::<RelayerKeyManagerArgs>(&io.read_input().to_vec())
+                .map(|args| args.key_manager)
+                .map_err(|_| errors::ERR_JSON_DESERIALIZE)?;
+
+        if state.key_manager == key_manager {
+            return Err(errors::ERR_SAME_KEY_MANAGER.into());
+        }
+
+        state.key_manager = key_manager;
+        state::set_state(&mut io, &state)?;
+
+        Ok(())
+    })
+}
+
+#[named]
+pub fn add_relayer_key<I: IO + Copy, E: Env, H: PromiseHandler>(
+    io: I,
+    env: &E,
+    handler: &mut H,
+) -> Result<(), ContractError> {
+    with_hashchain(io, env, function_name!(), |mut io| {
+        let state = state::get_state(&io)?;
+
+        require_running(&state)?;
+        require_key_manager_only(&state, &env.predecessor_account_id())?;
+
+        let public_key = serde_json::from_slice::<RelayerKeyArgs>(&io.read_input().to_vec())
+            .map(|args| args.public_key)
+            .map_err(|_| errors::ERR_JSON_DESERIALIZE)?;
+        let allowance = Yocto::new(env.attached_deposit());
+        aurora_engine_sdk::log!("attached key allowance: {allowance}");
+
+        if allowance.as_u128() < 100 {
+            // TODO: Clarify the minimum amount if check is needed then change error type
+            return Err(errors::ERR_NOT_ALLOWED.into());
+        }
+
+        engine::add_function_call_key(&mut io, &public_key);
+
+        let current_account_id = env.current_account_id();
+        let action = PromiseAction::AddFunctionCallKey {
+            public_key,
+            allowance,
+            nonce: 0, // not actually used - depends on block height
+            receiver_id: current_account_id.clone(),
+            function_names: "call,submit,submit_with_args".into(),
+        };
+        let promise = PromiseBatchAction {
+            target_account_id: current_account_id,
+            actions: vec![action],
+        };
+
+        let promise_id = unsafe { handler.promise_create_batch(&promise) };
+        handler.promise_return(promise_id);
+
+        Ok(())
+    })
+}
+
+#[named]
+pub fn remove_relayer_key<I: IO + Copy, E: Env, H: PromiseHandler>(
+    io: I,
+    env: &E,
+    handler: &mut H,
+) -> Result<(), ContractError> {
+    with_hashchain(io, env, function_name!(), |mut io| {
+        let state = state::get_state(&io)?;
+
+        require_running(&state)?;
+        require_key_manager_only(&state, &env.predecessor_account_id())?;
+
+        let args: RelayerKeyArgs = serde_json::from_slice(&io.read_input().to_vec())
+            .map_err(|_| errors::ERR_JSON_DESERIALIZE)?;
+
+        engine::remove_function_call_key(&mut io, &args.public_key)?;
+
+        let action = PromiseAction::DeleteKey {
+            public_key: args.public_key,
+        };
+        let promise = PromiseBatchAction {
+            target_account_id: env.current_account_id(),
+            actions: vec![action],
+        };
+
+        let promise_id = unsafe { handler.promise_create_batch(&promise) };
+        handler.promise_return(promise_id);
+
+        Ok(())
+    })
+}
+
+#[named]
+pub fn register_relayer<I: IO + Copy, E: Env>(io: I, env: &E) -> Result<(), ContractError> {
+    with_hashchain(io, env, function_name!(), |io| {
+        let state = state::get_state(&io)?;
+        require_running(&state)?;
+        let relayer_address = io.read_input_arr20()?;
+
+        let current_account_id = env.current_account_id();
+        let predecessor_account_id = env.predecessor_account_id();
+        let mut engine: Engine<_, E, AuroraModExp> = Engine::new_with_state(
+            state,
+            predecessor_address(&predecessor_account_id),
+            current_account_id,
+            io,
+            env,
+        );
+        engine.register_relayer(
+            predecessor_account_id.as_bytes(),
+            Address::from_array(relayer_address),
+        );
+        Ok(())
+    })
+}
+
+#[named]
+pub fn start_hashchain<I: IO + Copy, E: Env>(mut io: I, env: &E) -> Result<(), ContractError> {
     let mut state = state::get_state(&io)?;
-    require_owner_only(&state, &env.predecessor_account_id())?;
-    if !state.is_paused {
-        return Err(errors::ERR_RUNNING.into());
+    require_paused(&state)?;
+    require_key_manager_only(&state, &env.predecessor_account_id())?;
+
+    let input = io.read_input().to_vec();
+    let args = StartHashchainArgs::try_from_slice(&input).map_err(|_| errors::ERR_SERIALIZE)?;
+    let block_height = env.block_height();
+
+    // Starting hashchain must be for an earlier block
+    if block_height < args.block_height {
+        return Err(errors::ERR_ARGS.into());
     }
+
+    let mut hashchain = Hashchain::new(
+        state.chain_id,
+        env.current_account_id(),
+        args.block_height + 1,
+        args.block_hashchain,
+    );
+
+    if hashchain.get_current_block_height() < block_height {
+        hashchain.move_to_block(block_height)?;
+    }
+
+    hashchain.add_block_tx(
+        block_height,
+        function_name!(),
+        &input,
+        &[],
+        &Bloom::default(),
+    )?;
+    crate::hashchain::save_hashchain(&mut io, &hashchain)?;
+
     state.is_paused = false;
     state::set_state(&mut io, &state)?;
-    Ok(())
-}
 
-pub fn set_key_manager<I: IO + Copy, E: Env>(mut io: I, env: &E) -> Result<(), ContractError> {
-    let mut state = state::get_state(&io)?;
-
-    require_running(&state)?;
-    require_owner_only(&state, &env.predecessor_account_id())?;
-
-    let key_manager = serde_json::from_slice::<RelayerKeyManagerArgs>(&io.read_input().to_vec())
-        .map(|args| args.key_manager)
-        .map_err(|_| errors::ERR_JSON_DESERIALIZE)?;
-
-    if state.key_manager == key_manager {
-        return Err(errors::ERR_SAME_KEY_MANAGER.into());
-    }
-
-    state.key_manager = key_manager;
-    state::set_state(&mut io, &state)?;
-
-    Ok(())
-}
-
-pub fn add_relayer_key<I: IO + Copy, E: Env, H: PromiseHandler>(
-    mut io: I,
-    env: &E,
-    handler: &mut H,
-) -> Result<(), ContractError> {
-    let state = state::get_state(&io)?;
-
-    require_running(&state)?;
-    require_key_manager_only(&state, &env.predecessor_account_id())?;
-
-    let public_key = serde_json::from_slice::<RelayerKeyArgs>(&io.read_input().to_vec())
-        .map(|args| args.public_key)
-        .map_err(|_| errors::ERR_JSON_DESERIALIZE)?;
-    let allowance = Yocto::new(env.attached_deposit());
-    aurora_engine_sdk::log!("attached key allowance: {allowance}");
-
-    if allowance.as_u128() < 100 {
-        // TODO: Clarify the minimum amount if check is needed then change error type
-        return Err(errors::ERR_NOT_ALLOWED.into());
-    }
-
-    engine::add_function_call_key(&mut io, &public_key);
-
-    let current_account_id = env.current_account_id();
-    let action = PromiseAction::AddFunctionCallKey {
-        public_key,
-        allowance,
-        nonce: 0, // not actually used - depends on block height
-        receiver_id: current_account_id.clone(),
-        function_names: "call,submit,submit_with_args".into(),
-    };
-    let promise = PromiseBatchAction {
-        target_account_id: current_account_id,
-        actions: vec![action],
-    };
-
-    let promise_id = unsafe { handler.promise_create_batch(&promise) };
-    handler.promise_return(promise_id);
-
-    Ok(())
-}
-
-pub fn remove_relayer_key<I: IO + Copy, E: Env, H: PromiseHandler>(
-    mut io: I,
-    env: &E,
-    handler: &mut H,
-) -> Result<(), ContractError> {
-    let state = state::get_state(&io)?;
-
-    require_running(&state)?;
-    require_key_manager_only(&state, &env.predecessor_account_id())?;
-
-    let args: RelayerKeyArgs = serde_json::from_slice(&io.read_input().to_vec())
-        .map_err(|_| errors::ERR_JSON_DESERIALIZE)?;
-
-    engine::remove_function_call_key(&mut io, &args.public_key)?;
-
-    let action = PromiseAction::DeleteKey {
-        public_key: args.public_key,
-    };
-    let promise = PromiseBatchAction {
-        target_account_id: env.current_account_id(),
-        actions: vec![action],
-    };
-
-    let promise_id = unsafe { handler.promise_create_batch(&promise) };
-    handler.promise_return(promise_id);
-
-    Ok(())
-}
-
-pub fn register_relayer<'env, I: IO + Copy, E: Env>(
-    io: I,
-    env: &'env E,
-) -> Result<(), ContractError> {
-    let state = state::get_state(&io)?;
-    require_running(&state)?;
-    let relayer_address = io.read_input_arr20()?;
-
-    let current_account_id = env.current_account_id();
-    let predecessor_account_id = env.predecessor_account_id();
-    let mut engine: Engine<'env, I, E, AuroraModExp> = Engine::new_with_state(
-        state,
-        predecessor_address(&predecessor_account_id),
-        current_account_id,
-        io,
-        env,
-    );
-    engine.register_relayer(
-        predecessor_account_id.as_bytes(),
-        Address::from_array(relayer_address),
-    );
     Ok(())
 }
 

--- a/engine/src/contract_methods/connector.rs
+++ b/engine/src/contract_methods/connector.rs
@@ -2,7 +2,9 @@ use crate::{
     connector::{self, EthConnectorContract},
     contract_methods::{predecessor_address, require_owner_only, require_running, ContractError},
     engine::{self, Engine},
-    errors, state,
+    errors,
+    hashchain::with_hashchain,
+    state,
 };
 use aurora_engine_modexp::AuroraModExp;
 use aurora_engine_sdk::{
@@ -27,326 +29,378 @@ use aurora_engine_types::{
     types::{Address, PromiseResult, Yocto},
     Vec,
 };
+use function_name::named;
 
-pub fn ft_on_transfer<'env, I: IO + Copy, E: Env, H: PromiseHandler>(
+#[named]
+pub fn ft_on_transfer<I: IO + Copy, E: Env, H: PromiseHandler>(
     io: I,
-    env: &'env E,
+    env: &E,
     handler: &mut H,
 ) -> Result<(), ContractError> {
-    let state = state::get_state(&io)?;
-    require_running(&state)?;
-    let current_account_id = env.current_account_id();
-    let predecessor_account_id = env.predecessor_account_id();
-    let mut engine: Engine<'env, I, E, AuroraModExp> = Engine::new_with_state(
-        state,
-        predecessor_address(&predecessor_account_id),
-        current_account_id.clone(),
-        io,
-        env,
-    );
+    with_hashchain(io, env, function_name!(), |io| {
+        let state = state::get_state(&io)?;
+        require_running(&state)?;
+        let current_account_id = env.current_account_id();
+        let predecessor_account_id = env.predecessor_account_id();
+        let mut engine: Engine<_, E, AuroraModExp> = Engine::new_with_state(
+            state,
+            predecessor_address(&predecessor_account_id),
+            current_account_id.clone(),
+            io,
+            env,
+        );
 
-    let args: NEP141FtOnTransferArgs = serde_json::from_slice(&io.read_input().to_vec())
-        .map_err(Into::<ParseTypeFromJsonError>::into)?;
+        let args: NEP141FtOnTransferArgs = serde_json::from_slice(&io.read_input().to_vec())
+            .map_err(Into::<ParseTypeFromJsonError>::into)?;
 
-    if predecessor_account_id == current_account_id {
-        EthConnectorContract::init_instance(io)?.ft_on_transfer(&engine, &args)?;
-    } else {
-        engine.receive_erc20_tokens(&predecessor_account_id, &args, &current_account_id, handler);
-    }
-    Ok(())
+        if predecessor_account_id == current_account_id {
+            EthConnectorContract::init_instance(io)?.ft_on_transfer(&engine, &args)?;
+        } else {
+            engine.receive_erc20_tokens(
+                &predecessor_account_id,
+                &args,
+                &current_account_id,
+                handler,
+            );
+        }
+        Ok(())
+    })
 }
 
+#[named]
 pub fn deploy_erc20_token<I: IO + Copy, E: Env, H: PromiseHandler>(
-    mut io: I,
+    io: I,
     env: &E,
     handler: &mut H,
 ) -> Result<Address, ContractError> {
-    require_running(&state::get_state(&io)?)?;
-    // Id of the NEP141 token in Near
-    let args: DeployErc20TokenArgs = io.read_input_borsh()?;
+    with_hashchain(io, env, function_name!(), |mut io| {
+        require_running(&state::get_state(&io)?)?;
+        // Id of the NEP141 token in Near
+        let args: DeployErc20TokenArgs = io.read_input_borsh()?;
 
-    let address = engine::deploy_erc20_token(args, io, env, handler)?;
+        let address = engine::deploy_erc20_token(args, io, env, handler)?;
 
-    io.return_output(
-        &address
-            .as_bytes()
-            .try_to_vec()
-            .map_err(|_| errors::ERR_SERIALIZE)?,
-    );
-    Ok(address)
+        io.return_output(
+            &address
+                .as_bytes()
+                .try_to_vec()
+                .map_err(|_| errors::ERR_SERIALIZE)?,
+        );
+        Ok(address)
+    })
 }
 
+#[named]
 pub fn refund_on_error<I: IO + Copy, E: Env, H: PromiseHandler>(
     io: I,
     env: &E,
     handler: &mut H,
 ) -> Result<Option<SubmitResult>, ContractError> {
-    let state = state::get_state(&io)?;
-    require_running(&state)?;
-    env.assert_private_call()?;
+    with_hashchain(io, env, function_name!(), |io| {
+        let state = state::get_state(&io)?;
+        require_running(&state)?;
+        env.assert_private_call()?;
 
-    // This function should only be called as the callback of
-    // exactly one promise.
-    if handler.promise_results_count() != 1 {
-        return Err(errors::ERR_PROMISE_COUNT.into());
-    }
-
-    let maybe_result = if let Some(PromiseResult::Successful(_)) = handler.promise_result(0) {
-        // Promise succeeded -- nothing to do
-        None
-    } else {
-        // Exit call failed; need to refund tokens
-        let args: RefundCallArgs = io.read_input_borsh()?;
-        let refund_result = engine::refund_on_error(io, env, state, &args, handler)?;
-
-        if !refund_result.status.is_ok() {
-            return Err(errors::ERR_REFUND_FAILURE.into());
+        // This function should only be called as the callback of
+        // exactly one promise.
+        if handler.promise_results_count() != 1 {
+            return Err(errors::ERR_PROMISE_COUNT.into());
         }
-        Some(refund_result)
-    };
-    Ok(maybe_result)
+
+        let maybe_result = if let Some(PromiseResult::Successful(_)) = handler.promise_result(0) {
+            // Promise succeeded -- nothing to do
+            None
+        } else {
+            // Exit call failed; need to refund tokens
+            let args: RefundCallArgs = io.read_input_borsh()?;
+            let refund_result = engine::refund_on_error(io, env, state, &args, handler)?;
+
+            if !refund_result.status.is_ok() {
+                return Err(errors::ERR_REFUND_FAILURE.into());
+            }
+            Some(refund_result)
+        };
+        Ok(maybe_result)
+    })
 }
 
+#[named]
 pub fn new_eth_connector<I: IO + Copy, E: Env>(io: I, env: &E) -> Result<(), ContractError> {
-    let state = state::get_state(&io)?;
-    require_running(&state)?;
-    // Only the owner can initialize the EthConnector
-    let is_private = env.assert_private_call();
-    if is_private.is_err() {
-        require_owner_only(&state, &env.predecessor_account_id())?;
-    }
+    with_hashchain(io, env, function_name!(), |io| {
+        let state = state::get_state(&io)?;
+        require_running(&state)?;
+        // Only the owner can initialize the EthConnector
+        let is_private = env.assert_private_call();
+        if is_private.is_err() {
+            require_owner_only(&state, &env.predecessor_account_id())?;
+        }
 
-    let args: InitCallArgs = io.read_input_borsh()?;
-    let owner_id = env.current_account_id();
+        let args: InitCallArgs = io.read_input_borsh()?;
+        let owner_id = env.current_account_id();
 
-    EthConnectorContract::create_contract(io, &owner_id, args)?;
-    Ok(())
+        EthConnectorContract::create_contract(io, &owner_id, args)?;
+        Ok(())
+    })
 }
 
+#[named]
 pub fn set_eth_connector_contract_data<I: IO + Copy, E: Env>(
-    mut io: I,
+    io: I,
     env: &E,
 ) -> Result<(), ContractError> {
-    let state = state::get_state(&io)?;
-    require_running(&state)?;
-    // Only the owner can set the EthConnector contract data
-    let is_private = env.assert_private_call();
-    if is_private.is_err() {
-        require_owner_only(&state, &env.predecessor_account_id())?;
-    }
+    with_hashchain(io, env, function_name!(), |mut io| {
+        let state = state::get_state(&io)?;
+        require_running(&state)?;
+        // Only the owner can set the EthConnector contract data
+        let is_private = env.assert_private_call();
+        if is_private.is_err() {
+            require_owner_only(&state, &env.predecessor_account_id())?;
+        }
 
-    let args: SetContractDataCallArgs = io.read_input_borsh()?;
-    connector::set_contract_data(&mut io, args)?;
-    Ok(())
+        let args: SetContractDataCallArgs = io.read_input_borsh()?;
+        connector::set_contract_data(&mut io, args)?;
+        Ok(())
+    })
 }
 
+#[named]
 pub fn withdraw<I: IO + Copy, E: Env>(io: I, env: &E) -> Result<Vec<u8>, ContractError> {
-    require_running(&state::get_state(&io)?)?;
-    env.assert_one_yocto()?;
-    let args = io.read_input_borsh()?;
-    let current_account_id = env.current_account_id();
-    let predecessor_account_id = env.predecessor_account_id();
-    let result = EthConnectorContract::init_instance(io)?.withdraw_eth_from_near(
-        &current_account_id,
-        &predecessor_account_id,
-        &args,
-    )?;
-    let result_bytes = result.try_to_vec().map_err(|_| errors::ERR_SERIALIZE)?;
+    with_hashchain(io, env, function_name!(), |io| {
+        require_running(&state::get_state(&io)?)?;
+        env.assert_one_yocto()?;
+        let args = io.read_input_borsh()?;
+        let current_account_id = env.current_account_id();
+        let predecessor_account_id = env.predecessor_account_id();
+        let result = EthConnectorContract::init_instance(io)?.withdraw_eth_from_near(
+            &current_account_id,
+            &predecessor_account_id,
+            &args,
+        )?;
+        let result_bytes = result.try_to_vec().map_err(|_| errors::ERR_SERIALIZE)?;
 
-    // We only return the output via IO in the case of standalone.
-    // In the case of contract we intentionally avoid IO to call Wasm directly.
-    #[cfg(not(feature = "contract"))]
-    {
-        let mut io = io;
-        io.return_output(&result_bytes);
-    }
+        // We only return the output via IO in the case of standalone.
+        // In the case of contract we intentionally avoid IO to call Wasm directly.
+        #[cfg(not(feature = "contract"))]
+        {
+            let mut io = io;
+            io.return_output(&result_bytes);
+        }
 
-    Ok(result_bytes)
+        Ok(result_bytes)
+    })
 }
 
+#[named]
 pub fn deposit<I: IO + Copy, E: Env, H: PromiseHandler>(
     io: I,
     env: &E,
     handler: &mut H,
 ) -> Result<PromiseWithCallbackArgs, ContractError> {
-    require_running(&state::get_state(&io)?)?;
-    let raw_proof = io.read_input().to_vec();
-    let current_account_id = env.current_account_id();
-    let predecessor_account_id = env.predecessor_account_id();
-    let promise_args = EthConnectorContract::init_instance(io)?.deposit(
-        raw_proof,
-        current_account_id,
-        predecessor_account_id,
-    )?;
-    // Safety: this call is safe because it comes from the eth-connector, not users.
-    // The call is to verify the user-supplied proof for the deposit, with `finish_deposit`
-    // as a callback.
-    let promise_id = unsafe { handler.promise_create_with_callback(&promise_args) };
-    handler.promise_return(promise_id);
-    Ok(promise_args)
+    with_hashchain(io, env, function_name!(), |io| {
+        require_running(&state::get_state(&io)?)?;
+        let raw_proof = io.read_input().to_vec();
+        let current_account_id = env.current_account_id();
+        let predecessor_account_id = env.predecessor_account_id();
+        let promise_args = EthConnectorContract::init_instance(io)?.deposit(
+            raw_proof,
+            current_account_id,
+            predecessor_account_id,
+        )?;
+        // Safety: this call is safe because it comes from the eth-connector, not users.
+        // The call is to verify the user-supplied proof for the deposit, with `finish_deposit`
+        // as a callback.
+        let promise_id = unsafe { handler.promise_create_with_callback(&promise_args) };
+        handler.promise_return(promise_id);
+        Ok(promise_args)
+    })
 }
 
+#[named]
 pub fn finish_deposit<I: IO + Copy, E: Env, H: PromiseHandler>(
     io: I,
     env: &E,
     handler: &mut H,
 ) -> Result<Option<PromiseWithCallbackArgs>, ContractError> {
-    require_running(&state::get_state(&io)?)?;
-    env.assert_private_call()?;
+    with_hashchain(io, env, function_name!(), |io| {
+        require_running(&state::get_state(&io)?)?;
+        env.assert_private_call()?;
 
-    // Check result from proof verification call
-    if handler.promise_results_count() != 1 {
-        return Err(errors::ERR_PROMISE_COUNT.into());
-    }
-    let promise_result = match handler.promise_result(0) {
-        Some(PromiseResult::Successful(bytes)) => {
-            bool::try_from_slice(&bytes).map_err(|_| errors::ERR_PROMISE_ENCODING)?
+        // Check result from proof verification call
+        if handler.promise_results_count() != 1 {
+            return Err(errors::ERR_PROMISE_COUNT.into());
         }
-        _ => return Err(errors::ERR_PROMISE_FAILED.into()),
-    };
-    if !promise_result {
-        return Err(errors::ERR_VERIFY_PROOF.into());
-    }
+        let promise_result = match handler.promise_result(0) {
+            Some(PromiseResult::Successful(bytes)) => {
+                bool::try_from_slice(&bytes).map_err(|_| errors::ERR_PROMISE_ENCODING)?
+            }
+            _ => return Err(errors::ERR_PROMISE_FAILED.into()),
+        };
+        if !promise_result {
+            return Err(errors::ERR_VERIFY_PROOF.into());
+        }
 
-    let data = io.read_input_borsh()?;
-    let current_account_id = env.current_account_id();
-    let predecessor_account_id = env.predecessor_account_id();
-    let maybe_promise_args = EthConnectorContract::init_instance(io)?.finish_deposit(
-        predecessor_account_id,
-        current_account_id,
-        data,
-        env.prepaid_gas(),
-    )?;
+        let data = io.read_input_borsh()?;
+        let current_account_id = env.current_account_id();
+        let predecessor_account_id = env.predecessor_account_id();
+        let maybe_promise_args = EthConnectorContract::init_instance(io)?.finish_deposit(
+            predecessor_account_id,
+            current_account_id,
+            data,
+            env.prepaid_gas(),
+        )?;
 
-    if let Some(promise_args) = maybe_promise_args.as_ref() {
-        // Safety: this call is safe because it comes from the eth-connector, not users.
-        // The call will be to the Engine's ft_transfer_call`, which is needed as part
-        // of the bridge flow (if depositing ETH to an Aurora address).
-        let promise_id = unsafe { handler.promise_create_with_callback(promise_args) };
-        handler.promise_return(promise_id);
-    }
+        if let Some(promise_args) = maybe_promise_args.as_ref() {
+            // Safety: this call is safe because it comes from the eth-connector, not users.
+            // The call will be to the Engine's ft_transfer_call`, which is needed as part
+            // of the bridge flow (if depositing ETH to an Aurora address).
+            let promise_id = unsafe { handler.promise_create_with_callback(promise_args) };
+            handler.promise_return(promise_id);
+        }
 
-    Ok(maybe_promise_args)
+        Ok(maybe_promise_args)
+    })
 }
 
+#[named]
 pub fn ft_transfer<I: IO + Copy, E: Env>(io: I, env: &E) -> Result<(), ContractError> {
-    require_running(&state::get_state(&io)?)?;
-    env.assert_one_yocto()?;
-    let predecessor_account_id = env.predecessor_account_id();
-    let args: TransferCallArgs = serde_json::from_slice(&io.read_input().to_vec())
-        .map_err(Into::<ParseTypeFromJsonError>::into)?;
-    EthConnectorContract::init_instance(io)?.ft_transfer(&predecessor_account_id, &args)?;
-    Ok(())
+    with_hashchain(io, env, function_name!(), |io| {
+        require_running(&state::get_state(&io)?)?;
+        env.assert_one_yocto()?;
+        let predecessor_account_id = env.predecessor_account_id();
+        let args: TransferCallArgs = serde_json::from_slice(&io.read_input().to_vec())
+            .map_err(Into::<ParseTypeFromJsonError>::into)?;
+        EthConnectorContract::init_instance(io)?.ft_transfer(&predecessor_account_id, &args)?;
+        Ok(())
+    })
 }
 
+#[named]
 pub fn ft_resolve_transfer<I: IO + Copy, E: Env, H: PromiseHandler>(
     io: I,
     env: &E,
     handler: &H,
 ) -> Result<(), ContractError> {
-    require_running(&state::get_state(&io)?)?;
+    with_hashchain(io, env, function_name!(), |io| {
+        require_running(&state::get_state(&io)?)?;
 
-    env.assert_private_call()?;
-    if handler.promise_results_count() != 1 {
-        return Err(errors::ERR_PROMISE_COUNT.into());
-    }
+        env.assert_private_call()?;
+        if handler.promise_results_count() != 1 {
+            return Err(errors::ERR_PROMISE_COUNT.into());
+        }
 
-    let args: ResolveTransferCallArgs = io.read_input().to_value()?;
-    let promise_result = handler
-        .promise_result(0)
-        .ok_or(errors::ERR_PROMISE_ENCODING)?;
+        let args: ResolveTransferCallArgs = io.read_input().to_value()?;
+        let promise_result = handler
+            .promise_result(0)
+            .ok_or(errors::ERR_PROMISE_ENCODING)?;
 
-    EthConnectorContract::init_instance(io)?.ft_resolve_transfer(&args, promise_result);
-    Ok(())
+        EthConnectorContract::init_instance(io)?.ft_resolve_transfer(&args, promise_result);
+        Ok(())
+    })
 }
 
+#[named]
 pub fn ft_transfer_call<I: IO + Copy, E: Env, H: PromiseHandler>(
     io: I,
     env: &E,
     handler: &mut H,
 ) -> Result<PromiseWithCallbackArgs, ContractError> {
-    require_running(&state::get_state(&io)?)?;
-    // Check is payable
-    env.assert_one_yocto()?;
+    with_hashchain(io, env, function_name!(), |io| {
+        require_running(&state::get_state(&io)?)?;
+        // Check is payable
+        env.assert_one_yocto()?;
 
-    let args: TransferCallCallArgs = serde_json::from_slice(&io.read_input().to_vec())
-        .map_err(Into::<ParseTypeFromJsonError>::into)?;
-    let current_account_id = env.current_account_id();
-    let predecessor_account_id = env.predecessor_account_id();
-    let promise_args = EthConnectorContract::init_instance(io)?.ft_transfer_call(
-        predecessor_account_id,
-        current_account_id,
-        args,
-        env.prepaid_gas(),
-    )?;
-    // Safety: this call is safe. It is required by the NEP-141 spec that `ft_transfer_call`
-    // creates a call to another contract's `ft_on_transfer` method.
-    let promise_id = unsafe { handler.promise_create_with_callback(&promise_args) };
-    handler.promise_return(promise_id);
-    Ok(promise_args)
+        let args: TransferCallCallArgs = serde_json::from_slice(&io.read_input().to_vec())
+            .map_err(Into::<ParseTypeFromJsonError>::into)?;
+        let current_account_id = env.current_account_id();
+        let predecessor_account_id = env.predecessor_account_id();
+        let promise_args = EthConnectorContract::init_instance(io)?.ft_transfer_call(
+            predecessor_account_id,
+            current_account_id,
+            args,
+            env.prepaid_gas(),
+        )?;
+        // Safety: this call is safe. It is required by the NEP-141 spec that `ft_transfer_call`
+        // creates a call to another contract's `ft_on_transfer` method.
+        let promise_id = unsafe { handler.promise_create_with_callback(&promise_args) };
+        handler.promise_return(promise_id);
+        Ok(promise_args)
+    })
 }
 
+#[named]
 pub fn storage_deposit<I: IO + Copy, E: Env, H: PromiseHandler>(
     io: I,
     env: &E,
     handler: &mut H,
 ) -> Result<(), ContractError> {
-    require_running(&state::get_state(&io)?)?;
-    let args: StorageDepositCallArgs = serde_json::from_slice(&io.read_input().to_vec())
-        .map_err(Into::<ParseTypeFromJsonError>::into)?;
-    let predecessor_account_id = env.predecessor_account_id();
-    let amount = Yocto::new(env.attached_deposit());
-    let maybe_promise = EthConnectorContract::init_instance(io)?.storage_deposit(
-        predecessor_account_id,
-        amount,
-        args,
-    )?;
-    if let Some(promise) = maybe_promise {
-        // Safety: This call is safe. It is only a transfer back to the user in the case
-        // that they over paid for their deposit.
-        unsafe { handler.promise_create_batch(&promise) };
-    }
-    Ok(())
+    with_hashchain(io, env, function_name!(), |io| {
+        require_running(&state::get_state(&io)?)?;
+        let args: StorageDepositCallArgs = serde_json::from_slice(&io.read_input().to_vec())
+            .map_err(Into::<ParseTypeFromJsonError>::into)?;
+        let predecessor_account_id = env.predecessor_account_id();
+        let amount = Yocto::new(env.attached_deposit());
+        let maybe_promise = EthConnectorContract::init_instance(io)?.storage_deposit(
+            predecessor_account_id,
+            amount,
+            args,
+        )?;
+        if let Some(promise) = maybe_promise {
+            // Safety: This call is safe. It is only a transfer back to the user in the case
+            // that they over paid for their deposit.
+            unsafe { handler.promise_create_batch(&promise) };
+        }
+        Ok(())
+    })
 }
 
+#[named]
 pub fn storage_unregister<I: IO + Copy, E: Env, H: PromiseHandler>(
     io: I,
     env: &E,
     handler: &mut H,
 ) -> Result<(), ContractError> {
-    require_running(&state::get_state(&io)?)?;
-    env.assert_one_yocto()?;
-    let predecessor_account_id = env.predecessor_account_id();
-    let force = serde_json::from_slice::<serde_json::Value>(&io.read_input().to_vec())
-        .ok()
-        .and_then(|args| args["force"].as_bool());
-    let maybe_promise = EthConnectorContract::init_instance(io)?
-        .storage_unregister(predecessor_account_id, force)?;
-    if let Some(promise) = maybe_promise {
-        // Safety: This call is safe. It is only a transfer back to the user for their deposit.
-        unsafe { handler.promise_create_batch(&promise) };
-    }
-    Ok(())
+    with_hashchain(io, env, function_name!(), |io| {
+        require_running(&state::get_state(&io)?)?;
+        env.assert_one_yocto()?;
+        let predecessor_account_id = env.predecessor_account_id();
+        let force = serde_json::from_slice::<serde_json::Value>(&io.read_input().to_vec())
+            .ok()
+            .and_then(|args| args["force"].as_bool());
+        let maybe_promise = EthConnectorContract::init_instance(io)?
+            .storage_unregister(predecessor_account_id, force)?;
+        if let Some(promise) = maybe_promise {
+            // Safety: This call is safe. It is only a transfer back to the user for their deposit.
+            unsafe { handler.promise_create_batch(&promise) };
+        }
+        Ok(())
+    })
 }
 
+#[named]
 pub fn storage_withdraw<I: IO + Copy, E: Env>(io: I, env: &E) -> Result<(), ContractError> {
-    require_running(&state::get_state(&io)?)?;
-    env.assert_one_yocto()?;
-    let args: StorageWithdrawCallArgs = serde_json::from_slice(&io.read_input().to_vec())
-        .map_err(Into::<ParseTypeFromJsonError>::into)?;
-    let predecessor_account_id = env.predecessor_account_id();
-    EthConnectorContract::init_instance(io)?.storage_withdraw(&predecessor_account_id, &args)?;
-    Ok(())
+    with_hashchain(io, env, function_name!(), |io| {
+        require_running(&state::get_state(&io)?)?;
+        env.assert_one_yocto()?;
+        let args: StorageWithdrawCallArgs = serde_json::from_slice(&io.read_input().to_vec())
+            .map_err(Into::<ParseTypeFromJsonError>::into)?;
+        let predecessor_account_id = env.predecessor_account_id();
+        EthConnectorContract::init_instance(io)?
+            .storage_withdraw(&predecessor_account_id, &args)?;
+        Ok(())
+    })
 }
 
+#[named]
 pub fn set_paused_flags<I: IO + Copy, E: Env>(io: I, env: &E) -> Result<(), ContractError> {
-    let state = state::get_state(&io)?;
-    require_running(&state)?;
-    let is_private = env.assert_private_call();
-    if is_private.is_err() {
-        require_owner_only(&state, &env.predecessor_account_id())?;
-    }
-    let args: PauseEthConnectorCallArgs = io.read_input_borsh()?;
-    EthConnectorContract::init_instance(io)?.set_paused_flags(&args);
-    Ok(())
+    with_hashchain(io, env, function_name!(), |io| {
+        let state = state::get_state(&io)?;
+        require_running(&state)?;
+        let is_private = env.assert_private_call();
+        if is_private.is_err() {
+            require_owner_only(&state, &env.predecessor_account_id())?;
+        }
+        let args: PauseEthConnectorCallArgs = io.read_input_borsh()?;
+        EthConnectorContract::init_instance(io)?.set_paused_flags(&args);
+        Ok(())
+    })
 }

--- a/engine/src/contract_methods/evm_transactions.rs
+++ b/engine/src/contract_methods/evm_transactions.rs
@@ -1,7 +1,9 @@
 use crate::{
     contract_methods::{predecessor_address, require_running, ContractError},
     engine::{self, Engine},
-    errors, state,
+    errors,
+    hashchain::with_logs_hashchain,
+    state,
 };
 use aurora_engine_modexp::AuroraModExp;
 use aurora_engine_sdk::{
@@ -13,115 +15,128 @@ use aurora_engine_types::{
     borsh::BorshSerialize,
     parameters::engine::{CallArgs, SubmitArgs, SubmitResult},
 };
+use function_name::named;
 
-pub fn deploy_code<'env, I: IO + Copy, E: Env, H: PromiseHandler>(
-    mut io: I,
-    env: &'env E,
+#[named]
+pub fn deploy_code<I: IO + Copy, E: Env, H: PromiseHandler>(
+    io: I,
+    env: &E,
     handler: &mut H,
 ) -> Result<SubmitResult, ContractError> {
-    let state = state::get_state(&io)?;
-    require_running(&state)?;
-    let input = io.read_input().to_vec();
-    let current_account_id = env.current_account_id();
-    let mut engine: Engine<'env, I, E, AuroraModExp> = Engine::new_with_state(
-        state,
-        predecessor_address(&env.predecessor_account_id()),
-        current_account_id,
-        io,
-        env,
-    );
-    let result = engine.deploy_code_with_input(input, handler)?;
-    let result_bytes = result.try_to_vec().map_err(|_| errors::ERR_SERIALIZE)?;
-    io.return_output(&result_bytes);
-    Ok(result)
+    with_logs_hashchain(io, env, function_name!(), |mut io| {
+        let state = state::get_state(&io)?;
+        require_running(&state)?;
+        let input = io.read_input().to_vec();
+        let current_account_id = env.current_account_id();
+        let mut engine: Engine<_, E, AuroraModExp> = Engine::new_with_state(
+            state,
+            predecessor_address(&env.predecessor_account_id()),
+            current_account_id,
+            io,
+            env,
+        );
+        let result = engine.deploy_code_with_input(input, handler)?;
+        let result_bytes = result.try_to_vec().map_err(|_| errors::ERR_SERIALIZE)?;
+        io.return_output(&result_bytes);
+        Ok(result)
+    })
 }
 
-pub fn call<'env, I: IO + Copy, E: Env, H: PromiseHandler>(
-    mut io: I,
-    env: &'env E,
+#[named]
+pub fn call<I: IO + Copy, E: Env, H: PromiseHandler>(
+    io: I,
+    env: &E,
     handler: &mut H,
 ) -> Result<SubmitResult, ContractError> {
-    let state = state::get_state(&io)?;
-    require_running(&state)?;
-    let bytes = io.read_input().to_vec();
-    let args = CallArgs::deserialize(&bytes).ok_or(errors::ERR_BORSH_DESERIALIZE)?;
-    let current_account_id = env.current_account_id();
-    let predecessor_account_id = env.predecessor_account_id();
+    with_logs_hashchain(io, env, function_name!(), |mut io| {
+        let state = state::get_state(&io)?;
+        require_running(&state)?;
+        let bytes = io.read_input().to_vec();
+        let args = CallArgs::deserialize(&bytes).ok_or(errors::ERR_BORSH_DESERIALIZE)?;
+        let current_account_id = env.current_account_id();
+        let predecessor_account_id = env.predecessor_account_id();
 
-    // During the XCC flow the Engine will call itself to move wNEAR
-    // to the user's sub-account. We do not want this move to happen
-    // if prior promises in the flow have failed.
-    if current_account_id == predecessor_account_id {
-        let check_promise: Result<(), &[u8]> = match handler.promise_result_check() {
-            Some(true) | None => Ok(()),
-            Some(false) => Err(b"ERR_CALLBACK_OF_FAILED_PROMISE"),
-        };
-        check_promise?;
-    }
+        // During the XCC flow the Engine will call itself to move wNEAR
+        // to the user's sub-account. We do not want this move to happen
+        // if prior promises in the flow have failed.
+        if current_account_id == predecessor_account_id {
+            let check_promise: Result<(), &[u8]> = match handler.promise_result_check() {
+                Some(true) | None => Ok(()),
+                Some(false) => Err(b"ERR_CALLBACK_OF_FAILED_PROMISE"),
+            };
+            check_promise?;
+        }
 
-    let mut engine: Engine<'env, I, E, AuroraModExp> = Engine::new_with_state(
-        state,
-        predecessor_address(&predecessor_account_id),
-        current_account_id,
-        io,
-        env,
-    );
-    let result = engine.call_with_args(args, handler)?;
-    let result_bytes = result.try_to_vec().map_err(|_| errors::ERR_SERIALIZE)?;
-    io.return_output(&result_bytes);
-    Ok(result)
+        let mut engine: Engine<_, E, AuroraModExp> = Engine::new_with_state(
+            state,
+            predecessor_address(&predecessor_account_id),
+            current_account_id,
+            io,
+            env,
+        );
+        let result = engine.call_with_args(args, handler)?;
+        let result_bytes = result.try_to_vec().map_err(|_| errors::ERR_SERIALIZE)?;
+        io.return_output(&result_bytes);
+        Ok(result)
+    })
 }
 
+#[named]
 pub fn submit<I: IO + Copy, E: Env, H: PromiseHandler>(
-    mut io: I,
+    io: I,
     env: &E,
     handler: &mut H,
 ) -> Result<SubmitResult, ContractError> {
-    let state = state::get_state(&io)?;
-    require_running(&state)?;
-    let tx_data = io.read_input().to_vec();
-    let current_account_id = env.current_account_id();
-    let relayer_address = predecessor_address(&env.predecessor_account_id());
-    let args = SubmitArgs {
-        tx_data,
-        ..Default::default()
-    };
-    let result = engine::submit(
-        io,
-        env,
-        &args,
-        state,
-        current_account_id,
-        relayer_address,
-        handler,
-    )?;
-    let result_bytes = result.try_to_vec().map_err(|_| errors::ERR_SERIALIZE)?;
-    io.return_output(&result_bytes);
+    with_logs_hashchain(io, env, function_name!(), |mut io| {
+        let state = state::get_state(&io)?;
+        require_running(&state)?;
+        let tx_data = io.read_input().to_vec();
+        let current_account_id = env.current_account_id();
+        let relayer_address = predecessor_address(&env.predecessor_account_id());
+        let args = SubmitArgs {
+            tx_data,
+            ..Default::default()
+        };
+        let result = engine::submit(
+            io,
+            env,
+            &args,
+            state,
+            current_account_id,
+            relayer_address,
+            handler,
+        )?;
+        let result_bytes = result.try_to_vec().map_err(|_| errors::ERR_SERIALIZE)?;
+        io.return_output(&result_bytes);
 
-    Ok(result)
+        Ok(result)
+    })
 }
 
+#[named]
 pub fn submit_with_args<I: IO + Copy, E: Env, H: PromiseHandler>(
-    mut io: I,
+    io: I,
     env: &E,
     handler: &mut H,
 ) -> Result<SubmitResult, ContractError> {
-    let state = state::get_state(&io)?;
-    require_running(&state)?;
-    let args: SubmitArgs = io.read_input_borsh()?;
-    let current_account_id = env.current_account_id();
-    let relayer_address = predecessor_address(&env.predecessor_account_id());
-    let result = engine::submit(
-        io,
-        env,
-        &args,
-        state,
-        current_account_id,
-        relayer_address,
-        handler,
-    )?;
-    let result_bytes = result.try_to_vec().map_err(|_| errors::ERR_SERIALIZE)?;
-    io.return_output(&result_bytes);
+    with_logs_hashchain(io, env, function_name!(), |mut io| {
+        let state = state::get_state(&io)?;
+        require_running(&state)?;
+        let args: SubmitArgs = io.read_input_borsh()?;
+        let current_account_id = env.current_account_id();
+        let relayer_address = predecessor_address(&env.predecessor_account_id());
+        let result = engine::submit(
+            io,
+            env,
+            &args,
+            state,
+            current_account_id,
+            relayer_address,
+            handler,
+        )?;
+        let result_bytes = result.try_to_vec().map_err(|_| errors::ERR_SERIALIZE)?;
+        io.return_output(&result_bytes);
 
-    Ok(result)
+        Ok(result)
+    })
 }

--- a/engine/src/contract_methods/mod.rs
+++ b/engine/src/contract_methods/mod.rs
@@ -67,6 +67,13 @@ fn require_running(state: &crate::state::EngineState) -> Result<(), ContractErro
     Ok(())
 }
 
+fn require_paused(state: &crate::state::EngineState) -> Result<(), ContractError> {
+    if !state.is_paused {
+        return Err(errors::ERR_RUNNING.into());
+    }
+    Ok(())
+}
+
 fn require_owner_only(
     state: &crate::state::EngineState,
     predecessor_account_id: &AccountId,

--- a/engine/src/contract_methods/xcc.rs
+++ b/engine/src/contract_methods/xcc.rs
@@ -1,6 +1,8 @@
 use crate::{
     contract_methods::{require_owner_only, require_running, ContractError},
-    errors, state, xcc,
+    errors,
+    hashchain::with_hashchain,
+    state, xcc,
 };
 use aurora_engine_sdk::{
     env::Env,
@@ -8,46 +10,56 @@ use aurora_engine_sdk::{
     promise::PromiseHandler,
 };
 use aurora_engine_types::{borsh::BorshSerialize, types::Address};
+use function_name::named;
 
-pub fn factory_update<I: IO + Copy, E: Env>(mut io: I, env: &E) -> Result<(), ContractError> {
-    let state = state::get_state(&io)?;
-    require_running(&state)?;
-    require_owner_only(&state, &env.predecessor_account_id())?;
-    let bytes = io.read_input().to_vec();
-    let router_bytecode = xcc::RouterCode::new(bytes);
-    xcc::update_router_code(&mut io, &router_bytecode);
-    Ok(())
+#[named]
+pub fn factory_update<I: IO + Copy, E: Env>(io: I, env: &E) -> Result<(), ContractError> {
+    with_hashchain(io, env, function_name!(), |mut io| {
+        let state = state::get_state(&io)?;
+        require_running(&state)?;
+        require_owner_only(&state, &env.predecessor_account_id())?;
+        let bytes = io.read_input().to_vec();
+        let router_bytecode = xcc::RouterCode::new(bytes);
+        xcc::update_router_code(&mut io, &router_bytecode);
+        Ok(())
+    })
 }
 
+#[named]
 pub fn factory_update_address_version<I: IO + Copy, E: Env, H: PromiseHandler>(
-    mut io: I,
+    io: I,
     env: &E,
     handler: &H,
 ) -> Result<(), ContractError> {
-    require_running(&state::get_state(&io)?)?;
-    // The function is only set to be private, otherwise callback error will happen.
-    env.assert_private_call()?;
-    let check_deploy: Result<(), &[u8]> = match handler.promise_result_check() {
-        Some(true) => Ok(()),
-        Some(false) => Err(b"ERR_ROUTER_DEPLOY_FAILED"),
-        None => Err(b"ERR_ROUTER_UPDATE_NOT_CALLBACK"),
-    };
-    check_deploy?;
-    let args: xcc::AddressVersionUpdateArgs = io.read_input_borsh()?;
-    xcc::set_code_version_of_address(&mut io, &args.address, args.version);
-    Ok(())
+    with_hashchain(io, env, function_name!(), |mut io| {
+        require_running(&state::get_state(&io)?)?;
+        // The function is only set to be private, otherwise callback error will happen.
+        env.assert_private_call()?;
+        let check_deploy: Result<(), &[u8]> = match handler.promise_result_check() {
+            Some(true) => Ok(()),
+            Some(false) => Err(b"ERR_ROUTER_DEPLOY_FAILED"),
+            None => Err(b"ERR_ROUTER_UPDATE_NOT_CALLBACK"),
+        };
+        check_deploy?;
+        let args: xcc::AddressVersionUpdateArgs = io.read_input_borsh()?;
+        xcc::set_code_version_of_address(&mut io, &args.address, args.version);
+        Ok(())
+    })
 }
 
+#[named]
 pub fn factory_set_wnear_address<I: IO + Copy, E: Env>(
-    mut io: I,
+    io: I,
     env: &E,
 ) -> Result<(), ContractError> {
-    let state = state::get_state(&io)?;
-    require_running(&state)?;
-    require_owner_only(&state, &env.predecessor_account_id())?;
-    let address = io.read_input_arr20()?;
-    xcc::set_wnear_address(&mut io, &Address::from_array(address));
-    Ok(())
+    with_hashchain(io, env, function_name!(), |mut io| {
+        let state = state::get_state(&io)?;
+        require_running(&state)?;
+        require_owner_only(&state, &env.predecessor_account_id())?;
+        let address = io.read_input_arr20()?;
+        xcc::set_wnear_address(&mut io, &Address::from_array(address));
+        Ok(())
+    })
 }
 
 pub fn factory_get_wnear_address<I: IO + Copy>(mut io: I) -> Result<(), ContractError> {
@@ -57,19 +69,22 @@ pub fn factory_get_wnear_address<I: IO + Copy>(mut io: I) -> Result<(), Contract
     Ok(())
 }
 
+#[named]
 pub fn fund_xcc_sub_account<I: IO + Copy, E: Env, H: PromiseHandler>(
-    io: &I,
+    io: I,
     env: &E,
     handler: &mut H,
 ) -> Result<(), ContractError> {
-    let state = state::get_state(io)?;
-    require_running(&state)?;
-    // This method can only be called by the owner because it allows specifying the
-    // account ID of the wNEAR account. This information must be accurate for the
-    // sub-account to work properly, therefore this method can only be called by
-    // a trusted user.
-    require_owner_only(&state, &env.predecessor_account_id())?;
-    let args: xcc::FundXccArgs = io.read_input_borsh()?;
-    xcc::fund_xcc_sub_account(io, handler, env, args)?;
-    Ok(())
+    with_hashchain(io, env, function_name!(), |io| {
+        let state = state::get_state(&io)?;
+        require_running(&state)?;
+        // This method can only be called by the owner because it allows specifying the
+        // account ID of the wNEAR account. This information must be accurate for the
+        // sub-account to work properly, therefore this method can only be called by
+        // a trusted user.
+        require_owner_only(&state, &env.predecessor_account_id())?;
+        let args: xcc::FundXccArgs = io.read_input_borsh()?;
+        xcc::fund_xcc_sub_account(&io, handler, env, args)?;
+        Ok(())
+    })
 }

--- a/engine/src/hashchain.rs
+++ b/engine/src/hashchain.rs
@@ -1,0 +1,110 @@
+use crate::contract_methods::ContractError;
+use aurora_engine_hashchain::{
+    bloom::{self, Bloom},
+    error::BlockchainHashchainError,
+    hashchain::Hashchain,
+    wrapped_io::{CachedIO, IOCache},
+};
+use aurora_engine_sdk::{
+    env::Env,
+    io::{StorageIntermediate, IO},
+};
+use aurora_engine_types::{
+    parameters::engine::SubmitResult,
+    storage::{self, KeyPrefix},
+};
+use core::cell::RefCell;
+
+pub const HASHCHAIN_STATE: &[u8] = b"HC_STATE";
+
+pub fn with_hashchain<I, E, T, F>(
+    mut io: I,
+    env: &E,
+    function_name: &str,
+    f: F,
+) -> Result<T, ContractError>
+where
+    I: IO + Copy,
+    E: Env,
+    F: for<'a> FnOnce(CachedIO<'a, I>) -> Result<T, ContractError>,
+{
+    let block_height = env.block_height();
+    let maybe_hashchain = load_hashchain(&io, block_height)?;
+
+    let cache = RefCell::new(IOCache::default());
+    let hashchain_io = CachedIO::new(io, &cache);
+    let result = f(hashchain_io)?;
+
+    if let Some(mut hashchain) = maybe_hashchain {
+        let cache_ref = cache.borrow();
+        hashchain.add_block_tx(
+            block_height,
+            function_name,
+            &cache_ref.input,
+            &cache_ref.output,
+            &Bloom::default(),
+        )?;
+        save_hashchain(&mut io, &hashchain)?;
+    }
+
+    Ok(result)
+}
+
+pub fn with_logs_hashchain<I, E, F>(
+    mut io: I,
+    env: &E,
+    function_name: &str,
+    f: F,
+) -> Result<SubmitResult, ContractError>
+where
+    I: IO + Copy,
+    E: Env,
+    F: for<'a> FnOnce(CachedIO<'a, I>) -> Result<SubmitResult, ContractError>,
+{
+    let block_height = env.block_height();
+    let maybe_hashchain = load_hashchain(&io, block_height)?;
+
+    let cache = RefCell::new(IOCache::default());
+    let hashchain_io = CachedIO::new(io, &cache);
+    let result = f(hashchain_io)?;
+
+    if let Some(mut hashchain) = maybe_hashchain {
+        let log_bloom = bloom::get_logs_bloom(&result.logs);
+        let cache_ref = cache.borrow();
+        hashchain.add_block_tx(
+            block_height,
+            function_name,
+            &cache_ref.input,
+            &cache_ref.output,
+            &log_bloom,
+        )?;
+        save_hashchain(&mut io, &hashchain)?;
+    }
+
+    Ok(result)
+}
+
+fn load_hashchain<I: IO>(io: &I, block_height: u64) -> Result<Option<Hashchain>, ContractError> {
+    let key = storage::bytes_to_key(KeyPrefix::Hashchain, HASHCHAIN_STATE);
+    let mut maybe_hashchain = io.read_storage(&key).map_or(Ok(None), |value| {
+        let bytes = value.to_vec();
+        Hashchain::try_deserialize(&bytes)
+            .map(Some)
+            .map_err(|_| BlockchainHashchainError::DeserializationFailed)
+    })?;
+    if let Some(hashchain) = maybe_hashchain.as_mut() {
+        if block_height > hashchain.get_current_block_height() {
+            hashchain.move_to_block(block_height)?;
+        }
+    }
+    Ok(maybe_hashchain)
+}
+
+pub fn save_hashchain<I: IO>(io: &mut I, hashchain: &Hashchain) -> Result<(), ContractError> {
+    let key = storage::bytes_to_key(KeyPrefix::Hashchain, HASHCHAIN_STATE);
+    let bytes = hashchain
+        .try_serialize()
+        .map_err(|_| BlockchainHashchainError::SerializationFailed)?;
+    io.write_storage(&key, &bytes);
+    Ok(())
+}

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -36,6 +36,7 @@ pub mod deposit_event;
 pub mod engine;
 pub mod errors;
 pub mod fungible_token;
+pub mod hashchain;
 pub mod pausables;
 mod prelude;
 pub mod state;
@@ -114,7 +115,8 @@ mod contract {
     #[no_mangle]
     pub extern "C" fn new() {
         let io = Runtime;
-        contract_methods::admin::new(io)
+        let env = Runtime;
+        contract_methods::admin::new(io, &env)
             .map_err(ContractError::msg)
             .sdk_unwrap();
     }
@@ -388,7 +390,7 @@ mod contract {
         let io = Runtime;
         let env = Runtime;
         let mut handler = Runtime;
-        contract_methods::xcc::fund_xcc_sub_account(&io, &env, &mut handler)
+        contract_methods::xcc::fund_xcc_sub_account(io, &env, &mut handler)
             .map_err(ContractError::msg)
             .sdk_unwrap();
     }
@@ -459,6 +461,16 @@ mod contract {
         let env = Runtime;
         let mut handler = Runtime;
         contract_methods::admin::remove_relayer_key(io, &env, &mut handler)
+            .map_err(ContractError::msg)
+            .sdk_unwrap();
+    }
+
+    /// Initialize the hashchain.
+    #[no_mangle]
+    pub extern "C" fn start_hashchain() {
+        let io = Runtime;
+        let env = Runtime;
+        contract_methods::admin::start_hashchain(io, &env)
             .map_err(ContractError::msg)
             .sdk_unwrap();
     }

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -537,6 +537,14 @@ mod contract {
         io.return_output(&value.0);
     }
 
+    #[no_mangle]
+    pub extern "C" fn get_latest_hashchain() {
+        let mut io = Runtime;
+        contract_methods::admin::get_latest_hashchain(&mut io)
+            .map_err(ContractError::msg)
+            .sdk_unwrap();
+    }
+
     ///
     /// BENCHMARKING METHODS
     ///


### PR DESCRIPTION
## Description

This PR integrates the hashchain feature into the Aurora Engine contract (see https://github.com/aurora-is-near/AIPs/pull/8). This change is fully backwards compatible because by default there is no hashchain present in the contract state and therefore no hashchain computation is done.

The method to activate the hashchain is `start_hashchain` requires the contract to be paused and can only be called by a privileged account (I chose to use the key manager instead of introducing a new role). These restrictions are necessary because the hashchain is initialized with a value based on the Engine's transaction history (to enable validating Aurora blocks starting from the deployment of the contract).

## Performance / NEAR gas cost considerations

After activating the hashchain there will be a small increase in gas usage because of the hashchain computation. It's not very much for most transactions (as seen in the performance regression tests), but the amount of gas is proportional to the size of the input + output of the transaction (because we compute a hash from this data).

## Testing

The tests have been changed to enable the hashchain by default. Therefore all existing tests are running the hashchain code and testing that the Wasm and Standalone results match (this is important because the Refiner will be computing hashchain values off-chain using the Standalone Engine). An additional test has been added for the hashchain feature itself.

## Additional information

Note: the diff in `contract_methods` is relatively large, but the code changes are minimal. All that happened is the existing function bodies were wrapped in `with_hashchain`, which changed the indentation. Viewing the PR with whitespace changes ignored may make this section easier to review.
