### PR TITLE
Fix(xcc): Store the first upgradable XCC version in state

### DIFF
--- a/engine-types/src/parameters/xcc.rs
+++ b/engine-types/src/parameters/xcc.rs
@@ -27,7 +27,7 @@ pub struct WithdrawWnearToRouterArgs {
 pub struct CodeVersion(pub u32);
 
 impl CodeVersion {
-    pub const ONE: Self = Self(1);
+    pub const ZERO: Self = Self(0);
 
     #[must_use]
     pub const fn increment(self) -> Self {


### PR DESCRIPTION
## Description

In #866 I introduced a change to the XCC router where the contract became upgradable. In that PR I hardcoded that any XCC Router that was version 1 could not be upgraded, however this logic did not work on testnet where the XCC Router code had already been set twice, so it was actually version 3 which became the first upgradable version.

In this PR I add a new key to the engine which stores the first upgradable XCC version so that it does not need to be hardcoded. This should allow the logic to work properly on both testnet and mainnet.

## Performance / NEAR gas cost considerations

N/A

## Testing

Existing tests + testnet deployment (manual test)