### PR TITLE
fix: setting erc-20 metadata by the owner of the contract

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixes
+
+- The smart contract owner whose account id is not the same as the contract account id can set ERC-20 metadata
+  by [@aleksuss] ([#858]). 
+
+[#858]: https://github.com/aurora-is-near/aurora-engine/pull/858
+
 ## [3.3.0] 2023-10-23
 
 ### Changes

--- a/engine-tests/src/tests/erc20.rs
+++ b/engine-tests/src/tests/erc20.rs
@@ -3,15 +3,17 @@ use crate::prelude::{Address, U256};
 use crate::utils::{
     self,
     solidity::erc20::{self, ERC20Constructor, ERC20},
-    Signer,
+    str_to_account_id, Signer,
 };
 use aurora_engine::engine::EngineErrorKind;
 use aurora_engine::parameters::TransactionStatus;
 use aurora_engine_sdk as sdk;
 use aurora_engine_types::account_id::AccountId;
+use aurora_engine_types::borsh::BorshSerialize;
 use aurora_engine_types::parameters::connector::{
     Erc20Identifier, Erc20Metadata, SetErc20MetadataArgs,
 };
+use aurora_engine_types::parameters::engine::SetOwnerArgs;
 use bstr::ByteSlice;
 use libsecp256k1::SecretKey;
 use std::str::FromStr;
@@ -285,6 +287,70 @@ fn test_erc20_get_and_set_metadata() {
     let result = runner.one_shot().call(
         "get_erc20_metadata",
         &caller,
+        serde_json::to_vec::<Erc20Identifier>(
+            &AccountId::from_str(token_account_id).unwrap().into(),
+        )
+        .unwrap(),
+    );
+    assert!(result.is_ok());
+
+    let metadata: Erc20Metadata =
+        serde_json::from_slice(&result.unwrap().return_data.as_value().unwrap()).unwrap();
+    assert_eq!(metadata, new_metadata);
+}
+
+#[test]
+fn test_erc20_get_and_set_metadata_by_owner() {
+    let mut runner = utils::deploy_runner();
+    let token_account_id = "token";
+    let erc20_address = runner.deploy_erc20_token(token_account_id);
+    let caller = runner.aurora_account_id.clone();
+
+    // Change the owner of the aurora contract
+    let new_owner = "new_owner";
+    let set_owner_args = SetOwnerArgs {
+        new_owner: str_to_account_id(&new_owner),
+    };
+
+    let result = runner.call("set_owner", &caller, set_owner_args.try_to_vec().unwrap());
+    assert!(result.is_ok());
+
+    let caller = new_owner;
+
+    // Getting ERC-20 metadata by Address.
+    let result = runner.one_shot().call(
+        "get_erc20_metadata",
+        caller,
+        serde_json::to_vec::<Erc20Identifier>(&erc20_address.into()).unwrap(),
+    );
+
+    assert!(result.is_ok());
+
+    let metadata: Erc20Metadata =
+        serde_json::from_slice(&result.unwrap().return_data.as_value().unwrap()).unwrap();
+    assert_eq!(metadata, Erc20Metadata::default());
+
+    let new_metadata = Erc20Metadata {
+        name: "USD Token".to_string(),
+        symbol: "USDT".to_string(),
+        decimals: 20,
+    };
+
+    let result = runner.call(
+        "set_erc20_metadata",
+        caller,
+        serde_json::to_vec(&SetErc20MetadataArgs {
+            erc20_identifier: erc20_address.into(),
+            metadata: new_metadata.clone(),
+        })
+        .unwrap(),
+    );
+    assert!(result.is_ok());
+
+    // Getting ERC-20 metadata by NEP-141 account id.
+    let result = runner.one_shot().call(
+        "get_erc20_metadata",
+        caller,
         serde_json::to_vec::<Erc20Identifier>(
             &AccountId::from_str(token_account_id).unwrap().into(),
         )

--- a/engine-tests/src/tests/erc20.rs
+++ b/engine-tests/src/tests/erc20.rs
@@ -309,7 +309,7 @@ fn test_erc20_get_and_set_metadata_by_owner() {
     // Change the owner of the aurora contract
     let new_owner = "new_owner";
     let set_owner_args = SetOwnerArgs {
-        new_owner: str_to_account_id(&new_owner),
+        new_owner: str_to_account_id(new_owner),
     };
 
     let result = runner.call("set_owner", &caller, set_owner_args.try_to_vec().unwrap());

--- a/engine-tests/src/tests/sanity.rs
+++ b/engine-tests/src/tests/sanity.rs
@@ -434,8 +434,8 @@ fn test_solidity_pure_bench() {
         .unwrap();
 
     assert!(
-        result.gas_used > 38_000_000,
-        "Over 38 million EVM gas is used {}",
+        result.gas_used > 37_000_000,
+        "Over 37 million EVM gas is used {}",
         result.gas_used
     );
     let near_gas = profile.all_gas();

--- a/engine-tests/src/tests/sanity.rs
+++ b/engine-tests/src/tests/sanity.rs
@@ -435,7 +435,8 @@ fn test_solidity_pure_bench() {
 
     assert!(
         result.gas_used > 38_000_000,
-        "Over 38 million EVM gas is used"
+        "Over 38 million EVM gas is used {}",
+        result.gas_used
     );
     let near_gas = profile.all_gas();
     assert!(

--- a/engine/src/contract_methods/connector/mod.rs
+++ b/engine/src/contract_methods/connector/mod.rs
@@ -399,7 +399,7 @@ pub fn get_erc20_metadata<I: IO + Copy, E: Env>(mut io: I, env: &E) -> Result<()
     let current_account_id = env.current_account_id();
     let engine: Engine<_, E, AuroraModExp> = Engine::new_with_state(
         state,
-        predecessor_address(&current_account_id),
+        predecessor_address(&env.predecessor_account_id()),
         current_account_id,
         io,
         env,

--- a/engine/src/contract_methods/connector/mod.rs
+++ b/engine/src/contract_methods/connector/mod.rs
@@ -381,7 +381,7 @@ pub fn set_erc20_metadata<I: IO + Copy, E: Env, H: PromiseHandler>(
         let current_account_id = env.current_account_id();
         let mut engine: Engine<_, E, AuroraModExp> = Engine::new_with_state(
             state,
-            predecessor_address(&env.predecessor_account_id()),
+            predecessor_address(&current_account_id),
             current_account_id,
             io,
             env,
@@ -399,7 +399,7 @@ pub fn get_erc20_metadata<I: IO + Copy, E: Env>(mut io: I, env: &E) -> Result<()
     let current_account_id = env.current_account_id();
     let engine: Engine<_, E, AuroraModExp> = Engine::new_with_state(
         state,
-        predecessor_address(&env.predecessor_account_id()),
+        predecessor_address(&current_account_id),
         current_account_id,
         io,
         env,

--- a/engine/src/pausables.rs
+++ b/engine/src/pausables.rs
@@ -41,7 +41,7 @@ pub trait Authorizer {
 
 /// Can check if a subset of precompiles is currently paused or not.
 pub trait PausedPrecompilesChecker {
-    /// Checks if all of the `precompiles` are paused.
+    /// Checks if all the `precompiles` are paused.
     ///
     /// The `precompiles` mask can be a subset and every 1 bit is meant to be checked and every 0 bit is ignored.
     fn is_paused(&self, precompiles: PrecompileFlags) -> bool;


### PR DESCRIPTION
## Description

The PR fixes behaviour when the owner of the smart contract can't set ERC-20 metadata in case the account id of the owner and the account id of the contract are different.

## Performance / NEAR gas cost considerations

There are no changes in the performance.

## Testing

The corresponding test has been added.