### PR TITLE
fix: unpause eth connector after init in tests

### DIFF
--- a/engine-tests-connector/src/utils.rs
+++ b/engine-tests-connector/src/utils.rs
@@ -41,7 +41,7 @@ pub struct TestContract {
 }
 
 impl TestContract {
-    pub async fn deploy_aurora_contract() -> anyhow::Result<(Contract, Contract, Account)> {
+    async fn deploy_aurora_contract() -> anyhow::Result<(Contract, Contract, Account)> {
         use near_workspaces::{
             types::{KeyType, SecretKey},
             AccessKey,
@@ -140,6 +140,14 @@ impl TestContract {
             .transact()
             .await?;
         assert!(res.is_success());
+
+        let result = eth_connector_contract
+            .call("pa_unpause_feature")
+            .args_json(json!({ "key": "ALL" }))
+            .max_gas()
+            .transact()
+            .await?;
+        assert!(result.is_success(), "{result:#?}");
 
         let chain_id = [0u8; 32];
         let res = engine_contract

--- a/engine-tests/src/utils/workspace.rs
+++ b/engine-tests/src/utils/workspace.rs
@@ -85,6 +85,15 @@ async fn init_eth_connector(aurora: &EngineContract) -> anyhow::Result<()> {
         .await?;
     assert!(result.is_success());
 
+    // By default, the contract is paused. So we need to unpause it.
+    let result = contract
+        .call("pa_unpause_feature")
+        .args_json(json!({ "key": "ALL" }))
+        .max_gas()
+        .transact()
+        .await?;
+    assert!(result.is_success());
+
     let result = aurora
         .set_eth_connector_contract_account(contract_account.id(), WithdrawSerializeType::Borsh)
         .transact()


### PR DESCRIPTION
## Description

The changes in the PR unpause all features of the eth connector since they are now paused after initialization by default. 
