### PR TITLE
Fix panic in ExitToNear

### DIFF
--- a/engine-precompiles/src/native.rs
+++ b/engine-precompiles/src/native.rs
@@ -349,7 +349,7 @@ impl<I: IO> Precompile for ExitToNear<I> {
         // First byte of the input is a flag, selecting the behavior to be triggered:
         //      0x0 -> Eth transfer
         //      0x1 -> Erc20 transfer
-        let flag = input[0];
+        let flag = input.first().copied().unwrap_or_default();
         #[cfg(feature = "error_refund")]
         let (refund_address, mut input) = parse_input(input)?;
         #[cfg(not(feature = "error_refund"))]


### PR DESCRIPTION
## Description

If `input` is empty a panic occurs. This PR sets `flag` to the default value in that case.

## Performance / NEAR gas cost considerations

## Testing

Fuzzing.

## How should this be reviewed

Ensure that `flag` assuming the default value if `input` is empty is the intended behavior.

## Additional information