### PR TITLE
Feat: Allow hashchain to be initialized with new directly

### DIFF
--- a/engine-tests/src/tests/sanity.rs
+++ b/engine-tests/src/tests/sanity.rs
@@ -681,7 +681,7 @@ fn test_num_wasm_functions() {
     let module = walrus::ModuleConfig::default()
         .parse(runner.code.code())
         .unwrap();
-    let expected_number = 1464;
+    let expected_number = 1465;
     let actual_number = module.funcs.iter().count();
 
     assert!(

--- a/engine-types/src/parameters/engine.rs
+++ b/engine-types/src/parameters/engine.rs
@@ -16,6 +16,7 @@ pub enum NewCallArgs {
     V1(LegacyNewCallArgs),
     V2(NewCallArgsV2),
     V3(NewCallArgsV3),
+    V4(NewCallArgsV4),
 }
 
 impl NewCallArgs {
@@ -24,6 +25,14 @@ impl NewCallArgs {
             |_| LegacyNewCallArgs::try_from_slice(bytes).map(Self::V1),
             Ok,
         )
+    }
+
+    #[must_use]
+    pub const fn initial_hashchain(&self) -> Option<RawH256> {
+        match self {
+            Self::V4(args) => args.initial_hashchain,
+            Self::V1(_) | Self::V2(_) | Self::V3(_) => None,
+        }
     }
 }
 
@@ -64,6 +73,22 @@ pub struct NewCallArgsV3 {
     pub upgrade_delay_blocks: u64,
     /// Relayer keys manager.
     pub key_manager: AccountId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct NewCallArgsV4 {
+    /// Chain id, according to the EIP-115 / ethereum-lists spec.
+    pub chain_id: RawU256,
+    /// Account which can upgrade this contract.
+    /// Use empty to disable updatability.
+    pub owner_id: AccountId,
+    /// How many blocks after staging upgrade can deploy it.
+    pub upgrade_delay_blocks: u64,
+    /// Relayer keys manager.
+    pub key_manager: AccountId,
+    /// Initial value of the hashchain.
+    /// If none is provided then the hashchain will start disabled.
+    pub initial_hashchain: Option<RawH256>,
 }
 
 /// Borsh-encoded parameters for the `set_owner` function.

--- a/engine/src/state.rs
+++ b/engine/src/state.rs
@@ -1,8 +1,9 @@
-use crate::parameters::{LegacyNewCallArgs, NewCallArgs, NewCallArgsV2};
+use crate::parameters::{
+    LegacyNewCallArgs, NewCallArgs, NewCallArgsV2, NewCallArgsV3, NewCallArgsV4,
+};
 use aurora_engine_sdk::io::{StorageIntermediate, IO};
 use aurora_engine_types::account_id::AccountId;
 use aurora_engine_types::borsh::{self, BorshDeserialize, BorshSerialize};
-use aurora_engine_types::parameters::engine::NewCallArgsV3;
 use aurora_engine_types::storage::{bytes_to_key, KeyPrefix};
 use aurora_engine_types::{Cow, Vec};
 
@@ -177,12 +178,25 @@ impl From<NewCallArgsV3> for EngineState {
     }
 }
 
+impl From<NewCallArgsV4> for EngineState {
+    fn from(args: NewCallArgsV4) -> Self {
+        Self {
+            chain_id: args.chain_id,
+            owner_id: args.owner_id,
+            upgrade_delay_blocks: args.upgrade_delay_blocks,
+            is_paused: false,
+            key_manager: Some(args.key_manager),
+        }
+    }
+}
+
 impl From<NewCallArgs> for EngineState {
     fn from(args: NewCallArgs) -> Self {
         match args {
             NewCallArgs::V1(args) => args.into(),
             NewCallArgs::V2(args) => args.into(),
             NewCallArgs::V3(args) => args.into(),
+            NewCallArgs::V4(args) => args.into(),
         }
     }
 }


### PR DESCRIPTION
## Description

For the mainnet Aurora Engine we must use the `pause_contract` + `start_hashchain` migration procedure because it is already live. However, for new silos it will be useful to have the hashchain enabled from the start. This PR adds a new optional parameter to the `new` function where an initial (genesis) hashchain value can be specified and then hashchain will be enabled on all transactions going forward.

## Performance / NEAR gas cost considerations

N/A; impacts `new` only.

## Testing

Tests updated to use `new` for starting the hashchain by default. Some tests still use the migration procedure to ensure that is also tested.
