### PR TITLE
fix: exceeded prepaid gas error in mirror_erc20_token

### DIFF
--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -2674,7 +2674,7 @@ mod tests {
         // Check the storage value and hit the cache
         let actual_value = engine.storage(origin.raw(), index);
         assert_eq!(expected_value, actual_value);
-        // Cache should exists
+        // Cache should exist
         let cache_val = engine
             .contract_storage_cache
             .borrow()


### PR DESCRIPTION
## Description

After some investigation, we realised that the problem was caused by a change in gas costs after switching to near protocol version 66. The change relates to the amount of gas used to load contract data, which was [changed](https://github.com/near/nearcore/blob/master/core/parameters/res/runtime_configs/66.yaml#L15) from 216750 to 1089295 Gas per byte. The change increases the amount of gas used in the `mirror_erc20_token_callback` to approximately to 1TGas. So, more than 5TGas is needed now. Thanks to @birchmd for his help with this investigation.

## Performance / NEAR gas cost considerations

There are no changes in the performance.

## Testing

#950 bumps `near-workspace` to 0.12, which contains updated `near-sandbox` 2.1.1. on which the error is reproduced.

## How should this be reviewed

Check that the problem no longer reproduces after this commit is included in #950.
