### PR TITLE
fix: use parity-secp256k1 crate from github

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
             etc/eth-contracts
             etc/tests/uniswap
       - name: Install dependencies
-        run: cargo make -V || cargo install cargo-make
+        run: cargo +stable make -V || cargo +stable install cargo-make
       - name: Build main contract
         run: |
           case ${{ matrix.profile }} in
@@ -80,7 +80,7 @@ jobs:
             target/
           key: ${{ matrix.profile }}-cargo-modexp-test
       - name: Install dependencies
-        run: cargo make -V || cargo install cargo-make
+        run: cargo +stable make -V || cargo +stable install cargo-make
       - name: Test ${{ matrix.profile }} bench-modexp
         run: cargo make --profile ${{ matrix.profile }} bench-modexp
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3928,8 +3928,7 @@ dependencies = [
 [[package]]
 name = "parity-secp256k1"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fca4f82fccae37e8bbdaeb949a4a218a1bbc485d11598f193d2a908042e5fc1"
+source = "git+https://github.com/paritytech/rust-secp256k1?rev=d05fd8e#d05fd8e152f8d110b587906e3d854196b086e42a"
 dependencies = [
  "arrayvec 0.5.2",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,9 @@ test-case = "3.1"
 walrus = "0.20"
 wee_alloc = { version = "0.4", default-features = false }
 
+[patch.crates-io]
+parity-secp256k1 = { git = 'https://github.com/paritytech/rust-secp256k1', rev = "d05fd8e" }
+
 [workspace]
 resolver = "2"
 members = [

--- a/etc/tests/fibonacci/Cargo.toml
+++ b/etc/tests/fibonacci/Cargo.toml
@@ -17,3 +17,6 @@ panic = "abort"
 [dependencies]
 near-sdk = "4.1"
 serde = "1"
+
+[patch.crates-io]
+parity-secp256k1 = { git = 'https://github.com/paritytech/rust-secp256k1', rev = "d05fd8e" }

--- a/etc/tests/ft-receiver/Cargo.toml
+++ b/etc/tests/ft-receiver/Cargo.toml
@@ -10,3 +10,6 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 near-sdk = "4.1"
 near-contract-standards = "4.1"
+
+[patch.crates-io]
+parity-secp256k1 = { git = 'https://github.com/paritytech/rust-secp256k1', rev = "d05fd8e" }

--- a/etc/tests/modexp-bench/Cargo.toml
+++ b/etc/tests/modexp-bench/Cargo.toml
@@ -18,3 +18,6 @@ panic = "abort"
 aurora-engine-modexp = { path = "../../../engine-modexp", default-features = false, features = ["bench", "std"] }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 near-sdk = "4.1"
+
+[patch.crates-io]
+parity-secp256k1 = { git = 'https://github.com/paritytech/rust-secp256k1', rev = "d05fd8e" }

--- a/etc/xcc-router/Cargo.toml
+++ b/etc/xcc-router/Cargo.toml
@@ -18,6 +18,9 @@ panic = "abort"
 aurora-engine-types = { path = "../../engine-types", default-features = false, features = ["borsh-compat"] }
 near-sdk = "4.1"
 
+[patch.crates-io]
+parity-secp256k1 = { git = 'https://github.com/paritytech/rust-secp256k1', rev = "d05fd8e" }
+
 [features]
 default = []
 all-promise-actions = []


### PR DESCRIPTION
The PR fixes building by replacing the usage of the `parity-secp256k1` crate from crates.io to github.