### PR TITLE
chore(docs): remove duplicate `test` task

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ shasum -a 256 bin/aurora-<profile>.wasm
 #### Running unit & integration tests
 
 To run tests, there are a few cargo make tasks we can run:
-- `test`: tests the whole cargo workspace and ETH contracts. Requires a `--profile` argument.
 - `test-workspace`: tests only the cargo workspace.
 - `test-contracts`: tests only the contracts.
 - `test`: tests the whole cargo workspace, ETH contracts and runs modexp benchmarks. Requires a `--profile` argument.


### PR DESCRIPTION
The `test` task is duplicated in the README.