### PR TITLE
Fix(xcc): Ensure near_withdraw comes after ft_transfer

### DIFF
--- a/engine-standalone-storage/src/sync/mod.rs
+++ b/engine-standalone-storage/src/sync/mod.rs
@@ -189,6 +189,10 @@ pub fn parse_transaction_kind(
             })?;
             TransactionKind::FactorySetWNearAddress(address)
         }
+        TransactionKindTag::WithdrawWnearToRouter => {
+            let args = xcc::WithdrawWnearToRouterArgs::try_from_slice(&bytes).map_err(f)?;
+            TransactionKind::WithdrawWnearToRouter(args)
+        }
         TransactionKindTag::SetUpgradeDelayBlocks => {
             let args = parameters::SetUpgradeDelayBlocksArgs::try_from_slice(&bytes).map_err(f)?;
             TransactionKind::SetUpgradeDelayBlocks(args)
@@ -643,6 +647,12 @@ fn non_submit_execute<I: IO + Copy>(
             contract_methods::xcc::fund_xcc_sub_account(io, env, &mut handler)?;
 
             None
+        }
+        TransactionKind::WithdrawWnearToRouter(_) => {
+            let mut handler = crate::promise::NoScheduler { promise_data };
+            let result = contract_methods::xcc::withdraw_wnear_to_router(io, env, &mut handler)?;
+
+            Some(TransactionExecutionResult::Submit(Ok(result)))
         }
         TransactionKind::Unknown => None,
         // Not handled in this function; is handled by the general `execute_transaction` function

--- a/engine-types/src/parameters/xcc.rs
+++ b/engine-types/src/parameters/xcc.rs
@@ -1,6 +1,6 @@
 use crate::account_id::AccountId;
 use crate::borsh::{self, BorshDeserialize, BorshSerialize};
-use crate::types::Address;
+use crate::types::{Address, Yocto};
 
 #[derive(Debug, Clone, PartialEq, Eq, BorshDeserialize, BorshSerialize)]
 pub struct AddressVersionUpdateArgs {
@@ -12,6 +12,12 @@ pub struct AddressVersionUpdateArgs {
 pub struct FundXccArgs {
     pub target: Address,
     pub wnear_account_id: Option<AccountId>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshDeserialize, BorshSerialize)]
+pub struct WithdrawWnearToRouterArgs {
+    pub target: Address,
+    pub amount: Yocto,
 }
 
 /// Type wrapper for version of router contracts.

--- a/engine/src/contract_methods/evm_transactions.rs
+++ b/engine/src/contract_methods/evm_transactions.rs
@@ -56,17 +56,6 @@ pub fn call<I: IO + Copy, E: Env, H: PromiseHandler>(
         let current_account_id = env.current_account_id();
         let predecessor_account_id = env.predecessor_account_id();
 
-        // During the XCC flow the Engine will call itself to move wNEAR
-        // to the user's sub-account. We do not want this move to happen
-        // if prior promises in the flow have failed.
-        if current_account_id == predecessor_account_id {
-            let check_promise: Result<(), &[u8]> = match handler.promise_result_check() {
-                Some(true) | None => Ok(()),
-                Some(false) => Err(b"ERR_CALLBACK_OF_FAILED_PROMISE"),
-            };
-            check_promise?;
-        }
-
         let mut engine: Engine<_, E, AuroraModExp> = Engine::new_with_state(
             state,
             predecessor_address(&predecessor_account_id),

--- a/engine/src/contract_methods/xcc.rs
+++ b/engine/src/contract_methods/xcc.rs
@@ -30,11 +30,9 @@ pub fn withdraw_wnear_to_router<I: IO + Copy, E: Env, H: PromiseHandler>(
         let state = state::get_state(&io)?;
         require_running(&state)?;
         env.assert_private_call()?;
-        let check_promise: Result<(), &[u8]> = match handler.promise_result_check() {
-            Some(true) | None => Ok(()),
-            Some(false) => Err(b"ERR_CALLBACK_OF_FAILED_PROMISE"),
-        };
-        check_promise?;
+        if matches!(handler.promise_result_check(), Some(false)) {
+            return Err(b"ERR_CALLBACK_OF_FAILED_PROMISE".into());
+        }
         let args: WithdrawWnearToRouterArgs = io.read_input_borsh()?;
         let current_account_id = env.current_account_id();
         let recipient = AccountId::new(&format!(

--- a/engine/src/contract_methods/xcc.rs
+++ b/engine/src/contract_methods/xcc.rs
@@ -2,7 +2,7 @@ use crate::{
     contract_methods::{predecessor_address, require_owner_only, require_running, ContractError},
     engine::Engine,
     errors,
-    hashchain::with_hashchain,
+    hashchain::{with_hashchain, with_logs_hashchain},
     state, xcc,
 };
 use aurora_engine_modexp::AuroraModExp;
@@ -12,8 +12,11 @@ use aurora_engine_sdk::{
     promise::PromiseHandler,
 };
 use aurora_engine_types::{
-    account_id::AccountId, borsh::BorshSerialize, format,
-    parameters::xcc::WithdrawWnearToRouterArgs, types::Address,
+    account_id::AccountId,
+    borsh::BorshSerialize,
+    format,
+    parameters::{engine::SubmitResult, xcc::WithdrawWnearToRouterArgs},
+    types::Address,
 };
 use function_name::named;
 
@@ -22,8 +25,8 @@ pub fn withdraw_wnear_to_router<I: IO + Copy, E: Env, H: PromiseHandler>(
     io: I,
     env: &E,
     handler: &mut H,
-) -> Result<(), ContractError> {
-    with_hashchain(io, env, function_name!(), |io| {
+) -> Result<SubmitResult, ContractError> {
+    with_logs_hashchain(io, env, function_name!(), |io| {
         let state = state::get_state(&io)?;
         require_running(&state)?;
         env.assert_private_call()?;
@@ -59,7 +62,7 @@ pub fn withdraw_wnear_to_router<I: IO + Copy, E: Env, H: PromiseHandler>(
         }
         let id = ids.last().ok_or(b"ERR_NO_PROMISE_CREATED")?;
         handler.promise_return(*id);
-        Ok(())
+        Ok(result)
     })
 }
 

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -388,6 +388,19 @@ mod contract {
             .sdk_unwrap();
     }
 
+    /// A private function (only callable by the contract itself) used as part of the XCC flow.
+    /// This function uses the exit to Near precompile to move wNear from Aurora to a user's
+    /// XCC account.
+    #[no_mangle]
+    pub extern "C" fn withdraw_wnear_to_router() {
+        let io = Runtime;
+        let env = Runtime;
+        let mut handler = Runtime;
+        contract_methods::xcc::withdraw_wnear_to_router(io, &env, &mut handler)
+            .map_err(ContractError::msg)
+            .sdk_unwrap();
+    }
+
     /// Mirror existing ERC-20 token on the main Aurora contract.
     /// Notice: It works if the SILO mode is on.
     #[no_mangle]

--- a/engine/src/xcc.rs
+++ b/engine/src/xcc.rs
@@ -345,13 +345,22 @@ pub fn withdraw_wnear_to_router<I: IO + Copy, E: Env, M: ModExpAlgorithm, H: Pro
     handler: &mut H,
 ) -> EngineResult<(SubmitResult, Vec<PromiseId>)> {
     let mut interceptor = PromiseInterceptor::new(handler);
-    let withdraw_call_args = CallArgs::V2(FunctionCallArgsV2 {
+    let withdraw_call_args = withdraw_wnear_call_args(recipient, amount, wnear_address);
+    let result = engine.call_with_args(withdraw_call_args, &mut interceptor)?;
+    Ok((result, interceptor.promises))
+}
+
+#[must_use]
+pub fn withdraw_wnear_call_args(
+    recipient: &AccountId,
+    amount: Yocto,
+    wnear_address: Address,
+) -> CallArgs {
+    CallArgs::V2(FunctionCallArgsV2 {
         contract: wnear_address,
         value: [0u8; 32],
         input: withdraw_to_near_args(recipient, amount),
-    });
-    let result = engine.call_with_args(withdraw_call_args, &mut interceptor)?;
-    Ok((result, interceptor.promises))
+    })
 }
 
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
## Description

The XCC feature was designed to allow users to spend their own wNEAR ERC-20 tokens on Aurora in Near native interaction as if it were the base token. This works by bridging the wNEAR from Aurora out to the user's XCC account, then unwrapping it. The Rainbow bridge team noticed an issue where it is possible for the `wrap.near:withdraw_near` promise to resolve before the `wrap.near:ft_transfer` promise. This causes the XCC flow to fail if the user's XCC account does not carry a wNEAR balance because we attempt to withdraw tokens we don't yet have.

This PR aims to solve that issue. To see why this fix works, we need to know why the issue happens in the first place. The problem is the XCC flow used to use the `call` entry point to trigger the exit to Near function on the wNEAR ERC-20 token. That function invokes the exit to Near precompile which creates a promise to transfer the corresponding NEP-141 token from `aurora` to the destination account. However, that promise is not returned from `call` because instead it must return the EVM `SubmitResult` (the normal use-case for `call` is simply to invoke the EVM).

By not returning the `ft_transfer` promise, it is disconnected from the subsequent execution graph and therefore Near does not make any guarantees about when it will resolve relative to other promises the execution will create. Under normal (non-congested) conditions, the `ft_transfer` does resolve first because there is one block before the `wrap.near:withdraw_near` call is created (since after `aurora:call` comes `xcc_router:unwrap_and_refund_storage` which then makes the withdraw call). However, if the shard containing `wrap.near` is congested then the `ft_transfer` call can delayed by one block and then need to execute in the same block as `near_withdraw`, resulting in a 50% chance of failure.

Therefore, to fix the issue we must make sure the promise from the exit precompile is given as the return value of the call in the XCC flow to make sure it stays connected with the rest of the execution graph. Doing this will ensure `wrap.near:ft_transfer` resolves before `xcc_router:unwrap_and_refund_storage` is allowed to execute.

To that end, in this PR I introduce a new private function called `withdraw_wnear_to_router`. The only purpose of this function is to make the call to the exit precompile while capturing its promise  and then return that promise. With that context, this change should be pretty easy to follow. The new function is defined in `contract_methods::xcc`, and that logic is applied in both `lib.rs` and the standalone engine.

## Performance / NEAR gas cost considerations

All costs should remain unchanged. The same work is done, just in a different method to allow the promise return.

## Testing

The bug described above only occurs under congested conditions, so I do not know how to write a good test for it in near-workspaces. I am relying on the existing XCC tests to at least be sure this change does not break the feature.
