### PR TITLE
fix: do not require running contract in ft_resolve_transfer

### DIFF
--- a/engine/src/contract_methods/connector/internal.rs
+++ b/engine/src/contract_methods/connector/internal.rs
@@ -249,8 +249,6 @@ pub fn ft_resolve_transfer<I: IO + Copy, E: Env, H: PromiseHandler>(
     handler: &H,
 ) -> Result<(), ContractError> {
     with_hashchain(io, env, function_name!(), |io| {
-        require_running(&state::get_state(&io)?)?;
-
         env.assert_private_call()?;
         if handler.promise_results_count() != 1 {
             return Err(crate::errors::ERR_PROMISE_COUNT.into());


### PR DESCRIPTION
## Description

AuditOne has announced the [issue](https://github.com/AuditOneAuditReviews/AuroraEngine-Audit-Review/issues/18) in terms of migrating data before splitting the etc-connector logic. 

## Performance / NEAR gas cost considerations

No changes in performance.

## Testing

The test for that doesn't look trivial. 
