### PR TITLE
chore: bump borsh to 1.3.0 and remove borsh-compat feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1329,9 +1329,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.2"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
+checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -61,7 +61,7 @@ checksum = "7c7db3d5a9718568e4cf4a537cfd7070e6e6ff7481510d0237fb529ac850f6d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -81,9 +81,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aes"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if 1.0.0",
  "cipher 0.4.4",
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
  "getrandom 0.2.12",
  "once_cell",
@@ -103,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.7"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+checksum = "d713b3834d76b85304d4d525563c1276e2e30dc97cc67bfb4585a4a29fc2c89f"
 dependencies = [
  "cfg-if 1.0.0",
  "once_cell",
@@ -145,9 +145,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
+checksum = "96b09b5178381e0874812a9b157f7fe84982617e48f71f4e3235482775e5b540"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "arbitrary"
@@ -211,12 +211,6 @@ name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
-
-[[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
@@ -249,7 +243,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -260,7 +254,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -374,7 +368,7 @@ dependencies = [
  "aurora-engine-transactions",
  "aurora-engine-types",
  "aurora-engine-workspace",
- "borsh 0.10.3",
+ "borsh 1.3.1",
  "bstr",
  "byte-slice-cast",
  "criterion",
@@ -387,10 +381,10 @@ dependencies = [
  "git2",
  "hex",
  "libsecp256k1",
- "near-crypto 0.20.1",
+ "near-crypto",
  "near-parameters",
- "near-primitives 0.20.1",
- "near-primitives-core 0.20.1",
+ "near-primitives",
+ "near-primitives-core",
  "near-sdk",
  "near-vm-runner",
  "rand 0.8.5",
@@ -440,8 +434,7 @@ name = "aurora-engine-types"
 version = "1.0.0"
 dependencies = [
  "base64 0.21.7",
- "borsh 0.10.3",
- "borsh 0.9.3",
+ "borsh 1.3.1",
  "bs58 0.5.0",
  "hex",
  "primitive-types 0.12.2",
@@ -475,7 +468,7 @@ checksum = "823b8bb275161044e2ac7a25879cb3e2480cb403e3943022c7c769c599b756aa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -498,12 +491,6 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
-
-[[package]]
-name = "base64"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
 name = "base64"
@@ -568,7 +555,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -585,26 +572,14 @@ checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "bitvec"
-version = "0.20.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
-dependencies = [
- "funty 1.1.0",
- "radium 0.6.2",
- "tap",
- "wyz 0.2.0",
-]
-
-[[package]]
-name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
- "funty 2.0.0",
- "radium 0.7.0",
+ "funty",
+ "radium",
  "tap",
- "wyz 0.5.1",
+ "wyz",
 ]
 
 [[package]]
@@ -648,16 +623,6 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
-dependencies = [
- "borsh-derive 0.10.3",
- "hashbrown 0.13.2",
-]
-
-[[package]]
-name = "borsh"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f58b559fd6448c6e2fd0adb5720cd98a2506594cafa4737ff98c396f3e82f667"
@@ -672,21 +637,8 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6441c552f230375d18e3cc377677914d2ca2b0d36e52129fe15450a2dce46775"
 dependencies = [
- "borsh-derive-internal 0.9.3",
- "borsh-schema-derive-internal 0.9.3",
- "proc-macro-crate 0.1.5",
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0754613691538d51f329cce9af41d7b7ca150bc973056f1156611489475f54f7"
-dependencies = [
- "borsh-derive-internal 0.10.3",
- "borsh-schema-derive-internal 0.10.3",
+ "borsh-derive-internal",
+ "borsh-schema-derive-internal",
  "proc-macro-crate 0.1.5",
  "proc-macro2",
  "syn 1.0.109",
@@ -702,7 +654,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
  "syn_derive",
 ]
 
@@ -711,17 +663,6 @@ name = "borsh-derive-internal"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-derive-internal"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb438156919598d2c7bad7e1c0adf3d26ed3840dbc010db1a882a65583ca2fb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -740,23 +681,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "borsh-schema-derive-internal"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634205cc43f74a1b9046ef87c4540ebda95696ec0f315024860cad7c5b0f5ccd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "brownstone"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "030ea61398f34f1395ccbeb046fb68c87b631d1f34567fed0f0f11fa35d18d8d"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec",
 ]
 
 [[package]]
@@ -788,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
 
 [[package]]
 name = "byte-slice-cast"
@@ -908,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceed8ef69d8518a5dda55c07425450b58a4e1946f4951eab6d7191ee86c2443d"
+checksum = "694c8807f2ae16faecc43dc17d74b3eb042482789fd0eb64b39a2e04e087053f"
 dependencies = [
  "serde",
 ]
@@ -936,11 +866,10 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "7f9fa1897e4325be0d68d48df6aa1a71ac2ed4d27723887e7754192705350730"
 dependencies = [
- "jobserver",
  "libc",
 ]
 
@@ -973,9 +902,9 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
+checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -983,7 +912,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.0",
+ "windows-targets 0.52.3",
 ]
 
 [[package]]
@@ -1055,31 +984,31 @@ dependencies = [
  "clap_lex 0.2.4",
  "indexmap 1.9.3",
  "once_cell",
- "strsim",
+ "strsim 0.10.0",
  "termcolor",
  "textwrap",
 ]
 
 [[package]]
 name = "clap"
-version = "4.4.18"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+checksum = "c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da"
 dependencies = [
  "clap_builder",
- "clap_derive 4.4.7",
+ "clap_derive 4.5.0",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.4.18"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+checksum = "9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 0.6.0",
- "strsim",
+ "clap_lex 0.7.0",
+ "strsim 0.11.0",
 ]
 
 [[package]]
@@ -1097,14 +1026,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -1118,9 +1047,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "colorchoice"
@@ -1295,9 +1224,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1311,7 +1240,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.4.18",
+ "clap 4.5.1",
  "criterion-plot",
  "is-terminal",
  "itertools",
@@ -1400,22 +1329,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.1"
+version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
-dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.5.1",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
+checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -1437,14 +1353,14 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
 name = "darling"
-version = "0.20.5"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc5d6b04b3fd0ba9926f945895de7d806260a2d7431ba82e7edaecb043c4c6b8"
+checksum = "3a5d17510e4a1a87f323de70b7b1eaac1ee0e37866c6720b2d279452d0edf389"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1452,27 +1368,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.5"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e48a959bcd5c761246f5d090ebc2fbf7b9cd527a492b07a67510c108f1e7e3"
+checksum = "a98eea36a7ff910fa751413d0895551143a8ea41d695d9798ec7d665df7f7f5e"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
- "syn 2.0.48",
+ "strsim 0.10.0",
+ "syn 2.0.50",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.5"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1545d67a2149e1d93b7e5c7752dce5a7426eb5d1357ddcfd89336b94444f77"
+checksum = "d6a366a3f90c5d59a4b91169775f88e52e8f71a0e7804cc98a8db2932cf4ed57"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -1511,7 +1427,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -1620,34 +1536,11 @@ checksum = "53aff6fdc1b181225acdcb5b14c47106726fd8e486707315b1b138baed68ee31"
 
 [[package]]
 name = "ed25519"
-version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
-dependencies = [
- "signature 1.6.4",
-]
-
-[[package]]
-name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "signature 2.2.0",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
-dependencies = [
- "curve25519-dalek 3.2.1",
- "ed25519 1.5.3",
- "rand 0.7.3",
- "serde",
- "sha2 0.9.9",
- "zeroize",
+ "signature",
 ]
 
 [[package]]
@@ -1656,8 +1549,8 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
- "curve25519-dalek 4.1.1",
- "ed25519 2.2.3",
+ "curve25519-dalek",
+ "ed25519",
  "rand_core 0.6.4",
  "sha2 0.10.8",
  "subtle",
@@ -1665,9 +1558,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "elementtree"
@@ -1704,7 +1597,7 @@ dependencies = [
  "rocksdb",
  "serde",
  "serde_json",
- "strum 0.25.0",
+ "strum 0.26.1",
 ]
 
 [[package]]
@@ -1737,7 +1630,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -1758,7 +1651,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -1821,7 +1714,7 @@ checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
 dependencies = [
  "crunchy",
  "fixed-hash 0.8.0",
- "impl-codec 0.6.0",
+ "impl-codec",
  "impl-rlp",
  "impl-serde",
  "scale-info",
@@ -1838,7 +1731,7 @@ dependencies = [
  "ethereum-types",
  "hash-db",
  "hash256-std-hasher",
- "parity-scale-codec 3.6.9",
+ "parity-scale-codec",
  "rlp",
  "scale-info",
  "serde",
@@ -1854,7 +1747,7 @@ checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
 dependencies = [
  "ethbloom",
  "fixed-hash 0.8.0",
- "impl-codec 0.6.0",
+ "impl-codec",
  "impl-rlp",
  "impl-serde",
  "primitive-types 0.12.2",
@@ -1874,7 +1767,7 @@ dependencies = [
  "evm-gasometer",
  "evm-runtime",
  "log",
- "parity-scale-codec 3.6.9",
+ "parity-scale-codec",
  "primitive-types 0.12.2",
  "rlp",
  "scale-info",
@@ -1887,7 +1780,7 @@ name = "evm-core"
 version = "0.39.1"
 source = "git+https://github.com/aurora-is-near/sputnikvm.git?tag=v0.39.1#0334a09d6b6e83ff3a8da992e33f29ba95e0c9fe"
 dependencies = [
- "parity-scale-codec 3.6.9",
+ "parity-scale-codec",
  "primitive-types 0.12.2",
  "scale-info",
  "serde",
@@ -1958,7 +1851,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d81b511929c2669eaf64e36471cf27c2508133e62ade9d49e608e8d675e7854"
 dependencies = [
- "bitvec 1.0.1",
+ "bitvec",
  "dissimilar",
  "num-traits",
  "prefix-sum-vec",
@@ -1980,9 +1873,6 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
 dependencies = [
- "byteorder",
- "rand 0.8.5",
- "rustc-hex",
  "static_assertions",
 ]
 
@@ -2071,12 +1961,6 @@ checksum = "673464e1e314dd67a0fd9544abc99e8eb28d0c7e3b69b033bcff9b2d00b87333"
 
 [[package]]
 name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
-
-[[package]]
-name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
@@ -2136,7 +2020,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -2241,7 +2125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 dependencies = [
  "fallible-iterator 0.3.0",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "stable_deref_trait",
 ]
 
@@ -2289,7 +2173,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "slab",
  "tokio",
  "tokio-util 0.7.10",
@@ -2327,7 +2211,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash 0.7.7",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -2336,7 +2220,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.7",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -2345,7 +2229,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.7",
+ "ahash 0.8.9",
 ]
 
 [[package]]
@@ -2354,7 +2238,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "ahash 0.8.7",
+ "ahash 0.8.9",
 ]
 
 [[package]]
@@ -2383,9 +2267,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
+checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
 
 [[package]]
 name = "hex"
@@ -2492,7 +2376,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.5",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2582,20 +2466,11 @@ dependencies = [
 
 [[package]]
 name = "impl-codec"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161ebdfec3c8e3b52bf61c4f3550a1eea4f9579d10dc1b936f3171ebdcd6c443"
-dependencies = [
- "parity-scale-codec 2.3.1",
-]
-
-[[package]]
-name = "impl-codec"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
 dependencies = [
- "parity-scale-codec 3.6.9",
+ "parity-scale-codec",
 ]
 
 [[package]]
@@ -2646,9 +2521,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.2"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -2672,12 +2547,12 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
- "hermit-abi 0.3.5",
- "rustix",
+ "hermit-abi 0.3.6",
+ "libc",
  "windows-sys 0.52.0",
 ]
 
@@ -2704,15 +2579,6 @@ name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
-
-[[package]]
-name = "jobserver"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "joinery"
@@ -3111,26 +2977,6 @@ dependencies = [
 
 [[package]]
 name = "near-account-id"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d258582a1878e6db67400b0504a5099db85718d22c2e07f747fe1706ae7150"
-dependencies = [
- "borsh 0.9.3",
- "serde",
-]
-
-[[package]]
-name = "near-account-id"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0cb40869cab7f5232f934f45db35bffe0f2d2a7cb0cd0346202fbe4ebf2dd7"
-dependencies = [
- "borsh 0.10.3",
- "serde",
-]
-
-[[package]]
-name = "near-account-id"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35cbb989542587b47205e608324ddd391f0cee1c22b4b64ae49f458334b95907"
@@ -3141,35 +2987,24 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "0.17.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f9a1c805846237d56f99b328ba6ab77e5d43ef59aaaf8d2a41d42fdc708a7b"
+checksum = "d05e5a8ace81c09d7eb165dffc1742358a021b2fa761f2160943305f83216003"
 dependencies = [
  "anyhow",
+ "bytesize",
  "chrono",
  "derive_more",
- "near-config-utils 0.17.0",
- "near-crypto 0.17.0",
- "near-o11y 0.17.0",
- "near-primitives 0.17.0",
+ "near-config-utils",
+ "near-crypto",
+ "near-parameters",
+ "near-primitives",
  "num-rational 0.3.2",
  "once_cell",
  "serde",
  "serde_json",
  "sha2 0.10.8",
  "smart-default",
- "tracing",
-]
-
-[[package]]
-name = "near-config-utils"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5523e7dce493c45bc3241eb3100d943ec471852f9b1f84b46a34789eadf17031"
-dependencies = [
- "anyhow",
- "json_comments",
- "thiserror",
  "tracing",
 ]
 
@@ -3187,59 +3022,6 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e75673d69fd7365508f3d32483669fe45b03bfb34e4d9363e90adae9dfb416c"
-dependencies = [
- "arrayref",
- "blake2",
- "borsh 0.9.3",
- "bs58 0.4.0",
- "c2-chacha",
- "curve25519-dalek 3.2.1",
- "derive_more",
- "ed25519-dalek 1.0.1",
- "near-account-id 0.14.0",
- "once_cell",
- "parity-secp256k1",
- "primitive-types 0.10.1",
- "rand 0.7.3",
- "rand_core 0.5.1",
- "serde",
- "serde_json",
- "subtle",
- "thiserror",
-]
-
-[[package]]
-name = "near-crypto"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6b382b626e7e0cd372d027c6672ac97b4b6ee6114288c9e58d8180b935d315"
-dependencies = [
- "blake2",
- "borsh 0.10.3",
- "bs58 0.4.0",
- "c2-chacha",
- "curve25519-dalek 3.2.1",
- "derive_more",
- "ed25519-dalek 1.0.1",
- "hex",
- "near-account-id 0.17.0",
- "near-config-utils 0.17.0",
- "near-stdx 0.17.0",
- "once_cell",
- "primitive-types 0.10.1",
- "rand 0.7.3",
- "secp256k1",
- "serde",
- "serde_json",
- "subtle",
- "thiserror",
-]
-
-[[package]]
-name = "near-crypto"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2991d2912218a80ec0733ac87f84fa803accea105611eea209d4419271957667"
@@ -3248,13 +3030,13 @@ dependencies = [
  "borsh 1.3.1",
  "bs58 0.4.0",
  "c2-chacha",
- "curve25519-dalek 4.1.1",
+ "curve25519-dalek",
  "derive_more",
- "ed25519-dalek 2.1.1",
+ "ed25519-dalek",
  "hex",
- "near-account-id 1.0.0",
- "near-config-utils 0.20.1",
- "near-stdx 0.20.1",
+ "near-account-id",
+ "near-config-utils",
+ "near-stdx",
  "once_cell",
  "primitive-types 0.10.1",
  "rand 0.7.3",
@@ -3267,20 +3049,11 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c44c842c6cfcd9b8c387cccd4cd0619a5f21920cde5d5c292af3cc5d40510672"
-dependencies = [
- "near-primitives-core 0.17.0",
-]
-
-[[package]]
-name = "near-fmt"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7d998dfc1e04001608899b2498ad5a782c7d036b73769d510de21964db99286"
 dependencies = [
- "near-primitives-core 0.20.1",
+ "near-primitives-core",
 ]
 
 [[package]]
@@ -3296,17 +3069,17 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "118f44c02ad211db805c1370ad3ff26576af6ff554093c9fece1b835d29d233a"
+checksum = "18ad81e015f7aced8925d5b9ba3f369b36da9575c15812cfd0786bc1213284ca"
 dependencies = [
- "borsh 0.10.3",
+ "borsh 1.3.1",
  "lazy_static",
  "log",
  "near-chain-configs",
- "near-crypto 0.17.0",
+ "near-crypto",
  "near-jsonrpc-primitives",
- "near-primitives 0.17.0",
+ "near-primitives",
  "reqwest",
  "serde",
  "serde_json",
@@ -3315,44 +3088,18 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "0.17.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b2934b5ab243e25e951c984525ba0aff0e719ed915c988c5195405aa0f6987"
+checksum = "b0ce745e954ae776eef05957602e638ee9581106a3675946fb43c2fe7e38ef03"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
- "near-crypto 0.17.0",
- "near-primitives 0.17.0",
- "near-rpc-error-macro 0.17.0",
+ "near-crypto",
+ "near-primitives",
+ "near-rpc-error-macro",
  "serde",
  "serde_json",
  "thiserror",
-]
-
-[[package]]
-name = "near-o11y"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7d35397b02b131c188c72f3885e97daeccab134ec2fc8cc0073a94cf1cfe19"
-dependencies = [
- "actix",
- "atty",
- "clap 4.4.18",
- "near-crypto 0.17.0",
- "near-primitives-core 0.17.0",
- "once_cell",
- "opentelemetry",
- "opentelemetry-otlp",
- "opentelemetry-semantic-conventions",
- "prometheus",
- "serde",
- "strum 0.24.1",
- "thiserror",
- "tokio",
- "tracing",
- "tracing-appender",
- "tracing-opentelemetry",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -3363,10 +3110,10 @@ checksum = "d20762631bc8253030013bbae9b5f0542691edc1aa6722f1e8141cc9b928ae5b"
 dependencies = [
  "actix",
  "base64 0.21.7",
- "clap 4.4.18",
- "near-crypto 0.20.1",
- "near-fmt 0.20.1",
- "near-primitives-core 0.20.1",
+ "clap 4.5.1",
+ "near-crypto",
+ "near-fmt",
+ "near-primitives-core",
  "once_cell",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -3392,80 +3139,14 @@ dependencies = [
  "assert_matches",
  "borsh 1.3.1",
  "enum-map",
- "near-account-id 1.0.0",
- "near-primitives-core 0.20.1",
+ "near-account-id",
+ "near-primitives-core",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
  "serde_yaml",
  "strum 0.24.1",
  "thiserror",
-]
-
-[[package]]
-name = "near-primitives"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad1a9a1640539c81f065425c31bffcfbf6b31ef1aeaade59ce905f5df6ac860"
-dependencies = [
- "borsh 0.9.3",
- "byteorder",
- "bytesize",
- "chrono",
- "derive_more",
- "easy-ext",
- "hex",
- "near-crypto 0.14.0",
- "near-primitives-core 0.14.0",
- "near-rpc-error-macro 0.14.0",
- "near-vm-errors 0.14.0",
- "num-rational 0.3.2",
- "once_cell",
- "primitive-types 0.10.1",
- "rand 0.7.3",
- "reed-solomon-erasure",
- "serde",
- "serde_json",
- "smart-default",
- "strum 0.24.1",
- "thiserror",
-]
-
-[[package]]
-name = "near-primitives"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f7051aaf199adc4d068620fca6d5f70f906a1540d03a8bb3701271f8881835"
-dependencies = [
- "arbitrary",
- "borsh 0.10.3",
- "bytesize",
- "cfg-if 1.0.0",
- "chrono",
- "derive_more",
- "easy-ext",
- "enum-map",
- "hex",
- "near-crypto 0.17.0",
- "near-fmt 0.17.0",
- "near-primitives-core 0.17.0",
- "near-rpc-error-macro 0.17.0",
- "near-stdx 0.17.0",
- "near-vm-errors 0.17.0",
- "num-rational 0.3.2",
- "once_cell",
- "primitive-types 0.10.1",
- "rand 0.8.5",
- "reed-solomon-erasure",
- "serde",
- "serde_json",
- "serde_with",
- "serde_yaml",
- "smart-default",
- "strum 0.24.1",
- "thiserror",
- "time",
- "tracing",
 ]
 
 [[package]]
@@ -3484,13 +3165,13 @@ dependencies = [
  "easy-ext",
  "enum-map",
  "hex",
- "near-crypto 0.20.1",
- "near-fmt 0.20.1",
- "near-o11y 0.20.1",
+ "near-crypto",
+ "near-fmt",
+ "near-o11y",
  "near-parameters",
- "near-primitives-core 0.20.1",
- "near-rpc-error-macro 0.20.1",
- "near-stdx 0.20.1",
+ "near-primitives-core",
+ "near-rpc-error-macro",
+ "near-stdx",
  "near-vm-runner",
  "num-rational 0.3.2",
  "once_cell",
@@ -3512,45 +3193,6 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d508f0fc340f6461e4e256417685720d3c4c00bb5a939b105160e49137caba"
-dependencies = [
- "base64 0.11.0",
- "borsh 0.9.3",
- "bs58 0.4.0",
- "derive_more",
- "near-account-id 0.14.0",
- "num-rational 0.3.2",
- "serde",
- "sha2 0.10.8",
- "strum 0.24.1",
-]
-
-[[package]]
-name = "near-primitives-core"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775fec19ef51a341abdbf792a9dda5b4cb89f488f681b2fd689b9321d24db47b"
-dependencies = [
- "arbitrary",
- "base64 0.21.7",
- "borsh 0.10.3",
- "bs58 0.4.0",
- "derive_more",
- "enum-map",
- "near-account-id 0.17.0",
- "num-rational 0.3.2",
- "serde",
- "serde_repr",
- "serde_with",
- "sha2 0.10.8",
- "strum 0.24.1",
- "thiserror",
-]
-
-[[package]]
-name = "near-primitives-core"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8443eb718606f572c438be6321a097a8ebd69f8e48d953885b4f16601af88225"
@@ -3561,7 +3203,7 @@ dependencies = [
  "bs58 0.4.0",
  "derive_more",
  "enum-map",
- "near-account-id 1.0.0",
+ "near-account-id",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -3573,58 +3215,13 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-core"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ee0b41c75ef859c193a8ff1dadfa0c8207bc0ac447cc22259721ad769a1408"
-dependencies = [
- "quote",
- "serde",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "near-rpc-error-core"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c1eda300e2e78f4f945ae58117d49e806899f4a51ee2faa09eda5ebc2e6571"
-dependencies = [
- "quote",
- "serde",
- "syn 2.0.48",
-]
-
-[[package]]
-name = "near-rpc-error-core"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80fca203c51edd9595ec14db1d13359fb9ede32314990bf296b6c5c4502f6ab7"
 dependencies = [
  "quote",
  "serde",
- "syn 2.0.48",
-]
-
-[[package]]
-name = "near-rpc-error-macro"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e837bd4bacd807073ec5ceb85708da7f721b46a4c2a978de86027fb0034ce31"
-dependencies = [
- "near-rpc-error-core 0.14.0",
- "serde",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "near-rpc-error-macro"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31d2dadd765101c77e664029dd6fbec090e696877d4ae903c620d02ceda4969a"
-dependencies = [
- "fs2",
- "near-rpc-error-core 0.17.0",
- "serde",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -3634,9 +3231,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897a445de2102f6732c8a185d922f5e3bf7fd0a41243ce40854df2197237f799"
 dependencies = [
  "fs2",
- "near-rpc-error-core 0.20.1",
+ "near-rpc-error-core",
  "serde",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -3655,22 +3252,19 @@ dependencies = [
 
 [[package]]
 name = "near-sdk"
-version = "4.1.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15eb3de2defe3626260cc209a6cdb985c6b27b0bd4619fad97dcfae002c3c5bd"
+checksum = "b5c2e7c9524308b1b301cca05d875de13b3b20dc8b92e71f3890b380372e4c88"
 dependencies = [
- "base64 0.13.1",
- "borsh 0.9.3",
- "bs58 0.4.0",
- "near-abi",
- "near-crypto 0.14.0",
- "near-primitives 0.14.0",
- "near-primitives-core 0.14.0",
+ "base64 0.21.7",
+ "borsh 1.3.1",
+ "bs58 0.5.0",
+ "near-account-id",
+ "near-gas",
  "near-sdk-macros",
  "near-sys",
- "near-vm-logic",
+ "near-token",
  "once_cell",
- "schemars",
  "serde",
  "serde_json",
  "wee_alloc",
@@ -3678,21 +3272,20 @@ dependencies = [
 
 [[package]]
 name = "near-sdk-macros"
-version = "4.1.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4907affc9f5ed559456509188ff0024f1f2099c0830e6bdb66eb61d5b75912c0"
+checksum = "e1e9b23d9d7757ade258921c9cbc7923542e64d9d3b52a6cd91f746c77cb0a0f"
 dependencies = [
  "Inflector",
+ "darling",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "serde",
+ "serde_json",
+ "strum 0.26.1",
+ "strum_macros 0.26.1",
+ "syn 2.0.50",
 ]
-
-[[package]]
-name = "near-stdx"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6540152fba5e96fe5d575b79e8cd244cf2add747bb01362426bdc069bc3a23bc"
 
 [[package]]
 name = "near-stdx"
@@ -3712,55 +3305,8 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b68f3f8a2409f72b43efdbeff8e820b81e70824c49fee8572979d789d1683fb"
 dependencies = [
+ "borsh 1.3.1",
  "serde",
-]
-
-[[package]]
-name = "near-vm-errors"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0da466a30f0446639cbd788c30865086fac3e8dcb07a79e51d2b0775ed4261e"
-dependencies = [
- "borsh 0.9.3",
- "near-account-id 0.14.0",
- "near-rpc-error-macro 0.14.0",
- "serde",
-]
-
-[[package]]
-name = "near-vm-errors"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec545d1bede0579e7c15dd2dce9b998dc975c52f2165702ff40bec7ff69728bb"
-dependencies = [
- "borsh 0.10.3",
- "near-account-id 0.17.0",
- "near-rpc-error-macro 0.17.0",
- "serde",
- "strum 0.24.1",
- "thiserror",
-]
-
-[[package]]
-name = "near-vm-logic"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b534828419bacbf1f7b11ef7b00420f248c548c485d3f0cfda8bb6931152f2"
-dependencies = [
- "base64 0.13.1",
- "borsh 0.9.3",
- "bs58 0.4.0",
- "byteorder",
- "near-account-id 0.14.0",
- "near-crypto 0.14.0",
- "near-primitives 0.14.0",
- "near-primitives-core 0.14.0",
- "near-vm-errors 0.14.0",
- "ripemd",
- "serde",
- "sha2 0.10.8",
- "sha3",
- "zeropool-bn",
 ]
 
 [[package]]
@@ -3772,14 +3318,14 @@ dependencies = [
  "anyhow",
  "base64 0.21.7",
  "borsh 1.3.1",
- "ed25519-dalek 2.1.1",
+ "ed25519-dalek",
  "enum-map",
  "finite-wasm",
  "memoffset 0.8.0",
- "near-crypto 0.20.1",
+ "near-crypto",
  "near-parameters",
- "near-primitives-core 0.20.1",
- "near-stdx 0.20.1",
+ "near-primitives-core",
+ "near-stdx",
  "num-rational 0.3.2",
  "once_cell",
  "parity-wasm 0.41.0",
@@ -3809,27 +3355,25 @@ dependencies = [
 
 [[package]]
 name = "near-workspaces"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a14e772e49ba9644c06dad20f635b6463f74d378fa19822bfc35fef479c72e5"
+checksum = "a3e597da87d0c1a722e23efb8c24ae42a0ad99a15f37101dad45c15defb051c1"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
- "borsh 0.10.3",
  "bs58 0.5.0",
  "cargo-near",
  "chrono",
  "fs2",
  "json-patch",
  "libc",
- "near-account-id 0.17.0",
- "near-crypto 0.17.0",
+ "near-account-id",
+ "near-crypto",
  "near-gas",
  "near-jsonrpc-client",
  "near-jsonrpc-primitives",
- "near-primitives 0.17.0",
+ "near-primitives",
  "near-sandbox-utils",
- "near-sdk",
  "near-token",
  "rand 0.8.5",
  "reqwest",
@@ -3936,19 +3480,18 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -3982,9 +3525,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
 ]
@@ -3995,7 +3538,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.5",
+ "hermit-abi 0.3.6",
  "libc",
 ]
 
@@ -4007,7 +3550,7 @@ checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "crc32fast",
  "hashbrown 0.14.3",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "memchr",
 ]
 
@@ -4031,9 +3574,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.63"
+version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c9d69dd87a29568d4d017cfe8ec518706046a05184e5aea92d0af890b803c8"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
  "bitflags 2.4.2",
  "cfg-if 1.0.0",
@@ -4052,7 +3595,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -4063,9 +3606,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.99"
+version = "0.9.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
+checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
 dependencies = [
  "cc",
  "libc",
@@ -4135,42 +3678,16 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parity-scale-codec"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373b1a4c1338d9cd3d1fa53b3a11bdab5ab6bd80a20f7f7becd76953ae2be909"
-dependencies = [
- "arrayvec 0.7.4",
- "bitvec 0.20.4",
- "byte-slice-cast",
- "impl-trait-for-tuples",
- "parity-scale-codec-derive 2.3.1",
- "serde",
-]
-
-[[package]]
-name = "parity-scale-codec"
 version = "3.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881331e34fa842a2fb61cc2db9643a8fedc615e47cfcc52597d1af0db9a7e8fe"
 dependencies = [
- "arrayvec 0.7.4",
- "bitvec 1.0.1",
+ "arrayvec",
+ "bitvec",
  "byte-slice-cast",
  "impl-trait-for-tuples",
- "parity-scale-codec-derive 3.6.9",
+ "parity-scale-codec-derive",
  "serde",
-]
-
-[[package]]
-name = "parity-scale-codec-derive"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
-dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -4183,17 +3700,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "parity-secp256k1"
-version = "0.7.0"
-source = "git+https://github.com/paritytech/rust-secp256k1?rev=d05fd8e#d05fd8e152f8d110b587906e3d854196b086e42a"
-dependencies = [
- "arrayvec 0.5.2",
- "cc",
- "cfg-if 0.1.10",
- "rand 0.7.3",
 ]
 
 [[package]]
@@ -4290,7 +3796,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
 ]
 
 [[package]]
@@ -4337,7 +3843,7 @@ checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -4354,9 +3860,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "plain"
@@ -4472,7 +3978,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
  "proc-macro2",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -4482,7 +3988,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
 dependencies = [
  "fixed-hash 0.7.0",
- "impl-codec 0.5.1",
  "uint",
 ]
 
@@ -4493,7 +3998,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash 0.8.0",
- "impl-codec 0.6.0",
+ "impl-codec",
  "impl-rlp",
  "impl-serde",
  "scale-info",
@@ -4692,12 +4197,6 @@ checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "radium"
@@ -4945,16 +4444,17 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.7"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
+ "cfg-if 1.0.0",
  "getrandom 0.2.12",
  "libc",
  "spin 0.9.8",
  "untrusted",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4972,7 +4472,7 @@ version = "0.7.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cba464629b3394fc4dbc6f940ff8f5b4ff5c7aef40f29166fd4ad12acbc99c0"
 dependencies = [
- "bitvec 1.0.1",
+ "bitvec",
  "bytecheck",
  "bytes",
  "hashbrown 0.12.3",
@@ -5069,14 +4569,16 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.10"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
 dependencies = [
  "log",
  "ring",
+ "rustls-pki-types",
  "rustls-webpki",
- "sct",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -5089,12 +4591,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-webpki"
-version = "0.101.7"
+name = "rustls-pki-types"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+checksum = "048a63e5b3ac996d78d402940b5fa47973d2d080c6c6fffa1d0f19c4445310b7"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
 dependencies = [
  "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -5106,9 +4615,9 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "same-file"
@@ -5125,10 +4634,10 @@ version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f7d66a1128282b7ef025a8ead62a4a9fcf017382ec53b8ffbf4d7bf77bd3c60"
 dependencies = [
- "bitvec 1.0.1",
+ "bitvec",
  "cfg-if 1.0.0",
  "derive_more",
- "parity-scale-codec 3.6.9",
+ "parity-scale-codec",
  "scale-info-derive",
 ]
 
@@ -5206,17 +4715,7 @@ checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
-]
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -5269,31 +4768,31 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -5309,9 +4808,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
  "itoa",
  "ryu",
@@ -5326,7 +4825,7 @@ checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -5343,16 +4842,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b0ed1662c5a68664f45b76d18deb0e234aff37207086803165c961eb695e981"
+checksum = "15d167997bd841ec232f5b2b8e0e26606df2e7caa4c31b95ea9ca52b200bd270"
 dependencies = [
  "base64 0.21.7",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "serde",
+ "serde_derive",
  "serde_json",
  "serde_with_macros",
  "time",
@@ -5360,23 +4860,23 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568577ff0ef47b879f736cd66740e022f3672788cdf002a05a4e609ea5a6fb15"
+checksum = "865f9743393e638991566a8b7a479043c2c8da94a33e0a31f18214c9cae0a64d"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.31"
+version = "0.9.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adf8a49373e98a4c5f0ceb5d05aa7c648d75f63774981ed95b7c7443bbd50c6e"
+checksum = "8fd075d994154d4a774f95b51fb96bdc2832b0ea48425c92546073816cda1f2f"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "itoa",
  "ryu",
  "serde",
@@ -5454,12 +4954,6 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
-
-[[package]]
-name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
@@ -5506,16 +5000,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -5590,6 +5074,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strsim"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+
+[[package]]
 name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5600,11 +5090,11 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+checksum = "723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f"
 dependencies = [
- "strum_macros 0.25.3",
+ "strum_macros 0.26.1",
 ]
 
 [[package]]
@@ -5622,15 +5112,15 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.25.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -5657,7 +5147,7 @@ version = "8.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1165dabf9fc1d6bb6819c2c0e27c8dd0e3068d2c53cf186d319788e96517f0d6"
 dependencies = [
- "bitvec 1.0.1",
+ "bitvec",
  "dmsort",
  "elementtree",
  "fallible-iterator 0.2.0",
@@ -5694,9 +5184,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5712,7 +5202,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -5761,9 +5251,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.13"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69758bda2e78f098e4ccb393021a0963bb3442eac05f135c30f61b7370bbafae"
+checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
 
 [[package]]
 name = "tempfile"
@@ -5804,7 +5294,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -5815,41 +5305,41 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
  "test-case-core",
 ]
 
 [[package]]
 name = "textwrap"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if 1.0.0",
  "once_cell",
@@ -5922,11 +5412,11 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.2"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
- "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
@@ -5934,7 +5424,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.4.10",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -5951,13 +5441,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -5990,7 +5480,7 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "rand 0.8.5",
- "socket2 0.5.5",
+ "socket2",
  "tokio",
  "tokio-util 0.7.10",
  "whoami",
@@ -6067,7 +5557,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "toml_datetime",
  "winnow",
 ]
@@ -6078,7 +5568,7 @@ version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "toml_datetime",
  "winnow",
 ]
@@ -6089,7 +5579,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "toml_datetime",
  "winnow",
 ]
@@ -6201,7 +5691,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -6335,9 +5825,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
@@ -6362,15 +5852,16 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.9.1"
+version = "2.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cdd25c339e200129fe4de81451814e5228c9b771d57378817d6117cc2b3f97"
+checksum = "11f214ce18d8b2cbe84ed3aa6486ed3f5b285cf8d8fbdbce9f3f767a724adc35"
 dependencies = [
  "base64 0.21.7",
  "flate2",
  "log",
  "once_cell",
  "rustls",
+ "rustls-pki-types",
  "rustls-webpki",
  "url",
  "webpki-roots",
@@ -6504,7 +5995,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
  "wasm-bindgen-shared",
 ]
 
@@ -6538,7 +6029,7 @@ checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6714,7 +6205,7 @@ version = "0.115.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e06c0641a4add879ba71ccb3a1e4278fd546f76f1eafb21d8f7b07733b547cd5"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "semver",
 ]
 
@@ -6739,7 +6230,7 @@ dependencies = [
  "bumpalo",
  "cfg-if 1.0.0",
  "fxprof-processed-profile",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "libc",
  "log",
  "object",
@@ -6818,7 +6309,7 @@ dependencies = [
  "anyhow",
  "cranelift-entity",
  "gimli 0.28.1",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "log",
  "object",
  "serde",
@@ -6884,7 +6375,7 @@ dependencies = [
  "anyhow",
  "cc",
  "cfg-if 1.0.0",
- "indexmap 2.2.2",
+ "indexmap 2.2.3",
  "libc",
  "log",
  "mach",
@@ -6924,7 +6415,7 @@ checksum = "09b5575a75e711ca6c36bb9ad647c93541cdc8e34218031acba5da3f35919dd3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -6945,9 +6436,12 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.4"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "wee_alloc"
@@ -7020,7 +6514,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.3",
 ]
 
 [[package]]
@@ -7038,7 +6532,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.3",
 ]
 
 [[package]]
@@ -7058,17 +6552,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "d380ba1dc7187569a8a9e91ed34b8ccfc33123bbacb8c0aed2d1ad7f3ef2dc5f"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.3",
+ "windows_aarch64_msvc 0.52.3",
+ "windows_i686_gnu 0.52.3",
+ "windows_i686_msvc 0.52.3",
+ "windows_x86_64_gnu 0.52.3",
+ "windows_x86_64_gnullvm 0.52.3",
+ "windows_x86_64_msvc 0.52.3",
 ]
 
 [[package]]
@@ -7079,9 +6573,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "68e5dcfb9413f53afd9c8f86e56a7b4d86d9a2fa26090ea2dc9e40fba56c6ec6"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -7091,9 +6585,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "8dab469ebbc45798319e69eebf92308e541ce46760b49b18c6b3fe5e8965b30f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7103,9 +6597,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "2a4e9b6a7cac734a8b4138a4e1044eac3404d8326b6c0f939276560687a033fb"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -7115,9 +6609,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "28b0ec9c422ca95ff34a78755cfa6ad4a51371da2a5ace67500cf7ca5f232c58"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7127,9 +6621,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "704131571ba93e89d7cd43482277d6632589b18ecf4468f591fbae0a8b101614"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -7139,9 +6633,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "42079295511643151e98d61c38c0acc444e52dd42ab456f7ccfd5152e8ecf21c"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -7151,15 +6645,15 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "0770833d60a970638e989b3fa9fd2bb1aaadcf88963d1659fd7d9990196ed2d6"
 
 [[package]]
 name = "winnow"
-version = "0.5.39"
+version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5389a154b01683d28c77f8f68f49dea75f0a4da32557a58f68ee51ebba472d29"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]
@@ -7173,12 +6667,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "wyz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "wyz"
@@ -7223,28 +6711,14 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.3.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 
 [[package]]
 name = "zeropool-bn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,7 @@ anyhow = "1"
 base64 = { version = "0.21", default-features = false, features = ["alloc"] }
 bitflags = { version = "1", default-features = false }
 bn = { version = "0.5", package = "zeropool-bn", default-features = false }
-borsh = { version = "0.10", default-features = false }
-borsh-compat = { version = "0.9", package = "borsh", default-features = false }
+borsh = { version = "1", default-features = false, features = ["derive"] }
 bs58 = { version = "0.5", default-features = false, features = ["alloc", "sha2"] }
 bstr = "1"
 byte-slice-cast = { version = "1", default-features = false }
@@ -36,12 +35,12 @@ evm = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.39.1"
 evm-core = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.39.1", default-features = false, features = ["std"] }
 evm-gasometer = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.39.1", default-features = false, features = ["std", "tracing"] }
 evm-runtime = { git = "https://github.com/aurora-is-near/sputnikvm.git", tag = "v0.39.1", default-features = false, features = ["std", "tracing"] }
-fixed-hash = { version = "0.8.0", default-features = false}
-function_name = "0.3.0"
+fixed-hash = { version = "0.8", default-features = false }
+function_name = "0.3"
 git2 = "0.18"
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 ibig = { version = "0.3", default-features = false, features = ["num-traits"] }
-impl-serde = { version = "0.4", default-features = false}
+impl-serde = { version = "0.4", default-features = false }
 lazy_static = "1"
 libsecp256k1 = { version = "0.7", default-features = false }
 near-crypto = "0.20"
@@ -49,9 +48,9 @@ near-gas = "0.2"
 near-parameters = "0.20"
 near-primitives = "0.20"
 near-primitives-core = "0.20"
-near-sdk = "4"
-near-vm-runner = { version = "0.20", features = [ "wasmtime_vm", "wasmer2_vm" ] }
-near-workspaces = "0.9"
+near-sdk = "5"
+near-vm-runner = { version = "0.20", features = ["wasmtime_vm", "wasmer2_vm"] }
+near-workspaces = "0.10"
 num = { version = "0.4", default-features = false, features = ["alloc"] }
 postgres = "0.19"
 primitive-types = { version = "0.12", default-features = false, features = ["rlp", "serde_no_std"] }
@@ -64,15 +63,12 @@ serde = { version = "1", default-features = false, features = ["alloc", "derive"
 serde_json = { version = "1", default-features = false, features = ["alloc"] }
 sha2 = { version = "0.10", default-features = false }
 sha3 = { version = "0.10", default-features = false }
-strum = { version = "0.25", features = ["derive"] }
+strum = { version = "0.26", features = ["derive"] }
 tempfile = "3"
 tokio = { version = "1", default-features = false, features = ["macros"] }
 test-case = "3.1"
 walrus = "0.20"
 wee_alloc = { version = "0.4", default-features = false }
-
-[patch.crates-io]
-parity-secp256k1 = { git = 'https://github.com/paritytech/rust-secp256k1', rev = "d05fd8e" }
 
 [workspace]
 resolver = "2"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -135,29 +135,12 @@ args = [
     "clippy::as_conversions",
 ]
 
-[tasks.clippy-borsh-compat]
-extend = "clippy-base"
-args = [
-    "clippy",
-    "-p",
-    "aurora-engine-types",
-    "--all-targets",
-    "--features",
-    "borsh-compat",
-    "--",
-    "-D",
-    "warnings",
-    "-D",
-    "clippy::as_conversions",
-]
-
 [tasks.clippy]
 dependencies = [
     "clippy-base",
     "clippy-ext-connector",
     "clippy-contract",
     "clippy-contract-refund",
-    "clippy-borsh-compat",
 ]
 
 [tasks.check-fmt]

--- a/engine-hashchain/Cargo.toml
+++ b/engine-hashchain/Cargo.toml
@@ -19,4 +19,3 @@ impl-serde.workspace = true
 [features]
 default = ["std"]
 std = ["aurora-engine-types/std", "aurora-engine-sdk/std", "fixed-hash/std", "impl-serde/std"]
-borsh-compat = ["aurora-engine-types/borsh-compat", "aurora-engine-sdk/borsh-compat"]

--- a/engine-hashchain/src/bloom.rs
+++ b/engine-hashchain/src/bloom.rs
@@ -5,7 +5,7 @@
 #![allow(clippy::expl_impl_clone_on_copy, clippy::non_canonical_clone_impl)]
 
 use aurora_engine_sdk::keccak;
-use aurora_engine_types::borsh::{self, BorshDeserialize, BorshSerialize};
+use aurora_engine_types::borsh::{BorshDeserialize, BorshSerialize};
 use aurora_engine_types::parameters::engine::ResultLog;
 use fixed_hash::construct_fixed_hash;
 use impl_serde::impl_fixed_hash_serde;
@@ -16,6 +16,7 @@ const BLOOM_BITS: u32 = 3;
 construct_fixed_hash! {
     /// Bloom hash type with 256 bytes (2048 bits) size.
     #[derive(BorshSerialize, BorshDeserialize)]
+    #[borsh(crate = "aurora_engine_types::borsh")]
     pub struct Bloom(BLOOM_SIZE);
 }
 

--- a/engine-hashchain/src/hashchain.rs
+++ b/engine-hashchain/src/hashchain.rs
@@ -2,7 +2,7 @@ use crate::{bloom::Bloom, error::BlockchainHashchainError, merkle::StreamCompact
 use aurora_engine_sdk::keccak;
 use aurora_engine_types::{
     account_id::AccountId,
-    borsh::{self, maybestd::io, BorshDeserialize, BorshSerialize},
+    borsh::{self, io, BorshDeserialize, BorshSerialize},
     format,
     types::RawH256,
     Cow, Vec,
@@ -107,7 +107,7 @@ impl Hashchain {
 
     pub fn try_serialize(&self) -> Result<Vec<u8>, io::Error> {
         let serializable: BorshableHashchain = self.into();
-        serializable.try_to_vec()
+        borsh::to_vec(&serializable)
     }
 
     pub fn try_deserialize(bytes: &[u8]) -> Result<Self, io::Error> {
@@ -168,6 +168,7 @@ impl HashchainBuilder {
 /// is not bogged down with details of serialization (for example this data type is an enum
 /// to allow for easy changes to the serialized form in the future).
 #[derive(Debug, BorshDeserialize, BorshSerialize)]
+#[borsh(crate = "aurora_engine_types::borsh")]
 enum BorshableHashchain<'a> {
     V1 {
         chain_id: Cow<'a, [u8; 32]>,
@@ -221,6 +222,7 @@ impl<'a> TryFrom<BorshableHashchain<'a>> for Hashchain {
 /// 4. Clear the transactions of the current block.
 /// 5. Go back to step 2 for the next block.
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
+#[borsh(crate = "aurora_engine_types::borsh")]
 struct BlockHashchainComputer {
     pub txs_logs_bloom: Bloom,
     pub txs_merkle_tree: StreamCompactMerkleTree,

--- a/engine-hashchain/src/merkle.rs
+++ b/engine-hashchain/src/merkle.rs
@@ -1,6 +1,6 @@
 use aurora_engine_sdk::keccak;
 use aurora_engine_types::{
-    borsh::{self, BorshDeserialize, BorshSerialize},
+    borsh::{BorshDeserialize, BorshSerialize},
     types::RawH256,
     Vec,
 };
@@ -10,6 +10,7 @@ use aurora_engine_types::{
 /// Internally, compacts full binary subtrees maintaining only the growing branch.
 /// Space used is O(log n) where n is the number of leaf hashes added. It is usually less.
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
+#[borsh(crate = "aurora_engine_types::borsh")]
 pub struct StreamCompactMerkleTree {
     /// Complete binary merkle subtrees.
     /// Left subtrees are strictly higher (bigger).
@@ -121,6 +122,7 @@ impl Default for StreamCompactMerkleTree {
 /// For leaves, this represents only the leaf node with height 1 and the hash of the leaf.
 /// For bigger subtrees, this represents the entire balanced subtree with its height and merkle hash.
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
+#[borsh(crate = "aurora_engine_types::borsh")]
 struct CompactMerkleSubtree {
     /// Height of the subtree.
     pub height: u8,

--- a/engine-precompiles/Cargo.toml
+++ b/engine-precompiles/Cargo.toml
@@ -33,7 +33,6 @@ serde_json.workspace = true
 [features]
 default = ["std"]
 std = ["aurora-engine-types/std", "aurora-engine-sdk/std", "bn/std", "evm/std", "libsecp256k1/std", "ripemd/std", "sha2/std", "sha3/std", "ethabi/std"]
-borsh-compat = ["aurora-engine-types/borsh-compat", "aurora-engine-sdk/borsh-compat"]
 contract = ["aurora-engine-sdk/contract"]
 log = []
 error_refund = []

--- a/engine-precompiles/src/native.rs
+++ b/engine-precompiles/src/native.rs
@@ -7,7 +7,7 @@ use crate::prelude::{
     storage::{bytes_to_key, KeyPrefix},
     str,
     types::{Address, Yocto},
-    vec, BorshSerialize, Cow, ToString, Vec, U256,
+    vec, Cow, ToString, Vec, U256,
 };
 #[cfg(feature = "error_refund")]
 use crate::prelude::{parameters::RefundCallArgs, types};
@@ -18,6 +18,7 @@ use aurora_engine_types::parameters::WithdrawCallArgs;
 use aurora_engine_types::storage::EthConnectorStorageId;
 use aurora_engine_types::{
     account_id::AccountId,
+    borsh,
     parameters::{
         ExitToNearPrecompileCallbackCallArgs, PromiseWithCallbackArgs, TransferNearCallArgs,
     },
@@ -494,7 +495,7 @@ impl<I: IO> Precompile for ExitToNear<I> {
                 callback: PromiseCreateArgs {
                     target_account_id: self.current_account_id.clone(),
                     method: "exit_to_near_precompile_callback".to_string(),
-                    args: callback_args.try_to_vec().unwrap(),
+                    args: borsh::to_vec(&callback_args).unwrap(),
                     attached_balance: Yocto::new(0),
                     attached_gas: costs::EXIT_TO_NEAR_CALLBACK_GAS,
                 },
@@ -503,7 +504,7 @@ impl<I: IO> Precompile for ExitToNear<I> {
         let promise_log = Log {
             address: exit_to_near::ADDRESS.raw(),
             topics: Vec::new(),
-            data: promise.try_to_vec().unwrap(),
+            data: borsh::to_vec(&promise).unwrap(),
         };
         let exit_event_log = exit_event.encode();
         let exit_event_log = Log {
@@ -690,7 +691,7 @@ impl<I: IO> Precompile for ExitToEthereum<I> {
             attached_gas: costs::WITHDRAWAL_GAS,
         };
 
-        let promise = PromiseArgs::Create(withdraw_promise).try_to_vec().unwrap();
+        let promise = borsh::to_vec(&PromiseArgs::Create(withdraw_promise)).unwrap();
         let promise_log = Log {
             address: exit_to_ethereum::ADDRESS.raw(),
             topics: Vec::new(),
@@ -722,11 +723,10 @@ fn json_args(address: Address, amount: U256) -> Result<Vec<u8>, ExitError> {
 }
 
 fn borsh_args(address: Address, amount: U256) -> Result<Vec<u8>, ExitError> {
-    WithdrawCallArgs {
+    borsh::to_vec(&WithdrawCallArgs {
         recipient_address: address,
         amount: NEP141Wei::new(amount.as_u128()),
-    }
-    .try_to_vec()
+    })
     .map_err(|_| ExitError::Other(Cow::from("ERR_BORSH_SERIALIZE")))
 }
 
@@ -808,7 +808,7 @@ mod tests {
             parse_recipient(b"test.near").unwrap(),
             Recipient {
                 receiver_account_id: "test.near".parse().unwrap(),
-                message: None
+                message: None,
             }
         );
 
@@ -816,7 +816,7 @@ mod tests {
             parse_recipient(b"test.near:unwrap").unwrap(),
             Recipient {
                 receiver_account_id: "test.near".parse().unwrap(),
-                message: Some("unwrap")
+                message: Some("unwrap"),
             }
         );
 
@@ -824,7 +824,7 @@ mod tests {
             parse_recipient(b"test.near:some_msg:with_extra_colon").unwrap(),
             Recipient {
                 receiver_account_id: "test.near".parse().unwrap(),
-                message: Some("some_msg:with_extra_colon")
+                message: Some("some_msg:with_extra_colon"),
             }
         );
 
@@ -832,7 +832,7 @@ mod tests {
             parse_recipient(b"test.near:").unwrap(),
             Recipient {
                 receiver_account_id: "test.near".parse().unwrap(),
-                message: Some("")
+                message: Some(""),
             }
         );
     }

--- a/engine-precompiles/src/prelude.rs
+++ b/engine-precompiles/src/prelude.rs
@@ -1,5 +1,4 @@
 pub use aurora_engine_sdk as sdk;
-pub use aurora_engine_types::borsh::BorshSerialize;
 pub use aurora_engine_types::parameters;
 pub use aurora_engine_types::storage;
 pub use aurora_engine_types::types;

--- a/engine-precompiles/src/promise_result.rs
+++ b/engine-precompiles/src/promise_result.rs
@@ -2,7 +2,7 @@ use super::{EvmPrecompileResult, Precompile};
 use crate::prelude::types::{make_address, Address, EthGas};
 use crate::{utils, PrecompileOutput};
 use aurora_engine_sdk::promise::ReadOnlyPromiseHandler;
-use aurora_engine_types::{borsh::BorshSerialize, Cow, Vec};
+use aurora_engine_types::{borsh, Cow, Vec};
 use evm::{Context, ExitError};
 
 /// `get_promise_results` precompile address
@@ -71,8 +71,7 @@ impl<H: ReadOnlyPromiseHandler> Precompile for PromiseResult<H> {
             }
         }
 
-        let bytes = results
-            .try_to_vec()
+        let bytes = borsh::to_vec(&results)
             .map_err(|_| ExitError::Other(Cow::Borrowed("ERR_PROMISE_RESULT_SERIALIZATION")))?;
         Ok(PrecompileOutput::without_logs(cost, bytes))
     }

--- a/engine-precompiles/src/xcc.rs
+++ b/engine-precompiles/src/xcc.rs
@@ -7,7 +7,7 @@ use crate::{utils, HandleBasedPrecompile, PrecompileOutput};
 use aurora_engine_sdk::io::IO;
 use aurora_engine_types::{
     account_id::AccountId,
-    borsh::{BorshDeserialize, BorshSerialize},
+    borsh::{self, BorshDeserialize},
     format,
     parameters::{CrossContractCallArgs, PromiseCreateArgs},
     types::{balance::ZERO_YOCTO, Address, EthGas, NearGas},
@@ -147,8 +147,7 @@ impl<I: IO> HandleBasedPrecompile for CrossContractCall<I> {
                 let promise = PromiseCreateArgs {
                     target_account_id,
                     method: consts::ROUTER_EXEC_NAME.into(),
-                    args: call
-                        .try_to_vec()
+                    args: borsh::to_vec(&call)
                         .map_err(|_| ExitError::Other(Cow::from(consts::ERR_SERIALIZE)))?,
                     attached_balance: ZERO_YOCTO,
                     attached_gas: router_exec_cost.saturating_add(call_gas),
@@ -160,8 +159,7 @@ impl<I: IO> HandleBasedPrecompile for CrossContractCall<I> {
                 let promise = PromiseCreateArgs {
                     target_account_id,
                     method: consts::ROUTER_SCHEDULE_NAME.into(),
-                    args: call
-                        .try_to_vec()
+                    args: borsh::to_vec(&call)
                         .map_err(|_| ExitError::Other(Cow::from(consts::ERR_SERIALIZE)))?,
                     attached_balance: ZERO_YOCTO,
                     // We don't need to add any gas to the amount need for the schedule call
@@ -205,13 +203,13 @@ impl<I: IO> HandleBasedPrecompile for CrossContractCall<I> {
                     return Err(PrecompileFailure::Revert {
                         exit_status: r,
                         output: return_value,
-                    })
+                    });
                 }
                 evm::ExitReason::Error(e) => {
-                    return Err(PrecompileFailure::Error { exit_status: e })
+                    return Err(PrecompileFailure::Error { exit_status: e });
                 }
                 evm::ExitReason::Fatal(f) => {
-                    return Err(PrecompileFailure::Fatal { exit_status: f })
+                    return Err(PrecompileFailure::Fatal { exit_status: f });
                 }
             };
         }
@@ -226,8 +224,7 @@ impl<I: IO> HandleBasedPrecompile for CrossContractCall<I> {
         let promise_log = Log {
             address: cross_contract_call::ADDRESS.raw(),
             topics,
-            data: promise
-                .try_to_vec()
+            data: borsh::to_vec(&promise)
                 .map_err(|_| ExitError::Other(Cow::from(consts::ERR_SERIALIZE)))?,
         };
 

--- a/engine-sdk/Cargo.toml
+++ b/engine-sdk/Cargo.toml
@@ -17,8 +17,7 @@ sha2.workspace = true
 sha3.workspace = true
 
 [features]
-std = ["aurora-engine-types/std", "sha3/std", "sha2/std", "base64/std" ]
-borsh-compat = ["aurora-engine-types/borsh-compat"]
+std = ["aurora-engine-types/std", "sha3/std", "sha2/std", "base64/std"]
 contract = []
 log = []
 all-promise-actions = []

--- a/engine-sdk/src/io.rs
+++ b/engine-sdk/src/io.rs
@@ -1,7 +1,7 @@
 use crate::error;
 use crate::prelude::{vec, Vec};
 use aurora_engine_types::borsh::{BorshDeserialize, BorshSerialize};
-use aurora_engine_types::U256;
+use aurora_engine_types::{borsh, U256};
 
 /// The purpose of this trait is to represent a reference to a value that
 /// could be obtained by IO, but without eagerly loading it into memory.
@@ -161,7 +161,7 @@ pub trait IO {
         key: &[u8],
         value: &T,
     ) -> Option<Self::StorageValue> {
-        let bytes = value.try_to_vec().ok()?;
+        let bytes = borsh::to_vec(&value).ok()?;
         self.write_storage(key, &bytes)
     }
 }

--- a/engine-standalone-storage/Cargo.toml
+++ b/engine-standalone-storage/Cargo.toml
@@ -30,7 +30,6 @@ strum.workspace = true
 
 [features]
 default = ["snappy", "lz4", "zstd", "zlib"]
-borsh-compat = ["aurora-engine-types/borsh-compat", "aurora-engine-sdk/borsh-compat", "aurora-engine-precompiles/borsh-compat", "aurora-engine/borsh-compat"]
 mainnet = []
 testnet = []
 ext-connector = ["aurora-engine/ext-connector", "aurora-engine-precompiles/ext-connector"]

--- a/engine-standalone-storage/src/diff.rs
+++ b/engine-standalone-storage/src/diff.rs
@@ -2,10 +2,12 @@ use aurora_engine_types::borsh::{self, BorshDeserialize, BorshSerialize};
 use std::collections::{btree_map, BTreeMap};
 
 #[derive(Debug, Default, Clone, BorshDeserialize, BorshSerialize, PartialEq, Eq)]
+#[borsh(crate = "aurora_engine_types::borsh")]
 /// Collection of Engine state keys which changed by executing a transaction.
 pub struct Diff(BTreeMap<Vec<u8>, DiffValue>);
 
 #[derive(Debug, Clone, BorshDeserialize, BorshSerialize, PartialEq, Eq)]
+#[borsh(crate = "aurora_engine_types::borsh")]
 pub enum DiffValue {
     Modified(Vec<u8>),
     Deleted,
@@ -30,7 +32,7 @@ impl DiffValue {
     }
 
     pub fn try_to_bytes(&self) -> Result<Vec<u8>, std::io::Error> {
-        self.try_to_vec()
+        borsh::to_vec(&self)
     }
 
     pub fn try_from_bytes(bytes: &[u8]) -> Result<Self, std::io::Error> {
@@ -76,7 +78,7 @@ impl Diff {
     }
 
     pub fn try_to_bytes(&self) -> Result<Vec<u8>, std::io::Error> {
-        self.try_to_vec()
+        borsh::to_vec(&self)
     }
 
     pub fn try_from_bytes(bytes: &[u8]) -> Result<Self, std::io::Error> {

--- a/engine-standalone-storage/src/sync/types.rs
+++ b/engine-standalone-storage/src/sync/types.rs
@@ -12,6 +12,7 @@ use aurora_engine_types::{
     types::{self, Wei},
     H256, U256,
 };
+use serde::Serialize;
 use std::borrow::Cow;
 use strum::EnumString;
 
@@ -68,7 +69,7 @@ impl TransactionMessage {
     #[must_use]
     pub fn to_bytes(&self) -> Vec<u8> {
         let borshable: BorshableTransactionMessage = self.into();
-        borshable.try_to_vec().unwrap()
+        borsh::to_vec(&borshable).unwrap()
     }
 
     pub fn try_from_slice(bytes: &[u8]) -> Result<Self, std::io::Error> {
@@ -344,33 +345,33 @@ impl TransactionKind {
                                         access_list: Vec::new(),
                                     }
                                 },
-                                   |erc20_address| {
-                                       // ERC-20 refund
-                                       let from = Self::get_implicit_address(engine_account);
-                                       let nonce = Self::get_implicit_nonce(
-                                           &from,
-                                           block_height,
-                                           transaction_position,
-                                           storage,
-                                       );
-                                       let to = erc20_address;
-                                       let data = aurora_engine::engine::setup_refund_on_error_input(
-                                           U256::from_big_endian(&args.amount),
-                                           args.recipient_address,
-                                       );
-                                       NormalizedEthTransaction {
-                                           address: from,
-                                           chain_id: None,
-                                           nonce,
-                                           gas_limit: U256::from(u64::MAX),
-                                           max_priority_fee_per_gas: U256::zero(),
-                                           max_fee_per_gas: U256::zero(),
-                                           to: Some(to),
-                                           value: Wei::zero(),
-                                           data,
-                                           access_list: Vec::new(),
-                                       }
-                                   },
+                                                               |erc20_address| {
+                                                                   // ERC-20 refund
+                                                                   let from = Self::get_implicit_address(engine_account);
+                                                                   let nonce = Self::get_implicit_nonce(
+                                                                       &from,
+                                                                       block_height,
+                                                                       transaction_position,
+                                                                       storage,
+                                                                   );
+                                                                   let to = erc20_address;
+                                                                   let data = aurora_engine::engine::setup_refund_on_error_input(
+                                                                       U256::from_big_endian(&args.amount),
+                                                                       args.recipient_address,
+                                                                   );
+                                                                   NormalizedEthTransaction {
+                                                                       address: from,
+                                                                       chain_id: None,
+                                                                       nonce,
+                                                                       gas_limit: U256::from(u64::MAX),
+                                                                       max_priority_fee_per_gas: U256::zero(),
+                                                                       max_fee_per_gas: U256::zero(),
+                                                                       to: Some(to),
+                                                                       value: Wei::zero(),
+                                                                       data,
+                                                                       access_list: Vec::new(),
+                                                                   }
+                                                               },
                                 )
                             },
                         )
@@ -588,59 +589,61 @@ impl TransactionKind {
     pub fn raw_bytes(&self) -> Vec<u8> {
         match self {
             Self::Submit(tx) => tx.into(),
-            Self::SubmitWithArgs(args) => args.try_to_vec().unwrap_or_default(),
-            Self::Call(args) => args.try_to_vec().unwrap_or_default(),
-            Self::PausePrecompiles(args) | Self::ResumePrecompiles(args) => {
-                args.try_to_vec().unwrap_or_default()
-            }
+            Self::SubmitWithArgs(args) => to_borsh(args),
+            Self::Call(args) => to_borsh(args),
+            Self::PausePrecompiles(args) | Self::ResumePrecompiles(args) => to_borsh(args),
             Self::Deploy(bytes) | Self::Deposit(bytes) | Self::FactoryUpdate(bytes) => {
                 bytes.clone()
             }
-            Self::DeployErc20(args) => args.try_to_vec().unwrap_or_default(),
-            Self::FtOnTransfer(args) => serde_json::to_vec(args).unwrap_or_default(),
-            Self::FtTransferCall(args) => serde_json::to_vec(args).unwrap_or_default(),
-            Self::FinishDeposit(args) => args.try_to_vec().unwrap_or_default(),
-            Self::ResolveTransfer(args, _) => args.try_to_vec().unwrap_or_default(),
-            Self::FtTransfer(args) => serde_json::to_vec(args).unwrap_or_default(),
-            Self::Withdraw(args) => args.try_to_vec().unwrap_or_default(),
-            Self::StorageDeposit(args) => serde_json::to_vec(args).unwrap_or_default(),
-            Self::StorageUnregister(args) => serde_json::to_vec(args).unwrap_or_default(),
-            Self::StorageWithdraw(args) => serde_json::to_vec(args).unwrap_or_default(),
-            Self::SetOwner(args) => args.try_to_vec().unwrap_or_default(),
-            Self::SetUpgradeDelayBlocks(args) => args.try_to_vec().unwrap_or_default(),
-            Self::SetPausedFlags(args) => args.try_to_vec().unwrap_or_default(),
+            Self::DeployErc20(args) => to_borsh(args),
+            Self::FtOnTransfer(args) => to_json(args),
+            Self::FtTransferCall(args) => to_json(args),
+            Self::FinishDeposit(args) => to_borsh(args),
+            Self::ResolveTransfer(args, _) => to_borsh(args),
+            Self::FtTransfer(args) => to_json(args),
+            Self::Withdraw(args) => to_borsh(args),
+            Self::StorageDeposit(args) => to_json(args),
+            Self::StorageUnregister(args) => to_json(args),
+            Self::StorageWithdraw(args) => to_json(args),
+            Self::SetOwner(args) => to_borsh(args),
+            Self::SetUpgradeDelayBlocks(args) => to_borsh(args),
+            Self::SetPausedFlags(args) => to_borsh(args),
             Self::RegisterRelayer(address) | Self::FactorySetWNearAddress(address) => {
                 address.as_bytes().to_vec()
             }
             Self::ExitToNear(maybe_args) => maybe_args
                 .as_ref()
-                .and_then(|args| args.try_to_vec().ok())
+                .and_then(|args| borsh::to_vec(&args).ok())
                 .unwrap_or_default(),
-            Self::NewConnector(args) | Self::SetConnectorData(args) => {
-                args.try_to_vec().unwrap_or_default()
-            }
-            Self::NewEngine(args) => args.try_to_vec().unwrap_or_default(),
-            Self::FactoryUpdateAddressVersion(args) => args.try_to_vec().unwrap_or_default(),
-            Self::FundXccSubAccount(args) => args.try_to_vec().unwrap_or_default(),
-            Self::WithdrawWnearToRouter(args) => args.try_to_vec().unwrap_or_default(),
+            Self::NewConnector(args) | Self::SetConnectorData(args) => to_borsh(args),
+            Self::NewEngine(args) => to_borsh(args),
+            Self::FactoryUpdateAddressVersion(args) => to_borsh(args),
+            Self::FundXccSubAccount(args) => to_borsh(args),
+            Self::WithdrawWnearToRouter(args) => to_borsh(args),
             Self::PauseContract | Self::ResumeContract | Self::Unknown => Vec::new(),
-            Self::SetKeyManager(args) => args.try_to_vec().unwrap_or_default(),
-            Self::AddRelayerKey(args) | Self::RemoveRelayerKey(args) => {
-                args.try_to_vec().unwrap_or_default()
-            }
-            Self::StartHashchain(args) => args.try_to_vec().unwrap_or_default(),
-            Self::SetErc20Metadata(args) => serde_json::to_vec(args).unwrap_or_default(),
-            Self::SetFixedGas(args) => args.try_to_vec().unwrap_or_default(),
-            Self::SetSiloParams(args) => args.try_to_vec().unwrap_or_default(),
+            Self::SetKeyManager(args) => to_borsh(args),
+            Self::AddRelayerKey(args) | Self::RemoveRelayerKey(args) => to_borsh(args),
+            Self::StartHashchain(args) => to_borsh(args),
+            Self::SetErc20Metadata(args) => to_json(args),
+            Self::SetFixedGas(args) => to_borsh(args),
+            Self::SetSiloParams(args) => to_borsh(args),
             Self::AddEntryToWhitelist(args) | Self::RemoveEntryFromWhitelist(args) => {
-                args.try_to_vec().unwrap_or_default()
+                to_borsh(args)
             }
-            Self::AddEntryToWhitelistBatch(args) => args.try_to_vec().unwrap_or_default(),
-            Self::SetWhitelistStatus(args) => args.try_to_vec().unwrap_or_default(),
-            Self::SetEthConnectorContractAccount(args) => args.try_to_vec().unwrap_or_default(),
-            Self::MirrorErc20TokenCallback(args) => args.try_to_vec().unwrap_or_default(),
+            Self::AddEntryToWhitelistBatch(args) => to_borsh(args),
+            Self::SetWhitelistStatus(args) => to_borsh(args),
+            Self::SetEthConnectorContractAccount(args) => to_borsh(args),
+            Self::MirrorErc20TokenCallback(args) => to_borsh(args),
         }
     }
+}
+
+fn to_borsh<T: BorshSerialize>(args: &T) -> Vec<u8> {
+    borsh::to_vec(args).unwrap_or_default()
+}
+
+fn to_json<T: Serialize>(args: &T) -> Vec<u8> {
+    serde_json::to_vec(args).unwrap_or_default()
 }
 
 /// Used to make sure `TransactionKindTag` is kept in sync with `TransactionKind`
@@ -715,6 +718,7 @@ impl From<&TransactionKind> for TransactionKindTag {
 /// For details of what the individual fields mean, see the comments on the main
 /// `TransactionMessage` type.
 #[derive(BorshDeserialize, BorshSerialize)]
+#[borsh(crate = "aurora_engine_types::borsh")]
 enum BorshableTransactionMessage<'a> {
     V1(BorshableTransactionMessageV1<'a>),
     V2(BorshableTransactionMessageV2<'a>),
@@ -723,6 +727,7 @@ enum BorshableTransactionMessage<'a> {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
+#[borsh(crate = "aurora_engine_types::borsh")]
 struct BorshableTransactionMessageV1<'a> {
     pub block_hash: [u8; 32],
     pub near_receipt_id: [u8; 32],
@@ -735,6 +740,7 @@ struct BorshableTransactionMessageV1<'a> {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
+#[borsh(crate = "aurora_engine_types::borsh")]
 struct BorshableTransactionMessageV2<'a> {
     pub block_hash: [u8; 32],
     pub near_receipt_id: [u8; 32],
@@ -748,6 +754,7 @@ struct BorshableTransactionMessageV2<'a> {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
+#[borsh(crate = "aurora_engine_types::borsh")]
 struct BorshableTransactionMessageV3<'a> {
     pub block_hash: [u8; 32],
     pub near_receipt_id: [u8; 32],
@@ -762,6 +769,7 @@ struct BorshableTransactionMessageV3<'a> {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
+#[borsh(crate = "aurora_engine_types::borsh")]
 struct BorshableTransactionMessageV4<'a> {
     pub block_hash: [u8; 32],
     pub near_receipt_id: [u8; 32],
@@ -867,6 +875,7 @@ impl<'a> TryFrom<BorshableTransactionMessage<'a>> for TransactionMessage {
 /// so that this type can be cheaply created from a `TransactionKind` reference.
 /// !!!!! New types of transactions must be added at the end of the enum. !!!!!!
 #[derive(BorshDeserialize, BorshSerialize, Clone)]
+#[borsh(crate = "aurora_engine_types::borsh")]
 enum BorshableTransactionKind<'a> {
     Submit(Cow<'a, Vec<u8>>),
     Call(Cow<'a, parameters::CallArgs>),

--- a/engine-standalone-storage/src/sync/types.rs
+++ b/engine-standalone-storage/src/sync/types.rs
@@ -345,33 +345,33 @@ impl TransactionKind {
                                         access_list: Vec::new(),
                                     }
                                 },
-                                                               |erc20_address| {
-                                                                   // ERC-20 refund
-                                                                   let from = Self::get_implicit_address(engine_account);
-                                                                   let nonce = Self::get_implicit_nonce(
-                                                                       &from,
-                                                                       block_height,
-                                                                       transaction_position,
-                                                                       storage,
-                                                                   );
-                                                                   let to = erc20_address;
-                                                                   let data = aurora_engine::engine::setup_refund_on_error_input(
-                                                                       U256::from_big_endian(&args.amount),
-                                                                       args.recipient_address,
-                                                                   );
-                                                                   NormalizedEthTransaction {
-                                                                       address: from,
-                                                                       chain_id: None,
-                                                                       nonce,
-                                                                       gas_limit: U256::from(u64::MAX),
-                                                                       max_priority_fee_per_gas: U256::zero(),
-                                                                       max_fee_per_gas: U256::zero(),
-                                                                       to: Some(to),
-                                                                       value: Wei::zero(),
-                                                                       data,
-                                                                       access_list: Vec::new(),
-                                                                   }
-                                                               },
+                                   |erc20_address| {
+                                       // ERC-20 refund
+                                       let from = Self::get_implicit_address(engine_account);
+                                       let nonce = Self::get_implicit_nonce(
+                                           &from,
+                                           block_height,
+                                           transaction_position,
+                                           storage,
+                                       );
+                                       let to = erc20_address;
+                                       let data = aurora_engine::engine::setup_refund_on_error_input(
+                                           U256::from_big_endian(&args.amount),
+                                           args.recipient_address,
+                                       );
+                                       NormalizedEthTransaction {
+                                           address: from,
+                                           chain_id: None,
+                                           nonce,
+                                           gas_limit: U256::from(u64::MAX),
+                                           max_priority_fee_per_gas: U256::zero(),
+                                           max_fee_per_gas: U256::zero(),
+                                           to: Some(to),
+                                           value: Wei::zero(),
+                                           data,
+                                           access_list: Vec::new(),
+                                       }
+                                   },
                                 )
                             },
                         )

--- a/engine-tests-connector/src/utils.rs
+++ b/engine-tests-connector/src/utils.rs
@@ -158,7 +158,7 @@ impl TestContract {
         assert!(res.is_success());
 
         let acc = SetEthConnectorContractAccountArgs {
-            account: eth_connector_contract.id().parse().unwrap(),
+            account: eth_connector_contract.id().as_str().parse().unwrap(),
             withdraw_serialize_type: WithdrawSerializeType::Borsh,
         };
         let res = engine_contract
@@ -293,10 +293,11 @@ impl TestContract {
 
     pub async fn get_eth_balance(&self, address: &Address) -> anyhow::Result<u128> {
         #[derive(BorshSerialize, BorshDeserialize)]
+        #[borsh(crate = "aurora_engine_types::borsh")]
         pub struct BalanceOfEthCallArgs {
             pub address: Address,
         }
-        let args = BalanceOfEthCallArgs { address: *address }.try_to_vec()?;
+        let args = borsh::to_vec(&BalanceOfEthCallArgs { address: *address })?;
         let res = self
             .engine_contract
             .call("ft_balance_of_eth")

--- a/engine-tests/src/tests/erc20.rs
+++ b/engine-tests/src/tests/erc20.rs
@@ -9,7 +9,6 @@ use aurora_engine::engine::EngineErrorKind;
 use aurora_engine::parameters::TransactionStatus;
 use aurora_engine_sdk as sdk;
 use aurora_engine_types::account_id::AccountId;
-use aurora_engine_types::borsh::BorshSerialize;
 use aurora_engine_types::parameters::connector::{
     Erc20Identifier, Erc20Metadata, SetErc20MetadataArgs,
 };
@@ -310,7 +309,11 @@ fn test_erc20_get_and_set_metadata_by_owner() {
         new_owner: str_to_account_id(new_owner),
     };
 
-    let result = runner.call("set_owner", &caller, set_owner_args.try_to_vec().unwrap());
+    let result = runner.call(
+        "set_owner",
+        &caller,
+        borsh::to_vec(&set_owner_args).unwrap(),
+    );
     assert!(result.is_ok());
 
     let caller = new_owner;

--- a/engine-tests/src/tests/erc20_connector.rs
+++ b/engine-tests/src/tests/erc20_connector.rs
@@ -3,7 +3,7 @@ use crate::utils::{self, create_eth_transaction, AuroraRunner, DEFAULT_AURORA_AC
 use aurora_engine::engine::EngineError;
 use aurora_engine::parameters::{CallArgs, FunctionCallArgsV2};
 use aurora_engine_transactions::legacy::LegacyEthSignedTransaction;
-use aurora_engine_types::borsh::{BorshDeserialize, BorshSerialize};
+use aurora_engine_types::borsh::BorshDeserialize;
 use aurora_engine_types::parameters::engine::{SubmitResult, TransactionStatus};
 use ethabi::Token;
 use libsecp256k1::SecretKey;
@@ -72,12 +72,11 @@ impl AuroraRunner {
         self.make_call(
             "call",
             origin,
-            CallArgs::V2(FunctionCallArgsV2 {
+            borsh::to_vec(&CallArgs::V2(FunctionCallArgsV2 {
                 contract,
                 value: WeiU256::default(),
                 input,
-            })
-            .try_to_vec()
+            }))
             .unwrap(),
         )
     }
@@ -95,7 +94,7 @@ impl AuroraRunner {
             .make_call(
                 "deploy_erc20_token",
                 DEFAULT_AURORA_ACCOUNT_ID,
-                nep141.try_to_vec().unwrap(),
+                borsh::to_vec(&nep141).unwrap(),
             )
             .unwrap();
 
@@ -205,7 +204,7 @@ impl AuroraRunner {
         self.make_call(
             "register_relayer",
             relayer_account_id,
-            relayer_address.try_to_vec().unwrap(),
+            borsh::to_vec(&relayer_address).unwrap(),
         )
     }
 
@@ -216,7 +215,7 @@ impl AuroraRunner {
         self.make_call(
             "factory_set_wnear_address",
             DEFAULT_AURORA_ACCOUNT_ID,
-            wnear_address.try_to_vec().unwrap(),
+            borsh::to_vec(&wnear_address).unwrap(),
         )
     }
 }

--- a/engine-tests/src/tests/ghsa_3p69_m8gg_fwmf.rs
+++ b/engine-tests/src/tests/ghsa_3p69_m8gg_fwmf.rs
@@ -1,5 +1,4 @@
 use crate::utils;
-use aurora_engine_types::borsh::BorshSerialize;
 
 #[test]
 fn test_exploit_fix() {
@@ -40,7 +39,7 @@ fn test_exploit_fix() {
     let tx = contract.call_method_with_args("echo", &[ethabi::Token::Bytes(payload)], nonce.into());
     let sender = utils::address_from_secret_key(&signer.secret_key);
     let view_call_args = utils::as_view_call(tx, sender);
-    let input = view_call_args.try_to_vec().unwrap();
+    let input = borsh::to_vec(&view_call_args).unwrap();
     let error = runner.one_shot().call("view", "viewer", input).unwrap_err();
 
     assert!(

--- a/engine-tests/src/tests/hashchain.rs
+++ b/engine-tests/src/tests/hashchain.rs
@@ -3,7 +3,6 @@ use aurora_engine::parameters::{StartHashchainArgs, SubmitResult, TransactionSta
 use aurora_engine_hashchain::bloom::Bloom;
 use aurora_engine_transactions::legacy::TransactionLegacy;
 use aurora_engine_types::{
-    borsh::BorshSerialize,
     types::{Address, Wei},
     H256, U256,
 };
@@ -34,9 +33,12 @@ fn test_hashchain() {
     let signed_transaction =
         utils::sign_transaction(transaction, Some(runner.chain_id), &signer.secret_key);
     let input = rlp::encode(&signed_transaction).to_vec();
-    let output = SubmitResult::new(TransactionStatus::Succeed(Vec::new()), 21_000, Vec::new())
-        .try_to_vec()
-        .unwrap();
+    let output = borsh::to_vec(&SubmitResult::new(
+        TransactionStatus::Succeed(Vec::new()),
+        21_000,
+        Vec::new(),
+    ))
+    .unwrap();
 
     let expected_hc = {
         let start_hc_args = StartHashchainArgs {
@@ -54,7 +56,7 @@ fn test_hashchain() {
         hc.add_block_tx(
             block_height,
             "start_hashchain",
-            &start_hc_args.try_to_vec().unwrap(),
+            &borsh::to_vec(&start_hc_args).unwrap(),
             &[],
             &Bloom::default(),
         )

--- a/engine-tests/src/tests/pausable_precompiles.rs
+++ b/engine-tests/src/tests/pausable_precompiles.rs
@@ -6,7 +6,6 @@ use crate::utils::{
 };
 use aurora_engine::engine::EngineErrorKind;
 use aurora_engine::parameters::{PausePrecompilesCallArgs, TransactionStatus};
-use aurora_engine_types::borsh::BorshSerialize;
 use aurora_engine_types::types::Wei;
 
 const EXIT_TO_ETHEREUM_FLAG: u32 = 0b10;
@@ -19,7 +18,7 @@ fn test_paused_precompile_is_shown_when_viewing() {
     let call_args = PausePrecompilesCallArgs {
         paused_mask: EXIT_TO_ETHEREUM_FLAG,
     };
-    let input = call_args.try_to_vec().unwrap();
+    let input = borsh::to_vec(&call_args).unwrap();
 
     let _res = runner.call(PAUSE_PRECOMPILES, CALLED_ACCOUNT_ID, input);
     let result = runner
@@ -40,7 +39,7 @@ fn test_executing_paused_precompile_throws_error() {
     let call_args = PausePrecompilesCallArgs {
         paused_mask: EXIT_TO_ETHEREUM_FLAG,
     };
-    let input = call_args.try_to_vec().unwrap();
+    let input = borsh::to_vec(&call_args).unwrap();
 
     let _res = runner.call(PAUSE_PRECOMPILES, CALLED_ACCOUNT_ID, input);
     let is_to_near = false;
@@ -61,7 +60,7 @@ fn test_executing_paused_and_then_resumed_precompile_succeeds() {
     let call_args = PausePrecompilesCallArgs {
         paused_mask: EXIT_TO_ETHEREUM_FLAG,
     };
-    let input = call_args.try_to_vec().unwrap();
+    let input = borsh::to_vec(&call_args).unwrap();
 
     let _res = runner.call(PAUSE_PRECOMPILES, CALLED_ACCOUNT_ID, input.clone());
     let _res = runner.call(RESUME_PRECOMPILES, CALLED_ACCOUNT_ID, input);
@@ -83,7 +82,7 @@ fn test_resuming_precompile_does_not_throw_error() {
     let mut runner = utils::deploy_runner();
 
     let call_args = PausePrecompilesCallArgs { paused_mask: 0b1 };
-    let input = call_args.try_to_vec().unwrap();
+    let input = borsh::to_vec(&call_args).unwrap();
     let result = runner.call(RESUME_PRECOMPILES, CALLED_ACCOUNT_ID, input);
 
     assert!(result.is_ok(), "{result:?}");
@@ -93,7 +92,7 @@ fn test_resuming_precompile_does_not_throw_error() {
 fn test_pausing_precompile_does_not_throw_error() {
     let mut runner = utils::deploy_runner();
     let call_args = PausePrecompilesCallArgs { paused_mask: 0b1 };
-    let input = call_args.try_to_vec().unwrap();
+    let input = borsh::to_vec(&call_args).unwrap();
     let result = runner.call(PAUSE_PRECOMPILES, CALLED_ACCOUNT_ID, input);
 
     assert!(result.is_ok(), "{result:?}");

--- a/engine-tests/src/tests/pause_contract.rs
+++ b/engine-tests/src/tests/pause_contract.rs
@@ -1,6 +1,5 @@
 use crate::utils;
 use aurora_engine::parameters::SetUpgradeDelayBlocksArgs;
-use aurora_engine_types::borsh::BorshSerialize;
 
 #[test]
 fn test_pause_contract_require_owner() {
@@ -66,10 +65,9 @@ fn test_resume_contract_require_paused() {
 fn test_pause_contract() {
     let mut runner = utils::deploy_runner();
     let aurora_account_id = runner.aurora_account_id.clone();
-    let set = SetUpgradeDelayBlocksArgs {
+    let set = borsh::to_vec(&SetUpgradeDelayBlocksArgs {
         upgrade_delay_blocks: 2,
-    }
-    .try_to_vec()
+    })
     .unwrap();
 
     // contract is running by default, gets and sets should work
@@ -99,10 +97,9 @@ fn test_pause_contract() {
 fn test_resume_contract() {
     let mut runner = utils::deploy_runner();
     let aurora_account_id = runner.aurora_account_id.clone();
-    let set = SetUpgradeDelayBlocksArgs {
+    let set = borsh::to_vec(&SetUpgradeDelayBlocksArgs {
         upgrade_delay_blocks: 2,
-    }
-    .try_to_vec()
+    })
     .unwrap();
 
     // pause contract

--- a/engine-tests/src/tests/promise_results_precompile.rs
+++ b/engine-tests/src/tests/promise_results_precompile.rs
@@ -1,7 +1,6 @@
 use crate::utils;
 use aurora_engine_precompiles::promise_result::{self, costs};
 use aurora_engine_transactions::legacy::TransactionLegacy;
-use aurora_engine_types::borsh::BorshSerialize;
 use aurora_engine_types::{
     types::{Address, EthGas, NearGas, PromiseResult, Wei},
     U256,
@@ -35,7 +34,7 @@ fn test_promise_results_precompile() {
 
     assert_eq!(
         utils::unwrap_success(result),
-        promise_results.try_to_vec().unwrap(),
+        borsh::to_vec(&promise_results).unwrap(),
     );
 }
 
@@ -104,7 +103,7 @@ fn test_promise_result_gas_cost() {
         utils::within_x_percent(
             5,
             base_cost.as_u64(),
-            costs::PROMISE_RESULT_BASE_COST.as_u64()
+            costs::PROMISE_RESULT_BASE_COST.as_u64(),
         ),
         "Incorrect promise_result base cost. Expected: {} Actual: {}",
         base_cost,

--- a/engine-tests/src/tests/repro.rs
+++ b/engine-tests/src/tests/repro.rs
@@ -2,7 +2,7 @@
 
 use crate::utils::{standalone, AuroraRunner, ExecutionProfile};
 use aurora_engine::parameters::SubmitResult;
-use aurora_engine_types::borsh::{BorshDeserialize, BorshSerialize};
+use aurora_engine_types::borsh::BorshDeserialize;
 use engine_standalone_storage::json_snapshot;
 
 /// This test reproduces a transaction from testnet:
@@ -174,8 +174,8 @@ fn repro_common(context: &ReproContext) {
         .submit_raw("submit", &runner.context, &[], None)
         .unwrap();
     assert_eq!(
-        submit_result.try_to_vec().unwrap(),
-        standalone_result.try_to_vec().unwrap()
+        borsh::to_vec(&submit_result).unwrap(),
+        borsh::to_vec(&standalone_result).unwrap()
     );
     standalone.close();
 }

--- a/engine-tests/src/tests/sanity.rs
+++ b/engine-tests/src/tests/sanity.rs
@@ -4,7 +4,7 @@ use crate::utils::{self, str_to_account_id};
 use aurora_engine::engine::{EngineErrorKind, GasPaymentError, ZERO_ADDRESS_FIX_HEIGHT};
 use aurora_engine::parameters::{SetOwnerArgs, SetUpgradeDelayBlocksArgs, TransactionStatus};
 use aurora_engine_sdk as sdk;
-use aurora_engine_types::borsh::{BorshDeserialize, BorshSerialize};
+use aurora_engine_types::borsh::BorshDeserialize;
 #[cfg(not(feature = "ext-connector"))]
 use aurora_engine_types::parameters::connector::FungibleTokenMetadata;
 use aurora_engine_types::H160;
@@ -390,7 +390,7 @@ fn test_is_contract() {
     assert!(!call_contract(
         Address::from_array([1; 20]),
         &mut runner,
-        &mut signer
+        &mut signer,
     ));
 
     // Should return false for accounts that don't have contract code
@@ -1036,7 +1036,7 @@ fn test_block_hash_api() {
         .call(
             "get_block_hash",
             "any.near",
-            block_height.try_to_vec().unwrap(),
+            borsh::to_vec(&block_height).unwrap(),
         )
         .unwrap();
     let block_hash = outcome.return_data.as_value().unwrap();
@@ -1142,7 +1142,7 @@ fn test_set_owner() {
     let result = runner.call(
         "set_owner",
         &aurora_account_id,
-        set_owner_args.try_to_vec().unwrap(),
+        borsh::to_vec(&set_owner_args).unwrap(),
     );
 
     // setting owner from the owner with same owner id should succeed
@@ -1175,7 +1175,7 @@ fn test_set_owner_fail_on_same_owner() {
         .call(
             "set_owner",
             &aurora_account_id,
-            set_owner_args.try_to_vec().unwrap(),
+            borsh::to_vec(&set_owner_args).unwrap(),
         )
         .unwrap_err();
 
@@ -1196,7 +1196,7 @@ fn test_set_upgrade_delay_blocks() {
     let result = runner.call(
         "set_upgrade_delay_blocks",
         &aurora_account_id,
-        set_upgrade_delay_blocks.try_to_vec().unwrap(),
+        borsh::to_vec(&set_upgrade_delay_blocks).unwrap(),
     );
 
     // should succeed

--- a/engine-tests/src/tests/silo.rs
+++ b/engine-tests/src/tests/silo.rs
@@ -291,17 +291,15 @@ fn test_admin_access_right() {
     set_silo_params(&mut runner, Some(SILO_PARAMS_ARGS));
     // Allow to submit transactions.
 
-    let account = WhitelistArgs::WhitelistAccountArgs(WhitelistAccountArgs {
+    let account = borsh::to_vec(&WhitelistArgs::WhitelistAccountArgs(WhitelistAccountArgs {
         account_id: caller.clone(),
         kind: WhitelistKind::Account,
-    })
-    .try_to_vec()
+    }))
     .unwrap();
-    let address = WhitelistArgs::WhitelistAddressArgs(WhitelistAddressArgs {
+    let address = borsh::to_vec(&WhitelistArgs::WhitelistAddressArgs(WhitelistAddressArgs {
         address: sender,
         kind: WhitelistKind::Address,
-    })
-    .try_to_vec()
+    }))
     .unwrap();
 
     let err = runner
@@ -883,7 +881,7 @@ fn set_silo_params(runner: &mut AuroraRunner, silo_params: Option<SiloParamsArgs
 }
 
 fn call_function<T: BorshSerialize + Debug>(runner: &mut AuroraRunner, func: &str, args: T) {
-    let input = args.try_to_vec().unwrap();
+    let input = borsh::to_vec(&args).unwrap();
     let result = runner.call(func, &runner.aurora_account_id.clone(), input);
     assert!(
         result.is_ok(),

--- a/engine-tests/src/tests/standalone/call_tracer.rs
+++ b/engine-tests/src/tests/standalone/call_tracer.rs
@@ -2,7 +2,6 @@ use crate::prelude::{H160, H256};
 use crate::utils::solidity::erc20::{ERC20Constructor, ERC20};
 use crate::utils::{self, standalone, Signer};
 use aurora_engine_modexp::AuroraModExp;
-use aurora_engine_types::borsh::BorshSerialize;
 use aurora_engine_types::{
     parameters::{CrossContractCallArgs, PromiseArgs, PromiseCreateArgs},
     storage,
@@ -425,7 +424,7 @@ fn test_trace_precompiles_with_subcalls() {
         gas_limit: u64::MAX.into(),
         to: Some(xcc_address),
         value: Wei::zero(),
-        data: xcc_args.try_to_vec().unwrap(),
+        data: borsh::to_vec(&xcc_args).unwrap(),
     };
     let mut listener = CallTracer::default();
     let standalone_result = sputnik::traced_call(&mut listener, || {

--- a/engine-tests/src/tests/standalone/sync.rs
+++ b/engine-tests/src/tests/standalone/sync.rs
@@ -3,7 +3,7 @@ use aurora_engine::contract_methods::connector::deposit_event::TokenMessageData;
 use aurora_engine_modexp::AuroraModExp;
 use aurora_engine_sdk::env::{Env, Timestamp};
 #[cfg(not(feature = "ext-connector"))]
-use aurora_engine_types::borsh::{BorshDeserialize, BorshSerialize};
+use aurora_engine_types::borsh::BorshDeserialize;
 use aurora_engine_types::types::{Address, Balance, Wei};
 #[cfg(not(feature = "ext-connector"))]
 use aurora_engine_types::types::{Fee, NEP141Wei};
@@ -50,7 +50,7 @@ fn test_consume_deposit_message() {
     let recipient_address = Address::new(H160([22u8; 20]));
     let deposit_amount = Wei::new_u64(123_456_789);
     let proof = mock_proof(recipient_address, deposit_amount);
-    let tx_kind = sync::types::TransactionKind::Deposit(proof.try_to_vec().unwrap());
+    let tx_kind = sync::types::TransactionKind::Deposit(borsh::to_vec(&proof).unwrap());
     let raw_input = tx_kind.raw_bytes();
 
     let transaction_message = sync::types::TransactionMessage {
@@ -101,7 +101,7 @@ fn test_consume_deposit_message() {
         transaction: tx_kind,
         // Need to pass the result of calling the proof verifier
         // (which is `true` because the proof is valid in this case).
-        promise_data: vec![Some(true.try_to_vec().unwrap())],
+        promise_data: vec![Some(borsh::to_vec(&true).unwrap())],
         raw_input,
         action_hash: H256::default(),
     };

--- a/engine-tests/src/utils/mod.rs
+++ b/engine-tests/src/utils/mod.rs
@@ -1,7 +1,7 @@
 use aurora_engine::engine::{EngineError, EngineErrorKind, GasPaymentError};
 use aurora_engine::parameters::{SubmitArgs, ViewCallArgs};
 use aurora_engine_types::account_id::AccountId;
-use aurora_engine_types::borsh::{BorshDeserialize, BorshSerialize};
+use aurora_engine_types::borsh::BorshDeserialize;
 #[cfg(not(feature = "ext-connector"))]
 use aurora_engine_types::parameters::connector::FungibleTokenMetadata;
 #[cfg(feature = "ext-connector")]
@@ -346,11 +346,11 @@ impl AuroraRunner {
                 &[crate::prelude::storage::EthConnectorStorageId::UsedEvent.into()],
             );
 
-            trie.insert(ft_key, ft_value.try_to_vec().unwrap());
+            trie.insert(ft_key, borsh::to_vec(&ft_value).unwrap());
             trie.insert(proof_key, vec![0]);
             trie.insert(
                 aurora_balance_key,
-                aurora_balance_value.try_to_vec().unwrap(),
+                borsh::to_vec(&aurora_balance_value).unwrap(),
             );
         }
 
@@ -434,7 +434,7 @@ impl AuroraRunner {
         self.call(
             SUBMIT_WITH_ARGS,
             CALLER_ACCOUNT_ID,
-            args.try_to_vec().unwrap(),
+            borsh::to_vec(&args).unwrap(),
         )
         .map(Self::profile_outcome)
     }
@@ -468,7 +468,7 @@ impl AuroraRunner {
     }
 
     pub fn view_call(&self, args: &ViewCallArgs) -> Result<TransactionStatus, EngineError> {
-        let input = args.try_to_vec().unwrap();
+        let input = borsh::to_vec(&args).unwrap();
         let mut runner = self.one_shot();
         runner.context.view_config = Some(ViewConfig {
             max_gas_burnt: u64::MAX,
@@ -483,7 +483,7 @@ impl AuroraRunner {
         &self,
         args: &ViewCallArgs,
     ) -> Result<(TransactionStatus, ExecutionProfile), EngineError> {
-        let input = args.try_to_vec().unwrap();
+        let input = borsh::to_vec(&args).unwrap();
         let mut runner = self.one_shot();
 
         runner.context.view_config = Some(ViewConfig {
@@ -525,7 +525,7 @@ impl AuroraRunner {
         };
         let outcome = self
             .one_shot()
-            .call("get_storage_at", "getter", input.try_to_vec().unwrap())
+            .call("get_storage_at", "getter", borsh::to_vec(&input).unwrap())
             .unwrap();
         let output = outcome.return_data.as_value().unwrap();
         let mut result = [0u8; 32];
@@ -712,7 +712,7 @@ pub fn deploy_runner() -> AuroraRunner {
     });
 
     let account_id = runner.aurora_account_id.clone();
-    let result = runner.call("new", &account_id, args.try_to_vec().unwrap());
+    let result = runner.call("new", &account_id, borsh::to_vec(&args).unwrap());
 
     assert!(result.is_ok());
 
@@ -723,7 +723,11 @@ pub fn deploy_runner() -> AuroraRunner {
             eth_custodian_address: "d045f7e19B2488924B97F9c145b5E51D0D895A65".to_string(),
             metadata: FungibleTokenMetadata::default(),
         };
-        runner.call("new_eth_connector", &account_id, args.try_to_vec().unwrap())
+        runner.call(
+            "new_eth_connector",
+            &account_id,
+            borsh::to_vec(&args).unwrap(),
+        )
     };
 
     #[cfg(feature = "ext-connector")]
@@ -736,7 +740,7 @@ pub fn deploy_runner() -> AuroraRunner {
         runner.call(
             "set_eth_connector_contract_account",
             &account_id,
-            args.try_to_vec().unwrap(),
+            borsh::to_vec(&args).unwrap(),
         )
     };
 
@@ -769,7 +773,7 @@ pub fn init_hashchain(
     let result = runner.call(
         "start_hashchain",
         caller_account_id,
-        args.try_to_vec().unwrap(),
+        borsh::to_vec(&args).unwrap(),
     );
     assert!(result.is_ok());
 }

--- a/engine-tests/src/utils/solidity/self_destruct.rs
+++ b/engine-tests/src/utils/solidity/self_destruct.rs
@@ -3,7 +3,6 @@ use crate::prelude::{
     Address, WeiU256, U256,
 };
 use crate::utils::{self, solidity, AuroraRunner, Signer};
-use aurora_engine_types::borsh::BorshSerialize;
 use aurora_engine_types::types::Wei;
 
 pub struct SelfDestructFactoryConstructor(pub solidity::ContractConstructor);
@@ -173,12 +172,11 @@ impl SelfDestruct {
             .encode_input(&[])
             .unwrap();
 
-        let input = CallArgs::V2(FunctionCallArgsV2 {
+        let input = borsh::to_vec(&CallArgs::V2(FunctionCallArgsV2 {
             contract: self.contract.address,
             value: WeiU256::default(),
             input: data,
-        })
-        .try_to_vec()
+        }))
         .unwrap();
 
         runner.call("call", "anyone", input).unwrap();

--- a/engine-types/Cargo.toml
+++ b/engine-types/Cargo.toml
@@ -12,7 +12,6 @@ publish.workspace = true
 
 [dependencies]
 base64.workspace = true
-borsh-compat = { workspace = true, optional = true }
 borsh.workspace = true
 bs58.workspace = true
 hex.workspace = true

--- a/engine-types/src/account_id.rs
+++ b/engine-types/src/account_id.rs
@@ -3,10 +3,7 @@
 //! Inspired by: `https://github.com/near/nearcore/tree/master/core/account-id`
 
 use crate::{fmt, str, str::FromStr, AsBytes, Box, String, ToString, Vec};
-#[cfg(not(feature = "borsh-compat"))]
-use borsh::{maybestd::io, BorshDeserialize, BorshSerialize};
-#[cfg(feature = "borsh-compat")]
-use borsh_compat::{self as borsh, maybestd::io, BorshDeserialize, BorshSerialize};
+use borsh::{io, BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 
 pub const MIN_ACCOUNT_ID_LEN: usize = 2;
@@ -88,24 +85,9 @@ impl AccountId {
     }
 }
 
-#[cfg(not(feature = "borsh-compat"))]
 impl BorshDeserialize for AccountId {
     fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
         let account: String = BorshDeserialize::deserialize_reader(reader)?;
-
-        // It's for saving backward compatibility.
-        if account.is_empty() {
-            return Ok(Self::default());
-        }
-
-        Self::new(&account).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))
-    }
-}
-
-#[cfg(feature = "borsh-compat")]
-impl BorshDeserialize for AccountId {
-    fn deserialize(buf: &mut &[u8]) -> io::Result<Self> {
-        let account: String = BorshDeserialize::deserialize(buf)?;
 
         // It's for saving backward compatibility.
         if account.is_empty() {

--- a/engine-types/src/lib.rs
+++ b/engine-types/src/lib.rs
@@ -29,16 +29,12 @@ mod v0 {
         vec,
         vec::Vec,
     };
+    pub use borsh;
     pub use core::{
         cmp::Ordering, fmt::Display, marker::PhantomData, mem, ops::Add, ops::AddAssign, ops::Div,
         ops::Mul, ops::Sub, ops::SubAssign,
     };
     pub use primitive_types::{H160, H256, U256};
-
-    #[cfg(not(feature = "borsh-compat"))]
-    pub use borsh;
-    #[cfg(feature = "borsh-compat")]
-    pub use borsh_compat::{self as borsh};
 }
 
 pub use v0::*;

--- a/engine-types/src/parameters/connector.rs
+++ b/engine-types/src/parameters/connector.rs
@@ -1,8 +1,5 @@
 use base64::Engine;
-#[cfg(not(feature = "borsh-compat"))]
 use borsh::{BorshDeserialize, BorshSerialize};
-#[cfg(feature = "borsh-compat")]
-use borsh_compat::{self as borsh, BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 
 use crate::account_id::AccountId;

--- a/engine-types/src/parameters/promise.rs
+++ b/engine-types/src/parameters/promise.rs
@@ -3,10 +3,7 @@ use crate::public_key::PublicKey;
 use crate::types::{Address, NEP141Wei, NearGas, RawU256, Yocto};
 use crate::{Box, String, Vec};
 
-#[cfg(not(feature = "borsh-compat"))]
-use borsh::{maybestd::io, BorshDeserialize, BorshSerialize};
-#[cfg(feature = "borsh-compat")]
-use borsh_compat::{self as borsh, maybestd::io, BorshDeserialize, BorshSerialize};
+use borsh::{io, BorshDeserialize, BorshSerialize};
 
 #[must_use]
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
@@ -178,7 +175,6 @@ impl BorshSerialize for NearPromise {
     }
 }
 
-#[cfg(not(feature = "borsh-compat"))]
 impl BorshDeserialize for NearPromise {
     fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
         let variant_byte = {
@@ -201,36 +197,6 @@ impl BorshDeserialize for NearPromise {
             }
             0x02 => {
                 let promises: Vec<Self> = Vec::deserialize_reader(reader)?;
-                Ok(Self::And(promises))
-            }
-            _ => Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "Invalid variant byte for NearPromise",
-            )),
-        }
-    }
-}
-
-#[cfg(feature = "borsh-compat")]
-impl BorshDeserialize for NearPromise {
-    fn deserialize(buf: &mut &[u8]) -> io::Result<Self> {
-        let variant_byte = buf[0];
-        *buf = &buf[1..];
-        match variant_byte {
-            0x00 => {
-                let inner = SimpleNearPromise::deserialize(buf)?;
-                Ok(Self::Simple(inner))
-            }
-            0x01 => {
-                let base = Self::deserialize(buf)?;
-                let callback = SimpleNearPromise::deserialize(buf)?;
-                Ok(Self::Then {
-                    base: Box::new(base),
-                    callback,
-                })
-            }
-            0x02 => {
-                let promises: Vec<Self> = Vec::deserialize(buf)?;
                 Ok(Self::And(promises))
             }
             _ => Err(io::Error::new(

--- a/engine-types/src/parameters/silo.rs
+++ b/engine-types/src/parameters/silo.rs
@@ -56,6 +56,7 @@ pub struct WhitelistKindArgs {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 #[cfg_attr(feature = "impl-serde", derive(serde::Serialize, serde::Deserialize))]
+#[borsh(use_discriminant = false)]
 pub enum WhitelistKind {
     /// The whitelist of this type is for storing NEAR accounts. Accounts stored in this whitelist
     /// have an admin role. The admin role allows to add new admins and add new entities
@@ -90,7 +91,7 @@ fn test_account_whitelist_serialize() {
         account_id: "aurora".parse().unwrap(),
         kind: WhitelistKind::Admin,
     });
-    let bytes = args.try_to_vec().unwrap();
+    let bytes = borsh::to_vec(&args).unwrap();
     let args = WhitelistArgs::try_from_slice(&bytes).unwrap();
 
     assert_eq!(
@@ -109,7 +110,7 @@ fn test_address_whitelist_serialize() {
         address,
         kind: WhitelistKind::EvmAdmin,
     });
-    let bytes = args.try_to_vec().unwrap();
+    let bytes = borsh::to_vec(&args).unwrap();
     let args = WhitelistArgs::try_from_slice(&bytes).unwrap();
 
     assert_eq!(

--- a/engine-types/src/parameters/xcc.rs
+++ b/engine-types/src/parameters/xcc.rs
@@ -1,5 +1,5 @@
 use crate::account_id::AccountId;
-use crate::borsh::{self, BorshDeserialize, BorshSerialize};
+use crate::borsh::{BorshDeserialize, BorshSerialize};
 use crate::types::{Address, Yocto};
 
 #[derive(Debug, Clone, PartialEq, Eq, BorshDeserialize, BorshSerialize)]

--- a/engine-types/src/public_key.rs
+++ b/engine-types/src/public_key.rs
@@ -1,8 +1,5 @@
 use crate::{fmt, str::FromStr, String, ToString};
-#[cfg(not(feature = "borsh-compat"))]
-use borsh::{maybestd::io, BorshDeserialize, BorshSerialize};
-#[cfg(feature = "borsh-compat")]
-use borsh_compat::{maybestd::io, BorshDeserialize, BorshSerialize};
+use borsh::{io, BorshDeserialize, BorshSerialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PublicKey {
@@ -38,7 +35,6 @@ impl BorshSerialize for PublicKey {
     }
 }
 
-#[cfg(not(feature = "borsh-compat"))]
 impl BorshDeserialize for PublicKey {
     fn deserialize_reader<R: io::Read>(rd: &mut R) -> io::Result<Self> {
         let key_type = u8::deserialize_reader(rd).and_then(KeyType::try_from)?;
@@ -46,18 +42,6 @@ impl BorshDeserialize for PublicKey {
         match key_type {
             KeyType::Ed25519 => Ok(Self::Ed25519(BorshDeserialize::deserialize_reader(rd)?)),
             KeyType::Secp256k1 => Ok(Self::Secp256k1(BorshDeserialize::deserialize_reader(rd)?)),
-        }
-    }
-}
-
-#[cfg(feature = "borsh-compat")]
-impl BorshDeserialize for PublicKey {
-    fn deserialize(buf: &mut &[u8]) -> io::Result<Self> {
-        let key_type = <u8 as BorshDeserialize>::deserialize(buf).and_then(KeyType::try_from)?;
-
-        match key_type {
-            KeyType::Ed25519 => Ok(Self::Ed25519(BorshDeserialize::deserialize(buf)?)),
-            KeyType::Secp256k1 => Ok(Self::Secp256k1(BorshDeserialize::deserialize(buf)?)),
         }
     }
 }

--- a/engine-types/src/storage.rs
+++ b/engine-types/src/storage.rs
@@ -1,8 +1,5 @@
 use crate::{types::Address, Vec, H256};
-#[cfg(not(feature = "borsh-compat"))]
 use borsh::{BorshDeserialize, BorshSerialize};
-#[cfg(feature = "borsh-compat")]
-use borsh_compat::{self as borsh, BorshDeserialize, BorshSerialize};
 
 // NOTE: We start at 0x7 as our initial value as our original storage was not
 // version prefixed and ended as 0x6.
@@ -20,6 +17,7 @@ impl From<VersionPrefix> for u8 {
 
 #[allow(dead_code)]
 #[derive(Clone, Copy, BorshSerialize, BorshDeserialize)]
+#[borsh(use_discriminant = false)]
 pub enum KeyPrefix {
     Config = 0x0,
     Nonce = 0x1,
@@ -62,6 +60,7 @@ impl From<KeyPrefix> for u8 {
 
 /// Enum used to differentiate different storage keys used by eth-connector
 #[derive(Clone, Copy, BorshSerialize, BorshDeserialize)]
+#[borsh(use_discriminant = false)]
 pub enum EthConnectorStorageId {
     Contract = 0x0,
     FungibleToken = 0x1,

--- a/engine-types/src/types/balance.rs
+++ b/engine-types/src/types/balance.rs
@@ -1,9 +1,6 @@
 use crate::fmt::Formatter;
 use crate::{format, Add, Display, Sub, ToString};
-#[cfg(not(feature = "borsh-compat"))]
 use borsh::{BorshDeserialize, BorshSerialize};
-#[cfg(feature = "borsh-compat")]
-use borsh_compat::{self as borsh, BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 pub const ZERO_BALANCE: Balance = Balance::new(0);

--- a/engine-types/src/types/fee.rs
+++ b/engine-types/src/types/fee.rs
@@ -1,10 +1,7 @@
 use crate::fmt::Formatter;
 use crate::types::NEP141Wei;
 use crate::{Add, Display};
-#[cfg(not(feature = "borsh-compat"))]
 use borsh::{BorshDeserialize, BorshSerialize};
-#[cfg(feature = "borsh-compat")]
-use borsh_compat::{self as borsh, BorshDeserialize, BorshSerialize};
 
 #[derive(
     Default, Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, BorshSerialize, BorshDeserialize,

--- a/engine-types/src/types/gas.rs
+++ b/engine-types/src/types/gas.rs
@@ -1,10 +1,7 @@
 use crate::fmt::Formatter;
 use crate::types::Wei;
 use crate::{Add, AddAssign, Display, Div, Mul, Sub};
-#[cfg(not(feature = "borsh-compat"))]
 use borsh::{BorshDeserialize, BorshSerialize};
-#[cfg(feature = "borsh-compat")]
-use borsh_compat::{self as borsh, BorshDeserialize, BorshSerialize};
 use core::num::NonZeroU64;
 use primitive_types::U256;
 use serde::{Deserialize, Serialize};

--- a/engine-types/src/types/mod.rs
+++ b/engine-types/src/types/mod.rs
@@ -1,8 +1,5 @@
 use crate::{str, vec, String, Vec, U256};
-#[cfg(not(feature = "borsh-compat"))]
 use borsh::{BorshDeserialize, BorshSerialize};
-#[cfg(feature = "borsh-compat")]
-use borsh_compat::{self as borsh, BorshDeserialize, BorshSerialize};
 
 pub mod address;
 pub mod balance;

--- a/engine-types/src/types/wei.rs
+++ b/engine-types/src/types/wei.rs
@@ -2,10 +2,7 @@ use crate::fmt::Formatter;
 use crate::types::balance::error;
 use crate::types::{EthGas, Fee};
 use crate::{format, Add, Display, Mul, Sub, SubAssign, ToString, U256};
-#[cfg(not(feature = "borsh-compat"))]
-use borsh::{maybestd::io, BorshDeserialize, BorshSerialize};
-#[cfg(feature = "borsh-compat")]
-use borsh_compat::{self as borsh, maybestd::io, BorshDeserialize, BorshSerialize};
+use borsh::{io, BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 pub const ZERO_NEP141_WEI: NEP141Wei = NEP141Wei::new(0);
@@ -229,25 +226,6 @@ impl BorshSerialize for Wei {
     }
 }
 
-#[cfg(feature = "borsh-compat")]
-impl BorshDeserialize for Wei {
-    fn deserialize(buf: &mut &[u8]) -> io::Result<Self> {
-        if buf.len() < 32 {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "Invalid length of the input",
-            ));
-        }
-
-        let mut buffer = [0; 32];
-        buffer.copy_from_slice(&buf[..32]);
-        *buf = &buf[32..];
-
-        Ok(Self::from(buffer))
-    }
-}
-
-#[cfg(not(feature = "borsh-compat"))]
 impl BorshDeserialize for Wei {
     fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
         let mut buf = [0u8; 32];

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -22,7 +22,7 @@ aurora-engine-types.workspace = true
 aurora-engine-sdk.workspace = true
 bitflags.workspace = true
 ethabi.workspace = true
-evm = { workspace = true, features = [ "create-fixed" ] }
+evm = { workspace = true, features = ["create-fixed"] }
 function_name.workspace = true
 hex.workspace = true
 rlp.workspace = true
@@ -41,7 +41,6 @@ test-case.workspace = true
 default = ["std"]
 std = ["aurora-engine-types/std", "aurora-engine-hashchain/std", "aurora-engine-sdk/std", "aurora-engine-precompiles/std", "aurora-engine-transactions/std", "ethabi/std", "evm/std", "hex/std", "rlp/std", "serde/std", "serde_json/std"]
 contract = ["aurora-engine-sdk/contract", "aurora-engine-precompiles/contract"]
-borsh-compat = ["aurora-engine-types/borsh-compat", "aurora-engine-hashchain/borsh-compat", "aurora-engine-sdk/borsh-compat", "aurora-engine-precompiles/borsh-compat"]
 log = ["aurora-engine-sdk/log", "aurora-engine-precompiles/log"]
 tracing = ["evm/tracing"]
 error_refund = ["aurora-engine-precompiles/error_refund"]

--- a/engine/src/contract_methods/connector/deposit_event.rs
+++ b/engine/src/contract_methods/connector/deposit_event.rs
@@ -4,7 +4,6 @@ use crate::prelude::{
     format, vec, Address, BorshDeserialize, BorshSerialize, Fee, NEP141Wei, String, ToString, Vec,
     U256,
 };
-use aurora_engine_types::borsh;
 use aurora_engine_types::parameters::connector::LogEntry;
 use aurora_engine_types::types::address::error::AddressError;
 use ethabi::{Event, EventParam, Hash, Log, ParamType, RawLog};
@@ -16,6 +15,7 @@ pub type EventParams = Vec<EventParam>;
 /// On-transfer message. Used for `ft_transfer_call` and  `ft_on_transfer` functions.
 /// Message parsed from input args with `parse_on_transfer_message`.
 #[derive(BorshSerialize, BorshDeserialize)]
+#[borsh(crate = "aurora_engine_types::borsh")]
 #[cfg_attr(not(target_arch = "wasm32"), derive(Debug, PartialEq, Eq))]
 pub struct FtTransferMessageData {
     pub recipient: Address,
@@ -24,6 +24,7 @@ pub struct FtTransferMessageData {
 }
 
 #[derive(BorshSerialize, BorshDeserialize)]
+#[borsh(crate = "aurora_engine_types::borsh")]
 #[cfg_attr(not(target_arch = "wasm32"), derive(Debug, PartialEq, Eq))]
 pub struct FtTransferFee {
     pub relayer: AccountId,
@@ -151,6 +152,7 @@ impl FtTransferMessageData {
 /// The message parsed from event `recipient` field - `log_entry_data`
 /// after fetching proof `log_entry_data`
 #[derive(BorshSerialize, BorshDeserialize)]
+#[borsh(crate = "aurora_engine_types::borsh")]
 #[cfg_attr(not(target_arch = "wasm32"), derive(Debug, PartialEq, Eq))]
 pub enum TokenMessageData {
     /// Deposit no NEAR account

--- a/engine/src/contract_methods/connector/external.rs
+++ b/engine/src/contract_methods/connector/external.rs
@@ -285,7 +285,7 @@ pub fn set_eth_connector_account_id<I: IO + Copy, E: Env>(
 
 pub fn get_eth_connector_account_id<I: IO + Copy>(mut io: I) -> Result<(), ContractError> {
     let account = EthConnectorContract::init(io)?.get_eth_connector_contract_account();
-    let data = borsh::to_vec(&account).expect(errors::ERR_FAILED_PARSE);
+    let data = borsh::to_vec(&account).unwrap();
     io.return_output(&data);
 
     Ok(())

--- a/engine/src/contract_methods/connector/fungible_token.rs
+++ b/engine/src/contract_methods/connector/fungible_token.rs
@@ -20,6 +20,7 @@ const GAS_FOR_RESOLVE_TRANSFER: NearGas = NearGas::new(5_000_000_000_000);
 const GAS_FOR_FT_TRANSFER_CALL: NearGas = NearGas::new(35_000_000_000_000);
 
 #[derive(Debug, Default, BorshDeserialize, BorshSerialize)]
+#[borsh(crate = "aurora_engine_types::borsh")]
 pub struct FungibleToken {
     /// Total ETH supply on Near (nETH as NEP-141 token)
     pub total_eth_supply_on_near: NEP141Wei,
@@ -233,12 +234,11 @@ impl<I: IO + Copy> FungibleTokenOps<I> {
         })
         .unwrap();
 
-        let data2 = ResolveTransferCallArgs {
+        let data2 = borsh::to_vec(&ResolveTransferCallArgs {
             receiver_id: receiver_id.clone(),
             amount,
             sender_id,
-        }
-        .try_to_vec()
+        })
         .unwrap();
         // Initiating receiver's call and the callback
         let ft_on_transfer_call = PromiseCreateArgs {

--- a/engine/src/contract_methods/connector/internal.rs
+++ b/engine/src/contract_methods/connector/internal.rs
@@ -110,9 +110,7 @@ pub fn withdraw<I: IO + Copy, E: Env>(io: I, env: &E) -> Result<(), ContractErro
             &predecessor_account_id,
             &args,
         )?;
-        let result_bytes = result
-            .try_to_vec()
-            .map_err(|_| crate::errors::ERR_SERIALIZE)?;
+        let result_bytes = borsh::to_vec(&result).map_err(|_| crate::errors::ERR_SERIALIZE)?;
 
         // We only return the output via IO in the case of standalone.
         // In the case of contract we intentionally avoid IO to call Wasm directly.
@@ -351,7 +349,7 @@ pub fn set_paused_flags<I: IO + Copy, E: Env>(io: I, env: &E) -> Result<(), Cont
 
 pub fn get_paused_flags<I: IO + Copy>(mut io: I) -> Result<(), ContractError> {
     let paused_flags = EthConnectorContract::init(io)?.get_paused_flags();
-    let data = paused_flags.try_to_vec().unwrap();
+    let data = borsh::to_vec(&paused_flags).unwrap();
     io.return_output(&data);
 
     Ok(())
@@ -361,7 +359,7 @@ pub fn is_used_proof<I: IO + Copy + PromiseHandler>(mut io: I) -> Result<(), Con
     let args: IsUsedProofCallArgs = io.read_input_borsh()?;
 
     let is_used_proof = EthConnectorContract::init(io)?.is_used_proof(&args.proof);
-    let res = is_used_proof.try_to_vec().unwrap();
+    let res = borsh::to_vec(&is_used_proof).unwrap();
     io.return_output(&res);
 
     Ok(())
@@ -485,6 +483,7 @@ pub struct EthConnectorContract<I: IO> {
 /// Eth connector specific data. It always must contain `prover_account` - account id of the smart
 /// contract which is used for verifying a proof used in the deposit flow.
 #[derive(BorshSerialize, BorshDeserialize)]
+#[borsh(crate = "aurora_engine_types::borsh")]
 pub struct EthConnector {
     /// The account id of the Prover NEAR smart contract. It used in the Deposit flow for verifying
     /// a log entry from incoming proof.
@@ -609,7 +608,7 @@ impl<I: IO + Copy> EthConnectorContract<I> {
         );
 
         // Do not skip bridge call. This is only used for development and diagnostics.
-        let skip_bridge_call = false.try_to_vec().unwrap();
+        let skip_bridge_call = borsh::to_vec(&false).unwrap();
         let proof_to_verify = [raw_proof, skip_bridge_call].concat();
 
         let verify_call = PromiseCreateArgs {
@@ -623,15 +622,14 @@ impl<I: IO + Copy> EthConnectorContract<I> {
         // Finalize deposit
         let data = match event.token_message_data {
             // Deposit to NEAR accounts
-            TokenMessageData::Near(account_id) => FinishDepositCallArgs {
+            TokenMessageData::Near(account_id) => borsh::to_vec(&FinishDepositCallArgs {
                 new_owner_id: account_id,
                 amount: event.amount,
                 proof_key: proof_key(&proof),
                 relayer_id: predecessor_account_id,
                 fee: event.fee,
                 msg: None,
-            }
-            .try_to_vec()
+            })
             .unwrap(),
             // Deposit to Eth accounts
             // fee is being minted in the `ft_on_transfer` callback method
@@ -641,25 +639,23 @@ impl<I: IO + Copy> EthConnectorContract<I> {
             } => {
                 // Transfer to self and then transfer ETH in `ft_on_transfer`
                 // address - is NEAR account
-                let transfer_data = TransferCallCallArgs {
+                let transfer_data = borsh::to_vec(&TransferCallCallArgs {
                     receiver_id,
                     amount: event.amount,
                     memo: None,
                     msg: message.encode(),
-                }
-                .try_to_vec()
+                })
                 .unwrap();
 
                 // Send to self - current account id
-                FinishDepositCallArgs {
+                borsh::to_vec(&FinishDepositCallArgs {
                     new_owner_id: current_account_id.clone(),
                     amount: event.amount,
                     proof_key: proof_key(&proof),
                     relayer_id: predecessor_account_id,
                     fee: event.fee,
                     msg: Some(transfer_data),
-                }
-                .try_to_vec()
+                })
                 .unwrap()
             }
         };

--- a/engine/src/contract_methods/connector/mod.rs
+++ b/engine/src/contract_methods/connector/mod.rs
@@ -11,7 +11,7 @@ use aurora_engine_modexp::AuroraModExp;
 use aurora_engine_sdk::env::Env;
 use aurora_engine_sdk::io::{StorageIntermediate, IO};
 use aurora_engine_sdk::promise::PromiseHandler;
-use aurora_engine_types::borsh::{BorshDeserialize, BorshSerialize};
+use aurora_engine_types::borsh::{self, BorshDeserialize};
 use aurora_engine_types::parameters::connector::{
     Erc20Identifier, MirrorErc20TokenArgs, SetErc20MetadataArgs,
 };
@@ -125,10 +125,7 @@ pub fn deploy_erc20_token<I: IO + Copy, E: Env, H: PromiseHandler>(
         let address = engine::deploy_erc20_token(args, io, env, handler)?;
 
         io.return_output(
-            &address
-                .as_bytes()
-                .try_to_vec()
-                .map_err(|_| crate::errors::ERR_SERIALIZE)?,
+            &borsh::to_vec(address.as_bytes()).map_err(|_| crate::errors::ERR_SERIALIZE)?,
         );
         Ok(address)
     })
@@ -466,10 +463,9 @@ pub fn mirror_erc20_token<I: IO + Env + Copy, H: PromiseHandler>(
         PromiseCreateArgs {
             target_account_id: args.contract_id.clone(),
             method: "get_erc20_from_nep141".to_string(),
-            args: GetErc20FromNep141CallArgs {
+            args: borsh::to_vec(&GetErc20FromNep141CallArgs {
                 nep141: args.nep141.clone(),
-            }
-            .try_to_vec()
+            })
             .map_err(|_| crate::errors::ERR_SERIALIZE)?,
             attached_balance: Yocto::new(0),
             attached_gas: READ_PROMISE_ATTACHED_GAS,
@@ -538,10 +534,7 @@ pub fn mirror_erc20_token_callback<I: IO + Copy, E: Env, H: PromiseHandler>(
             engine::mirror_erc20_token(args, erc20_address, erc20_metadata, io, env, handler)?;
 
         io.return_output(
-            &address
-                .as_bytes()
-                .try_to_vec()
-                .map_err(|_| crate::errors::ERR_SERIALIZE)?,
+            &borsh::to_vec(address.as_bytes()).map_err(|_| crate::errors::ERR_SERIALIZE)?,
         );
 
         Ok(())
@@ -567,8 +560,8 @@ fn get_contract_data<T: BorshDeserialize, I: IO>(
 #[cfg(any(not(feature = "ext-connector"), test))]
 #[must_use]
 fn proof_key(proof: &aurora_engine_types::parameters::connector::Proof) -> crate::prelude::String {
-    let mut data = proof.log_index.try_to_vec().unwrap();
-    data.extend(proof.receipt_index.try_to_vec().unwrap());
+    let mut data = borsh::to_vec(&proof.log_index).unwrap();
+    data.extend(borsh::to_vec(&proof.receipt_index).unwrap());
     data.extend(proof.header_data.clone());
     aurora_engine_sdk::sha256(&data)
         .0

--- a/engine/src/contract_methods/evm_transactions.rs
+++ b/engine/src/contract_methods/evm_transactions.rs
@@ -12,7 +12,7 @@ use aurora_engine_sdk::{
     promise::PromiseHandler,
 };
 use aurora_engine_types::{
-    borsh::BorshSerialize,
+    borsh,
     parameters::engine::{CallArgs, SubmitArgs, SubmitResult},
 };
 use function_name::named;
@@ -36,7 +36,7 @@ pub fn deploy_code<I: IO + Copy, E: Env, H: PromiseHandler>(
             env,
         );
         let result = engine.deploy_code_with_input(input, None, handler)?;
-        let result_bytes = result.try_to_vec().map_err(|_| errors::ERR_SERIALIZE)?;
+        let result_bytes = borsh::to_vec(&result).map_err(|_| errors::ERR_SERIALIZE)?;
         io.return_output(&result_bytes);
         Ok(result)
     })
@@ -64,7 +64,7 @@ pub fn call<I: IO + Copy, E: Env, H: PromiseHandler>(
             env,
         );
         let result = engine.call_with_args(args, handler)?;
-        let result_bytes = result.try_to_vec().map_err(|_| errors::ERR_SERIALIZE)?;
+        let result_bytes = borsh::to_vec(&result).map_err(|_| errors::ERR_SERIALIZE)?;
         io.return_output(&result_bytes);
         Ok(result)
     })
@@ -95,7 +95,7 @@ pub fn submit<I: IO + Copy, E: Env, H: PromiseHandler>(
             relayer_address,
             handler,
         )?;
-        let result_bytes = result.try_to_vec().map_err(|_| errors::ERR_SERIALIZE)?;
+        let result_bytes = borsh::to_vec(&result).map_err(|_| errors::ERR_SERIALIZE)?;
         io.return_output(&result_bytes);
 
         Ok(result)
@@ -123,7 +123,7 @@ pub fn submit_with_args<I: IO + Copy, E: Env, H: PromiseHandler>(
             relayer_address,
             handler,
         )?;
-        let result_bytes = result.try_to_vec().map_err(|_| errors::ERR_SERIALIZE)?;
+        let result_bytes = borsh::to_vec(&result).map_err(|_| errors::ERR_SERIALIZE)?;
         io.return_output(&result_bytes);
 
         Ok(result)

--- a/engine/src/contract_methods/xcc.rs
+++ b/engine/src/contract_methods/xcc.rs
@@ -13,8 +13,7 @@ use aurora_engine_sdk::{
 };
 use aurora_engine_types::{
     account_id::AccountId,
-    borsh::BorshSerialize,
-    format,
+    borsh, format,
     parameters::{engine::SubmitResult, xcc::WithdrawWnearToRouterArgs},
     types::Address,
 };
@@ -116,7 +115,7 @@ pub fn factory_set_wnear_address<I: IO + Copy, E: Env>(
 
 pub fn factory_get_wnear_address<I: IO + Copy>(mut io: I) -> Result<(), ContractError> {
     let address = aurora_engine_precompiles::xcc::state::get_wnear_address(&io);
-    let bytes = address.try_to_vec().map_err(|_| errors::ERR_SERIALIZE)?;
+    let bytes = borsh::to_vec(&address).map_err(|_| errors::ERR_SERIALIZE)?;
     io.return_output(&bytes);
     Ok(())
 }

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -20,13 +20,16 @@ extern crate alloc;
 extern crate core;
 
 mod map;
+
 pub mod parameters {
     pub use aurora_engine_types::parameters::connector::*;
     pub use aurora_engine_types::parameters::engine::*;
 }
+
 pub mod proof {
     pub use aurora_engine_types::parameters::connector::Proof;
 }
+
 pub mod accounting;
 #[cfg_attr(feature = "contract", allow(dead_code))]
 pub mod contract_methods;
@@ -87,7 +90,7 @@ mod contract {
     use aurora_engine_sdk::env::Env;
     use aurora_engine_sdk::io::{StorageIntermediate, IO};
     use aurora_engine_sdk::near_runtime::{Runtime, ViewEnv};
-    use aurora_engine_types::borsh::BorshSerialize;
+    use aurora_engine_types::borsh;
     use aurora_engine_types::parameters::silo::{
         FixedGasArgs, SiloParamsArgs, WhitelistArgs, WhitelistKindArgs, WhitelistStatusArgs,
     };
@@ -492,7 +495,7 @@ mod contract {
         let engine: Engine<_, _> =
             Engine::new(args.sender, current_account_id, io, &env).sdk_unwrap();
         let result = Engine::view_with_args(&engine, args).sdk_unwrap();
-        io.return_output(&result.try_to_vec().sdk_expect(errors::ERR_SERIALIZE));
+        io.return_output(&borsh::to_vec(&result).sdk_expect(errors::ERR_SERIALIZE));
     }
 
     #[no_mangle]
@@ -852,7 +855,7 @@ mod contract {
     pub extern "C" fn verify_log_entry() {
         sdk::log!("Call from verify_log_entry");
         let mut io = Runtime;
-        let data = true.try_to_vec().unwrap();
+        let data = borsh::to_vec(&true).unwrap();
         io.return_output(&data);
     }
 
@@ -915,7 +918,7 @@ mod contract {
             let finish_call = aurora_engine_types::parameters::PromiseCreateArgs {
                 target_account_id: aurora_account_id,
                 method: crate::prelude::String::from("finish_deposit"),
-                args: args.try_to_vec().unwrap(),
+                args: borsh::to_vec(&args).unwrap(),
                 attached_balance: ZERO_ATTACHED_BALANCE,
                 attached_gas: GAS_FOR_FINISH,
             };
@@ -941,7 +944,7 @@ mod contract {
             fixed_gas: silo::get_fixed_gas(&io),
         };
 
-        io.return_output(&cost.try_to_vec().map_err(|e| e.to_string()).sdk_unwrap());
+        io.return_output(&borsh::to_vec(&cost).map_err(|e| e.to_string()).sdk_unwrap());
     }
 
     #[no_mangle]
@@ -961,7 +964,11 @@ mod contract {
         let mut io = Runtime;
         let params = silo::get_silo_params(&io);
 
-        io.return_output(&params.try_to_vec().map_err(|e| e.to_string()).sdk_unwrap());
+        io.return_output(
+            &borsh::to_vec(&params)
+                .map_err(|e| e.to_string())
+                .sdk_unwrap(),
+        );
     }
 
     #[no_mangle]
@@ -988,8 +995,7 @@ mod contract {
     pub extern "C" fn get_whitelist_status() {
         let mut io = Runtime;
         let args: WhitelistKindArgs = io.read_input_borsh().sdk_unwrap();
-        let status = silo::get_whitelist_status(&io, &args)
-            .try_to_vec()
+        let status = borsh::to_vec(&silo::get_whitelist_status(&io, &args))
             .map_err(|e| e.to_string())
             .sdk_unwrap();
 

--- a/engine/src/pausables.rs
+++ b/engine/src/pausables.rs
@@ -1,13 +1,14 @@
 use crate::prelude::{AccountId, Address, BTreeSet, Vec};
 use aurora_engine_precompiles::native::{exit_to_ethereum, exit_to_near};
 use aurora_engine_sdk::io::{StorageIntermediate, IO};
-use aurora_engine_types::borsh::{self, BorshDeserialize, BorshSerialize};
+use aurora_engine_types::borsh::{BorshDeserialize, BorshSerialize};
 use aurora_engine_types::storage::{bytes_to_key, KeyPrefix};
 use bitflags::bitflags;
 
 bitflags! {
     /// Wraps unsigned integer where each bit identifies a different precompile.
     #[derive(BorshSerialize, BorshDeserialize, Default)]
+    #[borsh(crate = "aurora_engine_types::borsh")]
     pub struct PrecompileFlags: u32 {
         const EXIT_TO_NEAR        = 0b01;
         const EXIT_TO_ETHEREUM    = 0b10;
@@ -82,6 +83,7 @@ pub trait PausedPrecompilesManager {
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug, Default, Clone)]
+#[borsh(crate = "aurora_engine_types::borsh")]
 pub struct EngineAuthorizer {
     /// List of [AccountId]s with the permission to pause precompiles.
     pub acl: BTreeSet<AccountId>,
@@ -97,6 +99,7 @@ impl EngineAuthorizer {
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug, Default, Clone)]
+#[borsh(crate = "aurora_engine_types::borsh")]
 pub struct EnginePrecompilesPauser<I: IO> {
     /// Storage to read pause flags from and write into.
     io: I,

--- a/engine/src/state.rs
+++ b/engine/src/state.rs
@@ -32,9 +32,7 @@ pub struct EngineState {
 impl EngineState {
     pub fn borsh_serialize(&self) -> Result<Vec<u8>, EngineStateError> {
         let borshable: BorshableEngineState = self.into();
-        borshable
-            .try_to_vec()
-            .map_err(|_| EngineStateError::SerializationFailed)
+        borsh::to_vec(&borshable).map_err(|_| EngineStateError::SerializationFailed)
     }
 
     /// Deserialization with lazy state migration.
@@ -54,6 +52,7 @@ impl EngineState {
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, PartialEq, Eq, Debug)]
+#[borsh(crate = "aurora_engine_types::borsh")]
 pub enum BorshableEngineState<'a> {
     V1(BorshableEngineStateV1<'a>),
     V2(BorshableEngineStateV2<'a>),
@@ -61,6 +60,7 @@ pub enum BorshableEngineState<'a> {
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Default, Clone, PartialEq, Eq, Debug)]
+#[borsh(crate = "aurora_engine_types::borsh")]
 pub struct BorshableEngineStateV1<'a> {
     pub chain_id: [u8; 32],
     pub owner_id: Cow<'a, AccountId>,
@@ -69,6 +69,7 @@ pub struct BorshableEngineStateV1<'a> {
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Default, Clone, PartialEq, Eq, Debug)]
+#[borsh(crate = "aurora_engine_types::borsh")]
 pub struct BorshableEngineStateV2<'a> {
     pub chain_id: [u8; 32],
     pub owner_id: Cow<'a, AccountId>,
@@ -76,6 +77,7 @@ pub struct BorshableEngineStateV2<'a> {
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Default, Clone, PartialEq, Eq, Debug)]
+#[borsh(crate = "aurora_engine_types::borsh")]
 pub struct BorshableEngineStateV3<'a> {
     pub chain_id: [u8; 32],
     pub owner_id: Cow<'a, AccountId>,

--- a/engine/src/xcc.rs
+++ b/engine/src/xcc.rs
@@ -59,6 +59,7 @@ impl<'a> RouterCode<'a> {
 
 /// Same as the corresponding struct in the xcc-router
 #[derive(BorshDeserialize, BorshSerialize)]
+#[borsh(crate = "aurora_engine_types::borsh")]
 pub struct DeployUpgradeParams {
     pub code: Vec<u8>,
     pub initialize_args: Vec<u8>,
@@ -134,9 +135,7 @@ where
             };
             promise_actions.push(PromiseAction::FunctionCall {
                 name: "deploy_upgrade".into(),
-                args: deploy_args
-                    .try_to_vec()
-                    .expect(ERR_UPGRADE_ARG_SERIALIZATION),
+                args: borsh::to_vec(&deploy_args).expect(ERR_UPGRADE_ARG_SERIALIZATION),
                 attached_yocto: fund_amount,
                 gas: UPGRADE_GAS + INITIALIZE_GAS,
             });
@@ -166,9 +165,7 @@ where
         let callback = PromiseCreateArgs {
             target_account_id: current_account_id,
             method: "factory_update_address_version".into(),
-            args: args
-                .try_to_vec()
-                .map_err(|_| FundXccError::SerializationFailure)?,
+            args: borsh::to_vec(&args).map_err(|_| FundXccError::SerializationFailure)?,
             attached_balance: ZERO_YOCTO,
             attached_gas: VERSION_UPDATE_GAS,
         };
@@ -246,9 +243,7 @@ where
                 };
                 promise_actions.push(PromiseAction::FunctionCall {
                     name: "deploy_upgrade".into(),
-                    args: deploy_args
-                        .try_to_vec()
-                        .expect(ERR_UPGRADE_ARG_SERIALIZATION),
+                    args: borsh::to_vec(&deploy_args).expect(ERR_UPGRADE_ARG_SERIALIZATION),
                     attached_yocto: ZERO_YOCTO,
                     gas: UPGRADE_GAS + INITIALIZE_GAS,
                 });
@@ -276,7 +271,7 @@ where
             let callback = PromiseCreateArgs {
                 target_account_id: current_account_id.clone(),
                 method: "factory_update_address_version".into(),
-                args: args.try_to_vec().unwrap(),
+                args: borsh::to_vec(&args).unwrap(),
                 attached_balance: ZERO_YOCTO,
                 attached_gas: VERSION_UPDATE_GAS,
             };
@@ -304,7 +299,7 @@ where
         let withdraw_call = PromiseCreateArgs {
             target_account_id: current_account_id.clone(),
             method: "withdraw_wnear_to_router".into(),
-            args: withdraw_call_args.try_to_vec().unwrap(),
+            args: borsh::to_vec(&withdraw_call_args).unwrap(),
             attached_balance: ZERO_YOCTO,
             attached_gas: WITHDRAW_GAS,
         };

--- a/etc/tests/fibonacci/Cargo.toml
+++ b/etc/tests/fibonacci/Cargo.toml
@@ -15,7 +15,7 @@ debug = false
 panic = "abort"
 
 [dependencies]
-near-sdk = "4.1"
+near-sdk = "5"
 serde = "1"
 
 [patch.crates-io]

--- a/etc/tests/fibonacci/src/lib.rs
+++ b/etc/tests/fibonacci/src/lib.rs
@@ -1,11 +1,12 @@
-use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
+use near_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use near_sdk::json_types::U128;
 use near_sdk::{env, near_bindgen, Gas, Promise, PromiseError};
 
-const FIVE_TGAS: Gas = Gas(5_000_000_000_000);
+const FIVE_TGAS: Gas = Gas::from_tgas(5);
 
 #[near_bindgen]
 #[derive(Default, BorshDeserialize, BorshSerialize)]
+#[borsh(crate = "near_sdk::borsh")]
 pub struct Fib;
 
 #[derive(serde::Deserialize, serde::Serialize)]
@@ -42,15 +43,19 @@ impl Fib {
     /// It begins with the seed, followed by `n` calls to the `accumulate` function.
     pub fn fib(n: u8) -> Promise {
         let account = env::current_account_id();
-        let mut p =
-            Promise::new(account.clone()).function_call("seed".into(), Vec::new(), 0, FIVE_TGAS);
+        let mut p = Promise::new(account.clone()).function_call(
+            "seed".into(),
+            Vec::new(),
+            near_sdk::NearToken::from_near(0),
+            FIVE_TGAS,
+        );
         let mut n = n;
         while n > 0 {
             n -= 1;
             p = p.then(Promise::new(account.clone()).function_call(
                 "accumulate".into(),
                 Vec::new(),
-                0,
+                near_sdk::NearToken::from_near(0),
                 FIVE_TGAS,
             ))
         }

--- a/etc/tests/ft-receiver/Cargo.toml
+++ b/etc/tests/ft-receiver/Cargo.toml
@@ -8,8 +8,5 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-near-sdk = "4.1"
-near-contract-standards = "4.1"
-
-[patch.crates-io]
-parity-secp256k1 = { git = 'https://github.com/paritytech/rust-secp256k1', rev = "d05fd8e" }
+near-sdk = "5"
+near-contract-standards = "5"

--- a/etc/tests/ft-receiver/src/lib.rs
+++ b/etc/tests/ft-receiver/src/lib.rs
@@ -1,22 +1,28 @@
 use near_contract_standards::fungible_token::receiver::FungibleTokenReceiver;
-use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
-use near_sdk::json_types::{U128, ValidAccountId};
-use near_sdk::{near_bindgen, log, PromiseOrValue};
+use near_sdk::borsh::{BorshDeserialize, BorshSerialize};
+use near_sdk::json_types::U128;
+use near_sdk::{log, near_bindgen, AccountId, PromiseOrValue};
 
 /// Will happily take and NEP-141
 #[near_bindgen]
 #[derive(BorshDeserialize, BorshSerialize, Default)]
+#[borsh(crate = "near_sdk::borsh")]
 struct DummyFungibleTokenReceiver;
 
 #[near_bindgen]
 impl FungibleTokenReceiver for DummyFungibleTokenReceiver {
     fn ft_on_transfer(
         &mut self,
-        sender_id: ValidAccountId,
+        sender_id: AccountId,
         amount: U128,
         msg: String,
     ) -> PromiseOrValue<U128> {
-        log!("in {} tokens from @{} ft_on_transfer, msg = {}", amount.0, sender_id.as_ref(), msg);
+        log!(
+            "in {} tokens from @{} ft_on_transfer, msg = {}",
+            amount.0,
+            sender_id,
+            msg
+        );
         PromiseOrValue::Value(U128::from(0))
     }
 }

--- a/etc/tests/modexp-bench/Cargo.toml
+++ b/etc/tests/modexp-bench/Cargo.toml
@@ -17,7 +17,4 @@ panic = "abort"
 [dependencies]
 aurora-engine-modexp = { path = "../../../engine-modexp", default-features = false, features = ["bench", "std"] }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
-near-sdk = "4.1"
-
-[patch.crates-io]
-parity-secp256k1 = { git = 'https://github.com/paritytech/rust-secp256k1', rev = "d05fd8e" }
+near-sdk = "5"

--- a/etc/tests/modexp-bench/src/lib.rs
+++ b/etc/tests/modexp-bench/src/lib.rs
@@ -1,7 +1,8 @@
-use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
+use near_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use near_sdk::{env, near_bindgen};
 
 #[near_bindgen]
+#[borsh(crate = "near_sdk::borsh")]
 #[derive(BorshDeserialize, BorshSerialize, Default)]
 pub struct Modexp;
 

--- a/etc/tests/self-contained-5bEgfRQ/Cargo.toml
+++ b/etc/tests/self-contained-5bEgfRQ/Cargo.toml
@@ -37,7 +37,7 @@ codegen-units = 1
 rpath = false
 
 [dependencies]
-borsh = { version = "0.10", default-features = false }
+borsh = { version = "1", default-features = false }
 aurora-engine = { path = "../../../engine", default-features = false }
 aurora-engine-sdk = { path = "../../../engine-sdk", default-features = false, features = ["contract"] }
 aurora-engine-types = { path = "../../../engine-types", default-features = false }

--- a/etc/tests/self-contained-5bEgfRQ/src/lib.rs
+++ b/etc/tests/self-contained-5bEgfRQ/src/lib.rs
@@ -56,7 +56,7 @@ pub extern "C" fn run() {
     .unwrap();
 
     let mut rt = near_runtime::Runtime;
-    let return_bytes = result.try_to_vec().unwrap();
+    let return_bytes = borsh::to_vec(&result).unwrap();
     rt.return_output(&return_bytes);
 }
 

--- a/etc/tests/state-migration-test/Cargo.toml
+++ b/etc/tests/state-migration-test/Cargo.toml
@@ -37,7 +37,7 @@ codegen-units = 1
 rpath = false
 
 [dependencies]
-borsh = { version = "0.10", default-features = false }
+borsh = { version = "1", default-features = false }
 aurora-engine = { path = "../../../engine", default-features = false }
 aurora-engine-sdk = { path = "../../../engine-sdk", default-features = false, features = ["contract"] }
 aurora-engine-types = { path = "../../../engine-types", default-features = false }

--- a/etc/tests/state-migration-test/src/lib.rs
+++ b/etc/tests/state-migration-test/src/lib.rs
@@ -29,7 +29,7 @@ pub extern "C" fn state_migration() {
         some_other_numbers: [3, 1, 4, 1, 5, 9, 2],
     };
 
-    io.write_storage(&state_key(), &new_state.try_to_vec().expect("ERR_SER"));
+    io.write_storage(&state_key(), &borsh::to_vec(&new_state).expect("ERR_SER"));
 }
 
 #[no_mangle]
@@ -40,7 +40,7 @@ pub extern "C" fn some_new_fancy_function() {
         .and_then(|bytes| NewFancyState::try_from_slice(&bytes.to_vec()).ok())
         .unwrap();
 
-    io.return_output(&state.some_other_numbers.try_to_vec().unwrap());
+    io.return_output(&borsh::to_vec(&state.some_other_numbers).unwrap());
 }
 
 fn state_key() -> Vec<u8> {

--- a/etc/xcc-router/Cargo.lock
+++ b/etc/xcc-router/Cargo.lock
@@ -9,26 +9,83 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
-name = "ahash"
-version = "0.7.8"
+name = "actix"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+checksum = "fb72882332b6d6282f428b77ba0358cb2687e61a6f6df6a6d3871e8a177c2d4f"
 dependencies = [
- "getrandom 0.2.12",
+ "actix-macros",
+ "actix-rt",
+ "actix_derive",
+ "bitflags 2.4.2",
+ "bytes",
+ "crossbeam-channel",
+ "futures-core",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+ "log",
  "once_cell",
- "version_check",
+ "parking_lot",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "tokio-util 0.7.10",
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.8"
+name = "actix-macros"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd52102d3df161c77a887b608d7a4897d7cc112886a9537b738a887a03aaff"
+checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
- "cfg-if 1.0.0",
- "once_cell",
- "version_check",
- "zerocopy",
+ "quote",
+ "syn 2.0.50",
+]
+
+[[package]]
+name = "actix-rt"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28f32d40287d3f402ae0028a9d54bef51af15c8769492826a69d28f81893151d"
+dependencies = [
+ "futures-core",
+ "tokio",
+]
+
+[[package]]
+name = "actix_derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c7db3d5a9718568e4cf4a537cfd7070e6e6ff7481510d0237fb529ac850f6d3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -47,30 +104,113 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayref"
-version = "0.3.7"
+name = "anstream"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+checksum = "96b09b5178381e0874812a9b157f7fe84982617e48f71f4e3235482775e5b540"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
 
 [[package]]
-name = "arrayvec"
-version = "0.5.2"
+name = "anstyle"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
-name = "arrayvec"
-version = "0.7.4"
+name = "anstyle-parse"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
+
+[[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
+]
 
 [[package]]
 name = "aurora-engine-types"
 version = "1.0.0"
 dependencies = [
  "base64 0.21.7",
- "borsh 0.10.3",
- "borsh 0.9.3",
+ "borsh",
  "bs58 0.5.0",
  "hex",
  "primitive-types 0.12.2",
@@ -86,10 +226,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "base64"
-version = "0.11.0"
+name = "backtrace"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base64"
@@ -104,16 +253,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
-name = "bitvec"
-version = "0.20.4"
+name = "bitflags"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "blake2"
@@ -128,15 +277,6 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
@@ -146,92 +286,26 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "0.9.3"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15bf3650200d8bffa99015595e10f1fbd17de07abbc25bb067da79e769939bfa"
+checksum = "f58b559fd6448c6e2fd0adb5720cd98a2506594cafa4737ff98c396f3e82f667"
 dependencies = [
- "borsh-derive 0.9.3",
- "hashbrown 0.11.2",
-]
-
-[[package]]
-name = "borsh"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
-dependencies = [
- "borsh-derive 0.10.3",
- "hashbrown 0.13.2",
+ "borsh-derive",
+ "cfg_aliases",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "0.9.3"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6441c552f230375d18e3cc377677914d2ca2b0d36e52129fe15450a2dce46775"
+checksum = "7aadb5b6ccbd078890f6d7003694e33816e6b784358f18e15e7e6d9f065a57cd"
 dependencies = [
- "borsh-derive-internal 0.9.3",
- "borsh-schema-derive-internal 0.9.3",
- "proc-macro-crate 0.1.5",
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0754613691538d51f329cce9af41d7b7ca150bc973056f1156611489475f54f7"
-dependencies = [
- "borsh-derive-internal 0.10.3",
- "borsh-schema-derive-internal 0.10.3",
- "proc-macro-crate 0.1.5",
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-derive-internal"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
-dependencies = [
+ "once_cell",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-derive-internal"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb438156919598d2c7bad7e1c0adf3d26ed3840dbc010db1a882a65583ca2fb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-schema-derive-internal"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-schema-derive-internal"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634205cc43f74a1b9046ef87c4540ebda95696ec0f315024860cad7c5b0f5ccd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "syn 2.0.50",
+ "syn_derive",
 ]
 
 [[package]]
@@ -246,21 +320,15 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
 dependencies = [
- "sha2 0.10.8",
+ "sha2",
  "tinyvec",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
-
-[[package]]
-name = "byte-slice-cast"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
+checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
 
 [[package]]
 name = "byteorder"
@@ -279,6 +347,9 @@ name = "bytesize"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "c2-chacha"
@@ -292,24 +363,21 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+checksum = "7f9fa1897e4325be0d68d48df6aa1a71ac2ed4d27723887e7754192705350730"
 
 [[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
@@ -323,7 +391,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets",
+ "windows-targets 0.52.3",
 ]
 
 [[package]]
@@ -334,6 +402,52 @@ checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim 0.11.0",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "convert_case"
@@ -355,6 +469,21 @@ checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crunchy"
@@ -384,15 +513,87 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.1"
+version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
+checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
 dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.5.1",
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "platforms",
+ "rand_core 0.6.4",
+ "rustc_version",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a5d17510e4a1a87f323de70b7b1eaac1ee0e37866c6720b2d279452d0edf389"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a98eea36a7ff910fa751413d0895551143a8ea41d695d9798ec7d665df7f7f5e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 2.0.50",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6a366a3f90c5d59a4b91169775f88e52e8f71a0e7804cc98a8db2932cf4ed57"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.50",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+ "serde",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -423,15 +624,9 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "crypto-common",
 ]
-
-[[package]]
-name = "dyn-clone"
-version = "1.0.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d"
 
 [[package]]
 name = "easy-ext"
@@ -441,25 +636,50 @@ checksum = "53aff6fdc1b181225acdcb5b14c47106726fd8e486707315b1b138baed68ee31"
 
 [[package]]
 name = "ed25519"
-version = "1.5.3"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "signature",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "1.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand 0.7.3",
- "serde",
- "sha2 0.9.9",
- "zeroize",
+ "rand_core 0.6.4",
+ "sha2",
+ "subtle",
+]
+
+[[package]]
+name = "either"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+
+[[package]]
+name = "enum-map"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
+dependencies = [
+ "enum-map-derive",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -469,14 +689,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "errno"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1676f435fc1dadde4d03e43f5d62b259e1ce5f40bd4ffb21db2b42ebe59c1382"
+
+[[package]]
 name = "fixed-hash"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
 dependencies = [
- "byteorder",
- "rand 0.8.5",
- "rustc-hex",
  "static_assertions",
 ]
 
@@ -490,10 +729,102 @@ dependencies = [
 ]
 
 [[package]]
-name = "funty"
-version = "1.1.0"
+name = "fixedbitset"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+
+[[package]]
+name = "futures-task"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+
+[[package]]
+name = "futures-util"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -511,7 +842,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -522,28 +853,41 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.11.2"
+name = "gimli"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "h2"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
- "ahash 0.7.8",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap 2.2.3",
+ "slab",
+ "tokio",
+ "tokio-util 0.7.10",
+ "tracing",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash 0.8.8",
-]
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -553,15 +897,112 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
 
 [[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "http"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "0.14.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -587,13 +1028,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "impl-codec"
-version = "0.5.1"
+name = "ident_case"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161ebdfec3c8e3b52bf61c4f3550a1eea4f9579d10dc1b936f3171ebdcd6c443"
-dependencies = [
- "parity-scale-codec",
-]
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "impl-rlp"
@@ -614,14 +1052,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "impl-trait-for-tuples"
-version = "0.2.2"
+name = "indexmap"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -632,6 +1070,16 @@ checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
+ "serde",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -648,6 +1096,12 @@ checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
 dependencies = [
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "json_comments"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dbbfed4e59ba9750e15ba154fdfd9329cee16ff3df539c2666b70f58cc32105"
 
 [[package]]
 name = "keccak"
@@ -674,10 +1128,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+
+[[package]]
+name = "lock_api"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
 
 [[package]]
 name = "memchr"
@@ -686,53 +1165,83 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
-name = "memory_units"
-version = "0.4.0"
+name = "memoffset"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
-name = "near-abi"
-version = "0.3.0"
+name = "miniz_oxide"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "885db39b08518fa700b73fa2214e8adbbfba316ba82dd510f50519173eadaf73"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
- "borsh 0.9.3",
- "schemars",
- "semver",
+ "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+dependencies = [
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "near-account-id"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35cbb989542587b47205e608324ddd391f0cee1c22b4b64ae49f458334b95907"
+dependencies = [
+ "borsh",
  "serde",
 ]
 
 [[package]]
-name = "near-account-id"
-version = "0.14.0"
+name = "near-config-utils"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d258582a1878e6db67400b0504a5099db85718d22c2e07f747fe1706ae7150"
+checksum = "2ae1eaab1d545a9be7a55b6ef09f365c2017f93a03063547591d12c0c6d27e58"
 dependencies = [
- "borsh 0.9.3",
- "serde",
+ "anyhow",
+ "json_comments",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]
 name = "near-crypto"
-version = "0.14.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e75673d69fd7365508f3d32483669fe45b03bfb34e4d9363e90adae9dfb416c"
+checksum = "2991d2912218a80ec0733ac87f84fa803accea105611eea209d4419271957667"
 dependencies = [
- "arrayref",
  "blake2",
- "borsh 0.9.3",
+ "borsh",
  "bs58 0.4.0",
  "c2-chacha",
  "curve25519-dalek",
  "derive_more",
  "ed25519-dalek",
+ "hex",
  "near-account-id",
+ "near-config-utils",
+ "near-stdx",
  "once_cell",
- "parity-secp256k1",
  "primitive-types 0.10.1",
  "rand 0.7.3",
- "rand_core 0.5.1",
+ "secp256k1",
  "serde",
  "serde_json",
  "subtle",
@@ -740,107 +1249,204 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-primitives"
-version = "0.14.0"
+name = "near-fmt"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad1a9a1640539c81f065425c31bffcfbf6b31ef1aeaade59ce905f5df6ac860"
+checksum = "b7d998dfc1e04001608899b2498ad5a782c7d036b73769d510de21964db99286"
 dependencies = [
- "borsh 0.9.3",
- "byteorder",
- "bytesize",
- "chrono",
- "derive_more",
- "easy-ext",
- "hex",
- "near-crypto",
  "near-primitives-core",
- "near-rpc-error-macro",
- "near-vm-errors",
- "num-rational",
+]
+
+[[package]]
+name = "near-gas"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14e75c875026229902d065e4435804497337b631ec69ba746b102954273e9ad1"
+dependencies = [
+ "borsh",
+ "serde",
+]
+
+[[package]]
+name = "near-o11y"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d20762631bc8253030013bbae9b5f0542691edc1aa6722f1e8141cc9b928ae5b"
+dependencies = [
+ "actix",
+ "base64 0.21.7",
+ "clap",
+ "near-crypto",
+ "near-fmt",
+ "near-primitives-core",
  "once_cell",
- "primitive-types 0.10.1",
- "rand 0.7.3",
- "reed-solomon-erasure",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "prometheus",
  "serde",
  "serde_json",
- "smart-default",
- "strum",
+ "strum 0.24.1",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-appender",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "near-parameters"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f16a59b6c3e69b0585be951af6fe42a0ba86c0e207cb8c63badd19efd16680"
+dependencies = [
+ "assert_matches",
+ "borsh",
+ "enum-map",
+ "near-account-id",
+ "near-primitives-core",
+ "num-rational",
+ "serde",
+ "serde_repr",
+ "serde_yaml",
+ "strum 0.24.1",
  "thiserror",
 ]
 
 [[package]]
-name = "near-primitives-core"
-version = "0.14.0"
+name = "near-primitives"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d508f0fc340f6461e4e256417685720d3c4c00bb5a939b105160e49137caba"
+checksum = "0462b067732132babcc89d5577db3bfcb0a1bcfbaaed3f2db4c11cd033666314"
 dependencies = [
- "base64 0.11.0",
- "borsh 0.9.3",
+ "arbitrary",
+ "base64 0.21.7",
+ "borsh",
+ "bytesize",
+ "cfg-if",
+ "chrono",
+ "derive_more",
+ "easy-ext",
+ "enum-map",
+ "hex",
+ "near-crypto",
+ "near-fmt",
+ "near-o11y",
+ "near-parameters",
+ "near-primitives-core",
+ "near-rpc-error-macro",
+ "near-stdx",
+ "near-vm-runner",
+ "num-rational",
+ "once_cell",
+ "primitive-types 0.10.1",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "reed-solomon-erasure",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "serde_yaml",
+ "sha3",
+ "smart-default",
+ "strum 0.24.1",
+ "thiserror",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "near-primitives-core"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8443eb718606f572c438be6321a097a8ebd69f8e48d953885b4f16601af88225"
+dependencies = [
+ "arbitrary",
+ "base64 0.21.7",
+ "borsh",
  "bs58 0.4.0",
  "derive_more",
+ "enum-map",
  "near-account-id",
  "num-rational",
  "serde",
- "sha2 0.10.8",
- "strum",
+ "serde_repr",
+ "serde_with",
+ "sha2",
+ "strum 0.24.1",
+ "thiserror",
 ]
 
 [[package]]
 name = "near-rpc-error-core"
-version = "0.14.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ee0b41c75ef859c193a8ff1dadfa0c8207bc0ac447cc22259721ad769a1408"
+checksum = "80fca203c51edd9595ec14db1d13359fb9ede32314990bf296b6c5c4502f6ab7"
 dependencies = [
  "quote",
  "serde",
- "syn 1.0.109",
+ "syn 2.0.50",
 ]
 
 [[package]]
 name = "near-rpc-error-macro"
-version = "0.14.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e837bd4bacd807073ec5ceb85708da7f721b46a4c2a978de86027fb0034ce31"
+checksum = "897a445de2102f6732c8a185d922f5e3bf7fd0a41243ce40854df2197237f799"
 dependencies = [
+ "fs2",
  "near-rpc-error-core",
  "serde",
- "syn 1.0.109",
+ "syn 2.0.50",
 ]
 
 [[package]]
 name = "near-sdk"
-version = "4.1.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15eb3de2defe3626260cc209a6cdb985c6b27b0bd4619fad97dcfae002c3c5bd"
+checksum = "b5c2e7c9524308b1b301cca05d875de13b3b20dc8b92e71f3890b380372e4c88"
 dependencies = [
- "base64 0.13.1",
- "borsh 0.9.3",
- "bs58 0.4.0",
- "near-abi",
+ "base64 0.21.7",
+ "borsh",
+ "bs58 0.5.0",
+ "near-account-id",
  "near-crypto",
+ "near-gas",
+ "near-parameters",
  "near-primitives",
  "near-primitives-core",
  "near-sdk-macros",
  "near-sys",
- "near-vm-logic",
+ "near-token",
+ "near-vm-runner",
  "once_cell",
- "schemars",
  "serde",
  "serde_json",
- "wee_alloc",
 ]
 
 [[package]]
 name = "near-sdk-macros"
-version = "4.1.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4907affc9f5ed559456509188ff0024f1f2099c0830e6bdb66eb61d5b75912c0"
+checksum = "e1e9b23d9d7757ade258921c9cbc7923542e64d9d3b52a6cd91f746c77cb0a0f"
 dependencies = [
  "Inflector",
+ "darling",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "serde",
+ "serde_json",
+ "strum 0.26.1",
+ "strum_macros 0.26.1",
+ "syn 2.0.50",
 ]
+
+[[package]]
+name = "near-stdx"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "855fd5540e3b4ff6fedf12aba2db1ee4b371b36f465da1363a6d022b27cb43b8"
 
 [[package]]
 name = "near-sys"
@@ -849,37 +1455,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "397688591acf8d3ebf2c2485ba32d4b24fc10aad5334e3ad8ec0b7179bfdf06b"
 
 [[package]]
-name = "near-vm-errors"
-version = "0.14.0"
+name = "near-token"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0da466a30f0446639cbd788c30865086fac3e8dcb07a79e51d2b0775ed4261e"
+checksum = "7b68f3f8a2409f72b43efdbeff8e820b81e70824c49fee8572979d789d1683fb"
 dependencies = [
- "borsh 0.9.3",
- "near-account-id",
- "near-rpc-error-macro",
+ "borsh",
  "serde",
 ]
 
 [[package]]
-name = "near-vm-logic"
-version = "0.14.0"
+name = "near-vm-runner"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b534828419bacbf1f7b11ef7b00420f248c548c485d3f0cfda8bb6931152f2"
+checksum = "c56c80bdb1954808f59bd36a9112377197b38d424991383bf05f52d0fe2e0da5"
 dependencies = [
- "base64 0.13.1",
- "borsh 0.9.3",
- "bs58 0.4.0",
- "byteorder",
- "near-account-id",
+ "base64 0.21.7",
+ "borsh",
+ "ed25519-dalek",
+ "enum-map",
+ "memoffset",
  "near-crypto",
- "near-primitives",
+ "near-parameters",
  "near-primitives-core",
- "near-vm-errors",
+ "near-stdx",
+ "num-rational",
+ "once_cell",
+ "prefix-sum-vec",
  "ripemd",
  "serde",
- "sha2 0.10.8",
+ "serde_repr",
+ "serde_with",
+ "sha2",
  "sha3",
+ "strum 0.24.1",
+ "thiserror",
+ "tracing",
  "zeropool-bn",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -892,6 +1514,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
@@ -925,6 +1553,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,41 +1584,141 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "parity-scale-codec"
-version = "2.3.1"
+name = "opentelemetry"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373b1a4c1338d9cd3d1fa53b3a11bdab5ab6bd80a20f7f7becd76953ae2be909"
+checksum = "6105e89802af13fdf48c49d7646d3b533a70e536d818aae7e78ba0433d01acb8"
 dependencies = [
- "arrayvec 0.7.4",
- "bitvec",
- "byte-slice-cast",
- "impl-trait-for-tuples",
- "parity-scale-codec-derive",
- "serde",
+ "async-trait",
+ "crossbeam-channel",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "js-sys",
+ "lazy_static",
+ "percent-encoding",
+ "pin-project",
+ "rand 0.8.5",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
-name = "parity-scale-codec-derive"
+name = "opentelemetry-otlp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1a6ca9de4c8b00aa7f1a153bd76cb263287155cec642680d79d98706f3d28a"
+dependencies = [
+ "async-trait",
+ "futures",
+ "futures-util",
+ "http",
+ "opentelemetry",
+ "prost",
+ "thiserror",
+ "tokio",
+ "tonic",
+ "tonic-build",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985cc35d832d412224b2cffe2f9194b1b89b6aa5d0bef76d080dce09d90e62bd"
+dependencies = [
+ "opentelemetry",
+]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "petgraph"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "fixedbitset",
+ "indexmap 2.2.3",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
+dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.50",
 ]
 
 [[package]]
-name = "parity-secp256k1"
-version = "0.7.0"
-source = "git+https://github.com/paritytech/rust-secp256k1?rev=d05fd8e#d05fd8e152f8d110b587906e3d854196b086e42a"
-dependencies = [
- "arrayvec 0.5.2",
- "cc",
- "cfg-if 0.1.10",
- "rand 0.7.3",
-]
+name = "pin-project-lite"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "platforms"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -980,13 +1727,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "prefix-sum-vec"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa06bd51638b6e76ac9ba9b6afb4164fa647bd2916d722f2623fbb6d1ed8bdba"
+
+[[package]]
 name = "primitive-types"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
 dependencies = [
  "fixed-hash 0.7.0",
- "impl-codec",
  "uint",
 ]
 
@@ -1004,21 +1756,34 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "0.1.5"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
+checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
- "toml",
+ "toml_edit",
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "1.3.1"
+name = "proc-macro-error"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
- "once_cell",
- "toml_edit",
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -1031,6 +1796,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
+name = "prost"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
+dependencies = [
+ "bytes",
+ "heck 0.3.3",
+ "itertools",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prost",
+ "prost-types",
+ "regex",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
+dependencies = [
+ "bytes",
+ "prost",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
 name = "quote"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,12 +1877,6 @@ checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
@@ -1117,6 +1950,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "reed-solomon-erasure"
 version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1124,6 +1966,50 @@ checksum = "a415a013dd7c5d4221382329a5a3482566da675737494935cbbbcdec04662f9d"
 dependencies = [
  "smallvec",
 ]
+
+[[package]]
+name = "regex"
+version = "1.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.5",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "ripemd"
@@ -1145,6 +2031,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
 name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1160,6 +2052,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.38.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+dependencies = [
+ "bitflags 2.4.2",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1167,76 +2072,66 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
-name = "schemars"
-version = "0.8.16"
+name = "scopeguard"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a28f4c49489add4ce10783f7911893516f15afe45d015608d41faca6bc4d29"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "secp256k1"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
- "dyn-clone",
- "schemars_derive",
- "serde",
- "serde_json",
+ "rand 0.8.5",
+ "secp256k1-sys",
 ]
 
 [[package]]
-name = "schemars_derive"
-version = "0.8.16"
+name = "secp256k1-sys"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c767fd6fa65d9ccf9cf026122c1b555f2ef9a4f0cea69da4d7dbc3e258d30967"
+checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
 dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn 1.0.109",
+ "cc",
 ]
 
 [[package]]
 name = "semver"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "syn 2.0.50",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
  "itoa",
  "ryu",
@@ -1244,16 +2139,57 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.9.9"
+name = "serde_repr"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
 dependencies = [
- "block-buffer 0.9.0",
- "cfg-if 1.0.0",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15d167997bd841ec232f5b2b8e0e26606df2e7caa4c31b95ea9ca52b200bd270"
+dependencies = [
+ "base64 0.21.7",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.2.3",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "865f9743393e638991566a8b7a479043c2c8da94a33e0a31f18214c9cae0a64d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd075d994154d4a774f95b51fb96bdc2832b0ea48425c92546073816cda1f2f"
+dependencies = [
+ "indexmap 2.2.3",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -1262,7 +2198,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest 0.10.7",
 ]
@@ -1278,10 +2214,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "signature"
-version = "1.6.4"
+name = "sharded-slab"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "smallvec"
@@ -1301,6 +2264,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1313,13 +2286,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+
+[[package]]
 name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.24.3",
 ]
+
+[[package]]
+name = "strum"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f"
 
 [[package]]
 name = "strum_macros"
@@ -1327,11 +2318,24 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -1353,9 +2357,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1363,10 +2367,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
+name = "syn_derive"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "rustix",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "thiserror"
@@ -1385,7 +2407,48 @@ checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -1404,12 +2467,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "toml"
-version = "0.5.11"
+name = "tokio"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
- "serde",
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "num_cpus",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1420,14 +2553,204 @@ checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.15"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap",
+ "indexmap 2.2.3",
  "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "tonic"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64 0.13.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "prost-derive",
+ "tokio",
+ "tokio-stream",
+ "tokio-util 0.6.10",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
+dependencies = [
+ "proc-macro2",
+ "prost-build",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util 0.7.10",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.17.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbbe89715c1dbbb790059e2565353978564924ee85017b5fff365c872ff6721f"
+dependencies = [
+ "once_cell",
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-log 0.1.4",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log 0.2.0",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -1454,10 +2777,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -1477,7 +2833,7 @@ version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
@@ -1492,7 +2848,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
  "wasm-bindgen-shared",
 ]
 
@@ -1514,7 +2870,7 @@ checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.50",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1526,15 +2882,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
 
 [[package]]
-name = "wee_alloc"
-version = "0.4.5"
+name = "which"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb3b5a6b2bb17cb6ad44a2e68a43e8d2722c997da10e928665c72ec6c0a0b8e"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
 dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "memory_units",
- "winapi",
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -1565,65 +2921,140 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.3",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d380ba1dc7187569a8a9e91ed34b8ccfc33123bbacb8c0aed2d1ad7f3ef2dc5f"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.3",
+ "windows_aarch64_msvc 0.52.3",
+ "windows_i686_gnu 0.52.3",
+ "windows_i686_msvc 0.52.3",
+ "windows_x86_64_gnu 0.52.3",
+ "windows_x86_64_gnullvm 0.52.3",
+ "windows_x86_64_msvc 0.52.3",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68e5dcfb9413f53afd9c8f86e56a7b4d86d9a2fa26090ea2dc9e40fba56c6ec6"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dab469ebbc45798319e69eebf92308e541ce46760b49b18c6b3fe5e8965b30f"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a4e9b6a7cac734a8b4138a4e1044eac3404d8326b6c0f939276560687a033fb"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b0ec9c422ca95ff34a78755cfa6ad4a51371da2a5ace67500cf7ca5f232c58"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704131571ba93e89d7cd43482277d6632589b18ecf4468f591fbae0a8b101614"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42079295511643151e98d61c38c0acc444e52dd42ab456f7ccfd5152e8ecf21c"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0770833d60a970638e989b3fa9fd2bb1aaadcf88963d1659fd7d9990196ed2d6"
 
 [[package]]
 name = "winnow"
@@ -1635,58 +3066,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "wyz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
-
-[[package]]
 name = "xcc_router"
 version = "1.0.0"
 dependencies = [
  "aurora-engine-types",
+ "near-primitives",
  "near-sdk",
 ]
 
 [[package]]
-name = "zerocopy"
-version = "0.7.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
 name = "zeroize"
-version = "1.3.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 
 [[package]]
 name = "zeropool-bn"
@@ -1694,7 +3086,6 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e61de68ede9ffdd69c01664f65a178c5188b73f78faa21f0936016a888ff7c"
 dependencies = [
- "borsh 0.9.3",
  "byteorder",
  "crunchy",
  "lazy_static",

--- a/etc/xcc-router/Cargo.toml
+++ b/etc/xcc-router/Cargo.toml
@@ -15,11 +15,11 @@ debug = false
 panic = "abort"
 
 [dependencies]
-aurora-engine-types = { path = "../../engine-types", default-features = false, features = ["borsh-compat"] }
-near-sdk = "4.1"
+aurora-engine-types = { path = "../../engine-types", default-features = false }
+near-sdk = { version = "5", default-features = false, features = ["legacy", "unit-testing"] }
 
-[patch.crates-io]
-parity-secp256k1 = { git = 'https://github.com/paritytech/rust-secp256k1', rev = "d05fd8e" }
+[dev-dependencies]
+near-primitives = "0.20"
 
 [features]
 default = []


### PR DESCRIPTION
## Description

The PR bumps borsh dependency to 1.3.0 along with the near-sdk 5.0.0 that allows us to get rid of the feature `borsh-compat`. 

## Performance / NEAR gas cost considerations

Not changes in performance.

## Testing

No new tests.