### PR TITLE
Rename `ENV` to `dotenv`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 # Editor backup files
 *~
 
-# ENV
+# dotenv
 .env/custom.env
 
 # Rust artifacts


### PR DESCRIPTION
The file format is technically called `dotenv`, not `ENV` (or `.env` for that matter)