### PR TITLE
chore: fix grammar in `Cargo.toml`

### DIFF
--- a/engine-types/Cargo.toml
+++ b/engine-types/Cargo.toml
@@ -26,7 +26,7 @@ rand.workspace = true
 [features]
 default = ["std"]
 std = ["borsh/std", "hex/std", "primitive-types/std", "primitive-types/serde", "serde/std", "serde_json/std", "rlp/std"]
-# `primitive-types/std` is excluded because its `std` implementation includes a transitive
+# `primitive-types/std` is excluded because it's `std` implementation includes a transitive
 # dependency on `getrandom` which uses OS call to obtain entropy. Such calls are not
 # available in Wasm, therefore we cannot use the `std` implementation of `primitive-types`
 # in other Rust contracts.


### PR DESCRIPTION
`It's` (possessive) rather than `Its`.