### PR TITLE
Fix(standalone): properly compute runtime random value

### DIFF
--- a/engine-standalone-storage/src/relayer_db/mod.rs
+++ b/engine-standalone-storage/src/relayer_db/mod.rs
@@ -155,6 +155,7 @@ where
             transaction: crate::sync::types::TransactionKind::Submit(tx),
             promise_data: Vec::new(),
             raw_input: transaction_bytes,
+            action_hash: H256::default(),
         };
         storage.set_transaction_included(tx_hash, &tx_msg, &diff)?;
     }
@@ -268,6 +269,7 @@ mod test {
                         transaction: TransactionKind::Unknown,
                         promise_data: Vec::new(),
                         raw_input: Vec::new(),
+                        action_hash: H256::default(),
                     },
                     &diff,
                 )

--- a/engine-tests/src/tests/random.rs
+++ b/engine-tests/src/tests/random.rs
@@ -1,12 +1,17 @@
 use crate::utils;
 use crate::utils::solidity::random::{Random, RandomConstructor};
 use aurora_engine_types::H256;
+use rand::SeedableRng;
 
 #[test]
 fn test_random_number_precompile() {
     let random_seed = H256::from_slice(vec![7; 32].as_slice());
-    let mut signer = utils::Signer::random();
-    let mut runner = utils::deploy_runner().with_random_seed(random_seed);
+    let secret_key = {
+        let mut rng = rand::rngs::StdRng::from_seed(random_seed.0);
+        libsecp256k1::SecretKey::random(&mut rng)
+    };
+    let mut signer = utils::Signer::new(secret_key);
+    let mut runner = utils::deploy_runner().with_block_random_value(random_seed);
 
     let random_ctr = RandomConstructor::load();
     let nonce = signer.use_nonce();
@@ -14,6 +19,13 @@ fn test_random_number_precompile() {
         .deploy_contract(&signer.secret_key, |ctr| ctr.deploy(nonce), random_ctr)
         .into();
 
+    // Value derived from `random_seed` above together with the `action_hash`
+    // of the following transaction.
+    let expected_value = H256::from_slice(
+        &hex::decode("1a71249ace8312de8ed3640c852d5d542b04b2caec668325f6e18811244e7f5c").unwrap(),
+    );
+    runner.context.random_seed = expected_value.0.to_vec();
+
     let counter_value = random.random_seed(&mut runner, &mut signer);
-    assert_eq!(counter_value, random_seed);
+    assert_eq!(counter_value, expected_value);
 }

--- a/engine-tests/src/tests/repro.rs
+++ b/engine-tests/src/tests/repro.rs
@@ -171,7 +171,7 @@ fn repro_common(context: &ReproContext) {
     let mut standalone = standalone::StandaloneRunner::default();
     json_snapshot::initialize_engine_state(&standalone.storage, snapshot).unwrap();
     let standalone_result = standalone
-        .submit_raw("submit", &runner.context, &[])
+        .submit_raw("submit", &runner.context, &[], None)
         .unwrap();
     assert_eq!(
         submit_result.try_to_vec().unwrap(),

--- a/engine-tests/src/tests/sanity.rs
+++ b/engine-tests/src/tests/sanity.rs
@@ -212,14 +212,18 @@ fn test_transaction_to_zero_address() {
     // Prior to the fix the zero address is interpreted as None, causing a contract deployment.
     // It also incorrectly derives the sender address, so does not increment the right nonce.
     context.block_height = ZERO_ADDRESS_FIX_HEIGHT - 1;
-    let result = runner.submit_raw(utils::SUBMIT, &context, &[]).unwrap();
+    let result = runner
+        .submit_raw(utils::SUBMIT, &context, &[], None)
+        .unwrap();
     assert_eq!(result.gas_used, 53_000);
     runner.env.block_height = ZERO_ADDRESS_FIX_HEIGHT;
     assert_eq!(runner.get_nonce(&address), U256::zero());
 
     // After the fix this transaction is simply a transfer of 0 ETH to the zero address
     context.block_height = ZERO_ADDRESS_FIX_HEIGHT;
-    let result = runner.submit_raw(utils::SUBMIT, &context, &[]).unwrap();
+    let result = runner
+        .submit_raw(utils::SUBMIT, &context, &[], None)
+        .unwrap();
     assert_eq!(result.gas_used, 21_000);
     runner.env.block_height = ZERO_ADDRESS_FIX_HEIGHT + 1;
     assert_eq!(runner.get_nonce(&address), U256::one());

--- a/engine-tests/src/tests/standalone/storage.rs
+++ b/engine-tests/src/tests/standalone/storage.rs
@@ -273,6 +273,7 @@ fn test_transaction_index() {
         transaction: TransactionKind::Unknown,
         promise_data: Vec::new(),
         raw_input: Vec::new(),
+        action_hash: H256::default(),
     };
     let tx_included = engine_standalone_storage::TransactionIncluded {
         block_hash,

--- a/engine-tests/src/tests/standalone/sync.rs
+++ b/engine-tests/src/tests/standalone/sync.rs
@@ -64,6 +64,7 @@ fn test_consume_deposit_message() {
         transaction: tx_kind,
         promise_data: Vec::new(),
         raw_input,
+        action_hash: H256::default(),
     };
 
     let outcome = sync::consume_message::<AuroraModExp>(
@@ -102,6 +103,7 @@ fn test_consume_deposit_message() {
         // (which is `true` because the proof is valid in this case).
         promise_data: vec![Some(true.try_to_vec().unwrap())],
         raw_input,
+        action_hash: H256::default(),
     };
 
     let outcome = sync::consume_message::<AuroraModExp>(
@@ -136,6 +138,7 @@ fn test_consume_deposit_message() {
         transaction: tx_kind,
         promise_data: Vec::new(),
         raw_input,
+        action_hash: H256::default(),
     };
 
     let outcome = sync::consume_message::<AuroraModExp>(
@@ -170,6 +173,7 @@ fn test_consume_deploy_message() {
         transaction: tx_kind,
         promise_data: Vec::new(),
         raw_input,
+        action_hash: H256::default(),
     };
 
     let outcome = sync::consume_message::<AuroraModExp>(
@@ -226,6 +230,7 @@ fn test_consume_deploy_erc20_message() {
         transaction: tx_kind,
         promise_data: Vec::new(),
         raw_input,
+        action_hash: H256::default(),
     };
 
     // Deploy ERC-20 (this would be the flow for bridging a new NEP-141 to Aurora)
@@ -268,6 +273,7 @@ fn test_consume_deploy_erc20_message() {
         transaction: tx_kind,
         promise_data: Vec::new(),
         raw_input,
+        action_hash: H256::default(),
     };
 
     // Mint new tokens (via ft_on_transfer flow, same as the bridge)
@@ -334,6 +340,7 @@ fn test_consume_ft_on_transfer_message() {
         transaction: tx_kind,
         promise_data: Vec::new(),
         raw_input,
+        action_hash: H256::default(),
     };
 
     let outcome = sync::consume_message::<AuroraModExp>(
@@ -382,6 +389,7 @@ fn test_consume_call_message() {
         transaction: tx_kind,
         promise_data: Vec::new(),
         raw_input,
+        action_hash: H256::default(),
     };
 
     let outcome = sync::consume_message::<AuroraModExp>(
@@ -436,6 +444,7 @@ fn test_consume_submit_message() {
         transaction: tx_kind,
         promise_data: Vec::new(),
         raw_input,
+        action_hash: H256::default(),
     };
 
     let outcome = sync::consume_message::<AuroraModExp>(

--- a/engine-tests/src/tests/standalone/tracing.rs
+++ b/engine-tests/src/tests/standalone/tracing.rs
@@ -73,6 +73,7 @@ fn test_evm_tracing_with_storage() {
             transaction: engine_standalone_storage::sync::types::TransactionKind::Unknown,
             promise_data: Vec::new(),
             raw_input: Vec::new(),
+            action_hash: H256::default(),
         },
         diff,
         maybe_result: Ok(None),

--- a/engine-tests/src/utils/mod.rs
+++ b/engine-tests/src/utils/mod.rs
@@ -98,6 +98,12 @@ pub struct AuroraRunner {
     // Empty by default. Can be set in tests if the transaction should be
     // executed as if it was a callback.
     pub promise_results: Vec<PromiseResult>,
+    // None by default. Can be set if the transaction requires randomness
+    // from the Near runtime.
+    // Note: this only sets the random value for the block, the random
+    // value available in the runtime is derived from this value and
+    // another hash that depends on the transaction itself.
+    pub block_random_value: Option<H256>,
 }
 
 /// Same as `AuroraRunner`, but consumes `self` on execution (thus preventing building on
@@ -234,7 +240,12 @@ impl AuroraRunner {
         self.previous_logs = outcome.logs.clone();
 
         if let Some(standalone_runner) = &mut self.standalone_runner {
-            standalone_runner.submit_raw(method_name, &self.context, &self.promise_results)?;
+            standalone_runner.submit_raw(
+                method_name,
+                &self.context,
+                &self.promise_results,
+                self.block_random_value,
+            )?;
             self.validate_standalone();
         }
 
@@ -539,8 +550,8 @@ impl AuroraRunner {
         outcome.return_data.as_value().unwrap()
     }
 
-    pub fn with_random_seed(mut self, random_seed: H256) -> Self {
-        self.context.random_seed = random_seed.as_bytes().to_vec();
+    pub const fn with_block_random_value(mut self, random_seed: H256) -> Self {
+        self.block_random_value = Some(random_seed);
         self
     }
 
@@ -645,6 +656,7 @@ impl Default for AuroraRunner {
             previous_logs: Vec::new(),
             standalone_runner: Some(standalone::StandaloneRunner::default()),
             promise_results: Vec::new(),
+            block_random_value: None,
         }
     }
 }


### PR DESCRIPTION
## Description

The Near runtime has a random value available to smart contracts via a cost function. Aurora exposes that random value to EVM smart contracts in two ways: (1) via a custom precompile, and (2) via [EVM opcode 0x44](https://www.evm.codes/#44?fork=shanghai) since it was changed from `DIFFICULTY` to `PREVRANDAO` after the merge. Therefore it is important for the standalone engine to be able to correctly provide the same random value as would be present on-chain.

In this PR I fix the standalone engine to be able to correctly reproduce the Near runtime random value based on the implementation present in nearcore. There will also be a follow-up PR to `borealis-engine-lib` to make use of this change in the Borealis Engine there.

The random value is computed as `sha256(block_random_value || action_hash)` where the `block_random_value` comes from the protocol-level VRF (this was the value which previously we were using directly) and the `action_hash` is derived from the (`FunctionCall`) `Action` that is being executed in the Near runtime. To have the `action_hash` available to the standalone engine I am adding a new field to `TransactionMessage` which stores this value.

In the tests the `action_hash` field is populated in a reasonable way, but not exactly as it would be in nearcore because there is no actual `Action` (we skip straight to the Wasm execution). However, in the follow-up PR in `borealis-engine-lib` the field will be populated from the Near data. Once this change is made, it will fix a bug in Borealis Engine where it was not correctly reproducing the execution of contracts involving randomness.

## Performance / NEAR gas cost considerations

N/A : change is to standalone engine only.

## Testing

The test for the random precompile has been updated to reflect this change. A test related to tracing is also changed to no longer depend on the randomness precompile because the test did not rely on the specifics of which precompile was used and now using randomness in the tests has extra setup steps.