### PR TITLE
Feat: Exit and XCC promises are sequential

### DIFF
--- a/engine-sdk/src/promise.rs
+++ b/engine-sdk/src/promise.rs
@@ -51,6 +51,16 @@ pub trait PromiseHandler {
     /// code or adding/removing access keys.
     unsafe fn promise_create_batch(&mut self, args: &PromiseBatchAction) -> PromiseId;
 
+    /// # Safety
+    /// See note on `promise_create_call`. Promise batches in particular must be used very
+    /// carefully because they can take destructive actions such as deploying new contract
+    /// code or adding/removing access keys.
+    unsafe fn promise_attach_batch_callback(
+        &mut self,
+        base: PromiseId,
+        args: &PromiseBatchAction,
+    ) -> PromiseId;
+
     fn promise_return(&mut self, promise: PromiseId);
 
     /// # Safety
@@ -129,6 +139,14 @@ impl PromiseHandler for Noop {
     }
 
     unsafe fn promise_create_batch(&mut self, _args: &PromiseBatchAction) -> PromiseId {
+        PromiseId::new(0)
+    }
+
+    unsafe fn promise_attach_batch_callback(
+        &mut self,
+        _base: PromiseId,
+        _args: &PromiseBatchAction,
+    ) -> PromiseId {
         PromiseId::new(0)
     }
 

--- a/engine-standalone-storage/src/promise.rs
+++ b/engine-standalone-storage/src/promise.rs
@@ -53,6 +53,14 @@ impl<'a> PromiseHandler for NoScheduler<'a> {
         PromiseId::new(0)
     }
 
+    unsafe fn promise_attach_batch_callback(
+        &mut self,
+        _base: PromiseId,
+        _args: &PromiseBatchAction,
+    ) -> PromiseId {
+        PromiseId::new(0)
+    }
+
     fn promise_return(&mut self, _promise: PromiseId) {}
 
     fn read_only(&self) -> Self::ReadOnly {

--- a/engine/src/xcc.rs
+++ b/engine/src/xcc.rs
@@ -520,6 +520,16 @@ impl<'a, H: PromiseHandler> PromiseHandler for PromiseInterceptor<'a, H> {
         id
     }
 
+    unsafe fn promise_attach_batch_callback(
+        &mut self,
+        base: PromiseId,
+        args: &PromiseBatchAction,
+    ) -> PromiseId {
+        let id = self.inner.promise_attach_batch_callback(base, args);
+        self.promises.push(id);
+        id
+    }
+
     fn promise_return(&mut self, promise: PromiseId) {
         self.inner.promise_return(promise);
     }


### PR DESCRIPTION
## Description

This PR is addressing a [usability issue with XCC](https://github.com/aurora-is-near/aurora-contracts-sdk/pull/13#discussion_r1329912329) brought up by @karim-en .

It is somewhat common that XCC requires tokens to be bridged from the user's Aurora address to their XCC account on Near. Naturally, this bridging needs to happen before the XCC promise resolves so that the tokens are available for it to use. However, due to the async nature of Near we could not guarantee that the bridging would happen before the XCC call.

In this PR we change how the Engine produces promises so that they are sequential instead of concurrent (i.e. all the promises produced by the EVM are connected by the `then` combinator, in the order they were produced during the EVM execution). This means a contract which calls the exit precompile and then later calls XCC will have the promises happen in that same order, as the developer intended.

## Performance / NEAR gas cost considerations

N/A

## Testing

Existing XCC tests