### PR TITLE
feat: provide amount of gas for state migration in upgrade

### DIFF
--- a/engine-types/src/parameters/engine.rs
+++ b/engine-types/src/parameters/engine.rs
@@ -339,6 +339,15 @@ pub struct RelayerKeyArgs {
 
 pub type FullAccessKeyArgs = RelayerKeyArgs;
 
+/// Parameters for upgrading the contract.
+#[derive(Debug, Clone, Eq, PartialEq, BorshSerialize, BorshDeserialize)]
+pub struct UpgradeParams {
+    /// Code for upgrading.
+    pub code: Vec<u8>,
+    /// Amount of gas for the state migration.
+    pub state_migration_gas: Option<u64>,
+}
+
 mod chain_id_deserialize {
     use crate::types::{u256_to_arr, RawU256};
     use primitive_types::U256;


### PR DESCRIPTION
The PR's motivation is to add the possibility of setting the amount of gas for the state migration in the `upgrade` transaction. This allows us to upgrade Aurora via a controller contract. With the previous amount of gas for the state migration (100 TGas), we can't do it because 200 Tgas is insufficient for the upgrade procedure via a controller. If we need more than 50 TGas for the state migration, we can call the `upgrade` transaction directly.  