### PR TITLE
feat: pause FT transfers

### DIFF
--- a/engine-tests-connector/src/utils.rs
+++ b/engine-tests-connector/src/utils.rs
@@ -31,6 +31,8 @@ pub const UNPAUSE_ALL: PausedMask = 0;
 pub const PAUSE_DEPOSIT: PausedMask = 1 << 0;
 /// Admin control flow flag indicates that withdrawal is paused.
 pub const PAUSE_WITHDRAW: PausedMask = 1 << 1;
+/// Admin control flow flag indicates that ft transfers are paused.
+pub const PAUSE_FT: PausedMask = 1 << 2;
 
 pub struct TestContract {
     pub engine_contract: Contract,

--- a/engine-tests/src/tests/erc20_connector.rs
+++ b/engine-tests/src/tests/erc20_connector.rs
@@ -911,7 +911,7 @@ pub mod workspace {
         let result = transfer_call_nep_141(
             &aurora.id(),
             &ft_owner,
-            &aurora.id().to_string(),
+            aurora.id().as_ref(),
             transfer_amount,
             transfer_call_msg,
             false,
@@ -933,7 +933,7 @@ pub mod workspace {
         transfer_call_nep_141(
             &aurora.id(),
             &ft_owner,
-            &aurora.id().to_string(),
+            aurora.id().as_ref(),
             transfer_amount,
             transfer_call_msg,
             false,

--- a/engine-tests/src/utils/workspace.rs
+++ b/engine-tests/src/utils/workspace.rs
@@ -239,26 +239,30 @@ pub async fn transfer_nep_141(
 }
 
 #[cfg(not(feature = "ext-connector"))]
+pub async fn storage_deposit_nep141(
+    nep_141: &AccountId,
+    source: &Account,
+    dest: &str,
+) -> anyhow::Result<ExecutionFinalResult> {
+    source
+        .call(nep_141, "storage_deposit")
+        .args_json(json!({
+            "account_id": dest,
+        }))
+        .deposit(STORAGE_AMOUNT)
+        .max_gas()
+        .transact()
+        .await
+}
+
+#[cfg(not(feature = "ext-connector"))]
 pub async fn transfer_call_nep_141(
     nep_141: &AccountId,
     source: &Account,
     dest: &str,
     amount: u128,
     msg: &str,
-    storage_deposit: bool,
 ) -> anyhow::Result<ExecutionFinalResult> {
-    if storage_deposit {
-        let _ = source
-            .call(nep_141, "storage_deposit")
-            .args_json(json!({
-                "account_id": dest,
-            }))
-            .deposit(STORAGE_AMOUNT)
-            .max_gas()
-            .transact()
-            .await?;
-    }
-
     source
         .call(nep_141, "ft_transfer_call")
         .args_json(json!({

--- a/engine-tests/src/utils/workspace.rs
+++ b/engine-tests/src/utils/workspace.rs
@@ -10,9 +10,9 @@ use aurora_engine_types::parameters::connector::{FungibleTokenMetadata, Withdraw
 use aurora_engine_types::types::Address;
 use aurora_engine_types::U256;
 use aurora_engine_workspace::account::Account;
-use aurora_engine_workspace::{
-    types::ExecutionFinalResult, types::NearToken, EngineContract, RawContract,
-};
+#[cfg(not(feature = "ext-connector"))]
+use aurora_engine_workspace::types::ExecutionFinalResult;
+use aurora_engine_workspace::{types::NearToken, EngineContract, RawContract};
 use serde_json::json;
 
 const FT_PATH: &str = "src/tests/res/fungible_token.wasm";

--- a/engine-tests/src/utils/workspace.rs
+++ b/engine-tests/src/utils/workspace.rs
@@ -238,6 +238,7 @@ pub async fn transfer_nep_141(
     Ok(())
 }
 
+#[cfg(not(feature = "ext-connector"))]
 pub async fn transfer_call_nep_141(
     nep_141: &AccountId,
     source: &Account,

--- a/engine-tests/src/utils/workspace.rs
+++ b/engine-tests/src/utils/workspace.rs
@@ -10,7 +10,9 @@ use aurora_engine_types::parameters::connector::{FungibleTokenMetadata, Withdraw
 use aurora_engine_types::types::Address;
 use aurora_engine_types::U256;
 use aurora_engine_workspace::account::Account;
-use aurora_engine_workspace::{types::NearToken, EngineContract, RawContract};
+use aurora_engine_workspace::{
+    types::ExecutionFinalResult, types::NearToken, EngineContract, RawContract,
+};
 use serde_json::json;
 
 const FT_PATH: &str = "src/tests/res/fungible_token.wasm";
@@ -234,6 +236,40 @@ pub async fn transfer_nep_141(
     assert!(result.is_success());
 
     Ok(())
+}
+
+pub async fn transfer_call_nep_141(
+    nep_141: &AccountId,
+    source: &Account,
+    dest: &str,
+    amount: u128,
+    msg: &str,
+    storage_deposit: bool,
+) -> anyhow::Result<ExecutionFinalResult> {
+    if storage_deposit {
+        let _ = source
+            .call(nep_141, "storage_deposit")
+            .args_json(json!({
+                "account_id": dest,
+            }))
+            .deposit(STORAGE_AMOUNT)
+            .max_gas()
+            .transact()
+            .await?;
+    }
+
+    source
+        .call(nep_141, "ft_transfer_call")
+        .args_json(json!({
+            "receiver_id": dest,
+            "amount": amount.to_string(),
+            "memo": "null",
+            "msg": msg,
+        }))
+        .deposit(NearToken::from_yoctonear(1))
+        .max_gas()
+        .transact()
+        .await
 }
 
 #[cfg(feature = "ext-connector")]

--- a/engine/src/contract_methods/connector/errors.rs
+++ b/engine/src/contract_methods/connector/errors.rs
@@ -91,6 +91,7 @@ pub enum FtTransferCallError {
     MessageParseFailed(ParseOnTransferMessageError),
     InsufficientAmountForFee,
     Transfer(TransferError),
+    Paused,
 }
 
 impl From<TransferError> for FtTransferCallError {
@@ -118,6 +119,7 @@ impl AsRef<[u8]> for FtTransferCallError {
             Self::InsufficientAmountForFee => errors::ERR_NOT_ENOUGH_BALANCE_FOR_FEE,
             Self::Transfer(e) => e.as_ref(),
             Self::BalanceOverflow(e) => e.as_ref(),
+            Self::Paused => errors::ERR_PAUSED,
         }
     }
 }
@@ -200,6 +202,7 @@ pub enum TransferError {
     SelfTransfer,
     Deposit(DepositError),
     Withdraw(WithdrawError),
+    Paused,
 }
 
 impl AsRef<[u8]> for TransferError {
@@ -213,6 +216,7 @@ impl AsRef<[u8]> for TransferError {
             Self::SelfTransfer => errors::ERR_SENDER_EQUALS_RECEIVER,
             Self::Deposit(e) => e.as_ref(),
             Self::Withdraw(e) => e.as_ref(),
+            Self::Paused => errors::ERR_PAUSED,
         }
     }
 }
@@ -239,6 +243,7 @@ pub enum StorageFundingError {
     NoAvailableBalance,
     InsufficientDeposit,
     UnRegisterPositiveBalance,
+    Paused,
 }
 
 impl AsRef<[u8]> for StorageFundingError {
@@ -250,6 +255,7 @@ impl AsRef<[u8]> for StorageFundingError {
             Self::UnRegisterPositiveBalance => {
                 errors::ERR_FAILED_UNREGISTER_ACCOUNT_POSITIVE_BALANCE
             }
+            Self::Paused => errors::ERR_PAUSED,
         }
     }
 }

--- a/engine/src/contract_methods/connector/errors.rs
+++ b/engine/src/contract_methods/connector/errors.rs
@@ -119,7 +119,7 @@ impl AsRef<[u8]> for FtTransferCallError {
             Self::InsufficientAmountForFee => errors::ERR_NOT_ENOUGH_BALANCE_FOR_FEE,
             Self::Transfer(e) => e.as_ref(),
             Self::BalanceOverflow(e) => e.as_ref(),
-            Self::Paused => errors::ERR_PAUSED,
+            Self::Paused => errors::ERR_FT_PAUSED,
         }
     }
 }
@@ -216,7 +216,7 @@ impl AsRef<[u8]> for TransferError {
             Self::SelfTransfer => errors::ERR_SENDER_EQUALS_RECEIVER,
             Self::Deposit(e) => e.as_ref(),
             Self::Withdraw(e) => e.as_ref(),
-            Self::Paused => errors::ERR_PAUSED,
+            Self::Paused => errors::ERR_FT_PAUSED,
         }
     }
 }
@@ -255,7 +255,7 @@ impl AsRef<[u8]> for StorageFundingError {
             Self::UnRegisterPositiveBalance => {
                 errors::ERR_FAILED_UNREGISTER_ACCOUNT_POSITIVE_BALANCE
             }
-            Self::Paused => errors::ERR_PAUSED,
+            Self::Paused => errors::ERR_FT_PAUSED,
         }
     }
 }

--- a/engine/src/errors.rs
+++ b/engine/src/errors.rs
@@ -24,6 +24,7 @@ pub const ERR_NO_UPGRADE: &[u8; 14] = b"ERR_NO_UPGRADE";
 pub const ERR_NOT_ALLOWED: &[u8; 15] = b"ERR_NOT_ALLOWED";
 pub const ERR_NOT_OWNER: &[u8; 13] = b"ERR_NOT_OWNER";
 pub const ERR_PAUSED: &[u8; 10] = b"ERR_PAUSED";
+pub const ERR_FT_PAUSED: &[u8; 13] = b"ERR_FT_PAUSED";
 pub const ERR_RUNNING: &[u8; 11] = b"ERR_RUNNING";
 
 pub const ERR_SERIALIZE: &str = "ERR_SERIALIZE";


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Here are some helpful tips:

* Always create branches on and target the `develop` branch.
* Run all the tests locally and ensure that they are passing.
* Run `make format` to ensure that the code is formatted.
* Run `make check` to ensure that all checks passed successfully.
* Small commits and contributions that attempt one single goal is preferable.
* If the idea changes or adds anything functional which will affect users, an 
AIP discussion is required first on the Aurora forum: 
https://forum.aurora.dev/discussions/AIPs%20(Aurora%20Improvement%20Proposals).
* Avoid breaking the public API (namely in engine/src/lib.rs) unless required.
* If your PR is a WIP, ensure that you enable "draft" mode.
* Your first PRs won't use the CI automatically unless a maintainer starts.
If this is not your first PR, please do NOT abuse the CI resources.

Checklist:
- [ ] I have performed a self-review of my code
- [ ] I have documented my code, particularly in the hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to prove my fix or new feature is effective and works
- [ ] Any dependent changes have been merged
- [ ] The PR is targeting the `develop` branch and not `master`
- [ ] I have pre-squashed my commits into a single commit and rebased.
-->

## Description
Add the possibility of pausing the ft transfers for the internal eth-connector; this is needed to avoid pausing the whole Aurora engine during migration.
A new flag, `PAUSE_FT`, has been added that pauses all the public methods that could change the internal balances of the eth-connector token [`ft_transfer`, `ft_transfer_call`, `storage_deposit`, `storage_unregister`].
<!-- 
Provide a general summary of your changes. A clear overview along with an 
in-depth explanation is beneficial.

If this PR closes any issues, be sure to add "closes #<number>" somewhere.
-->

## Performance / NEAR gas cost considerations

<!--
Performance regressions are not ideal, though we welcome performance 
improvements. Any PR must be completely mindful of any gas cost increases. The 
CI will fail if the gas costs change at all. Do update these tests to 
accommodate for the new gas changes. It is good to explain 
this change, if necessary.
-->

## Testing
Some tests have been added to test the pause and unpause logic.
<!--
Please describe the tests that you ran to verify your changes.
-->

## How should this be reviewed

<!--
Include any recommendations of areas to be careful of to ensure that the 
reviewers use extra attention.
-->

## Additional information

<!--
Include any additional information which you think should be in this PR, such
as prior arts, future extensions, unresolved problems, or a TODO list which 
should be followed up.
-->
