### PR TITLE
Feat: extend `ExecutionProfile` with logs for tests

### DIFF
--- a/engine-tests/src/utils/mod.rs
+++ b/engine-tests/src/utils/mod.rs
@@ -681,6 +681,7 @@ impl Default for AuroraRunner {
 pub struct ExecutionProfile {
     pub host_breakdown: ProfileDataV3,
     total_gas_cost: u64,
+    pub logs: Vec<String>,
 }
 
 impl ExecutionProfile {
@@ -688,6 +689,7 @@ impl ExecutionProfile {
         Self {
             host_breakdown: outcome.profile.clone(),
             total_gas_cost: outcome.burnt_gas,
+            logs: outcome.logs.clone(),
         }
     }
 


### PR DESCRIPTION
## Description

Extended `ExecutionProfile` with logs for tests. 

Changes related only to `engine-tests` and do not affect main contract.

### Motivation

To profile NEAR contract execution flow it's convenient to debug.

