### PR TITLE
deps: bump near dependencies in the tests

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: github-hosted-heavy-runner
     strategy:
       matrix:
-        profile: [mainnet, mainnet-silo, testnet, testnet-silo]
+        profile: [ mainnet, mainnet-silo, testnet, testnet-silo ]
     steps:
       - name: Potential broken submodules fix
         run: |
           git checkout -f $(git -c user.name=x -c user.email=x@x commit-tree $(git hash-object -t tree /dev/null) < /dev/null) || :
       - name: Clone the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -41,7 +41,7 @@ jobs:
     needs: build
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
       - run: ls -la contracts
       - name: Publish contracts for ${{ github.ref }} release
         uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -10,47 +10,47 @@ name: Lints
 jobs:
   fmt:
     name: Format
-    runs-on: [self-hosted, light]
+    runs-on: [ self-hosted, light ]
     steps:
       - name: Potential broken submodules fix
         run: |
           git checkout -f $(git -c user.name=x -c user.email=x@x commit-tree $(git hash-object -t tree /dev/null) < /dev/null) || :
       - name: Clone the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run cargo fmt
         run: cargo make check-fmt
   clippy:
     name: Clippy
-    runs-on: [self-hosted, heavy]
+    runs-on: [ self-hosted, heavy ]
     steps:
       - name: Potential broken submodules fix
         run: |
           git checkout -f $(git -c user.name=x -c user.email=x@x commit-tree $(git hash-object -t tree /dev/null) < /dev/null) || :
       - name: Clone the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - run: cargo make build-contracts
       - name: Run Contract cargo clippy
         run: cargo make clippy
   udeps:
     name: Udeps
-    runs-on: [self-hosted, heavy]
+    runs-on: [ self-hosted, heavy ]
     steps:
       - name: Potential broken submodules fix
         run: |
           git checkout -f $(git -c user.name=x -c user.email=x@x commit-tree $(git hash-object -t tree /dev/null) < /dev/null) || :
       - name: Clone the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run udeps
         run: cargo make udeps
   contracts:
     name: Contracts
-    runs-on: [self-hosted, light]
+    runs-on: [ self-hosted, light ]
     steps:
       - name: Potential broken submodules fix
         run: |
           git checkout -f $(git -c user.name=x -c user.email=x@x commit-tree $(git hash-object -t tree /dev/null) < /dev/null) || :
       - name: Clone the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run yarn lint
         run: cargo make check-contracts
       - name: Check committed EvmErc20.bin

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
             target/
           key: ${{ matrix.profile }}-cargo-test
       - name: Setup Node and cache
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
           cache: 'yarn'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Clone the repository
         uses: actions/checkout@v4
       - name: Cargo Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -70,7 +70,7 @@ jobs:
       - name: Clone the repository
         uses: actions/checkout@v4
       - name: Cargo Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util",
 ]
 
 [[package]]
@@ -96,7 +96,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if 1.0.0",
- "cipher 0.4.4",
+ "cipher",
  "cpufeatures",
 ]
 
@@ -106,7 +106,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "once_cell",
  "version_check",
 ]
@@ -131,6 +131,12 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "android-tzdata"
@@ -230,12 +236,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "assert_matches"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
-
-[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,7 +330,7 @@ dependencies = [
  "hex",
  "libsecp256k1",
  "num",
- "rand 0.8.5",
+ "rand",
  "ripemd",
  "serde",
  "serde_json",
@@ -387,13 +387,13 @@ dependencies = [
  "git2",
  "hex",
  "libsecp256k1",
- "near-crypto 0.20.1",
- "near-parameters 0.20.1",
- "near-primitives 0.20.1",
- "near-primitives-core 0.20.1",
+ "near-crypto 0.25.0",
+ "near-parameters 0.25.0",
+ "near-primitives 0.25.0",
+ "near-primitives-core 0.25.0",
  "near-sdk",
  "near-vm-runner",
- "rand 0.8.5",
+ "rand",
  "reqwest",
  "rlp",
  "serde",
@@ -444,7 +444,7 @@ dependencies = [
  "bs58 0.5.1",
  "hex",
  "primitive-types 0.12.2",
- "rand 0.8.5",
+ "rand",
  "rlp",
  "serde",
  "serde_json",
@@ -622,8 +622,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93f2635620bf0b9d4576eb7bb9a38a55df78bd1205d26fa994b25911a69f212f"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand",
+ "rand_core",
  "serde",
  "unicode-normalization",
 ]
@@ -660,17 +660,6 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4e37d16930f5459780f5621038b6382b9bb37c19016f39fb6b5808d831f174"
-dependencies = [
- "crypto-mac 0.8.0",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "blake2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
@@ -694,6 +683,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blst"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4378725facc195f1a538864863f6de233b500a8862747e7f165078a419d5e874"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
 ]
 
 [[package]]
@@ -875,16 +876,6 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
-]
-
-[[package]]
-name = "c2-chacha"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d27dae93fe7b1e0424dc57179ac396908c26b035a87234809f5c4dfd1b47dc80"
-dependencies = [
- "cipher 0.2.5",
- "ppv-lite86",
 ]
 
 [[package]]
@@ -1071,15 +1062,6 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
-]
-
-[[package]]
-name = "cipher"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -1532,7 +1514,7 @@ dependencies = [
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
- "rand_core 0.6.4",
+ "rand_core",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -1606,7 +1588,7 @@ dependencies = [
  "num",
  "once_cell",
  "openssl",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -1763,13 +1745,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "dynasm"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33dc03612f42465a8ed7f5e354bc2b79ba54cedefa81d5bd3a064f1835adaba8"
+dependencies = [
+ "bitflags 1.3.2",
+ "byteorder",
+ "lazy_static",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "dynasmrt"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fba5a42bd76a17cad4bfa00de168ee1cbfa06a5e8ce992ae880218c05641a9"
 dependencies = [
  "byteorder",
- "dynasm",
+ "dynasm 1.2.3",
+ "memmap2",
+]
+
+[[package]]
+name = "dynasmrt"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7dccc31a678058996aef614f6bd418ced384da70f284e83e2b7bf29b27b6a28"
+dependencies = [
+ "byteorder",
+ "dynasm 2.0.0",
+ "fnv",
  "memmap2",
 ]
 
@@ -1802,7 +1811,7 @@ checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core 0.6.4",
+ "rand_core",
  "sha2 0.10.8",
  "subtle",
 ]
@@ -2160,16 +2169,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand 0.8.5",
+ "rand",
  "rustc-hex",
  "static_assertions",
 ]
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -2383,24 +2386,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -2485,7 +2477,7 @@ dependencies = [
  "indexmap 2.5.0",
  "slab",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util",
  "tracing",
 ]
 
@@ -2504,7 +2496,7 @@ dependencies = [
  "indexmap 2.5.0",
  "slab",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util",
  "tracing",
 ]
 
@@ -2567,6 +2559,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash 0.8.11",
+ "allocator-api2",
  "serde",
 ]
 
@@ -3317,7 +3310,7 @@ dependencies = [
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
- "rand 0.8.5",
+ "rand",
  "serde",
  "sha2 0.9.9",
  "typenum",
@@ -3416,6 +3409,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
 dependencies = [
  "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "lru"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -3566,7 +3568,7 @@ checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.48.0",
 ]
 
@@ -3578,7 +3580,7 @@ checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi 0.3.9",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.52.0",
 ]
 
@@ -3598,18 +3600,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
-name = "multimap"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
 name = "names"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bddcd3bf5144b6392de80e04c347cd7fab2508f6df16a85fc496ecd5cec39bc"
 dependencies = [
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -3703,7 +3699,7 @@ dependencies = [
  "near-async-derive",
  "near-o11y 0.24.1",
  "near-performance-metrics",
- "near-time",
+ "near-time 0.24.1",
  "once_cell",
  "serde",
  "serde_json",
@@ -3808,18 +3804,6 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ae1eaab1d545a9be7a55b6ef09f365c2017f93a03063547591d12c0c6d27e58"
-dependencies = [
- "anyhow",
- "json_comments",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "near-config-utils"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "270955a98d49ff56e4e1286ab5a2e78aa131585eba92bd3c56a8c39f7f1f58e3"
@@ -3831,30 +3815,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-crypto"
-version = "0.20.1"
+name = "near-config-utils"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2991d2912218a80ec0733ac87f84fa803accea105611eea209d4419271957667"
+checksum = "ae8f85d03abe7dbb0778a56ba0f03a74ce2c8bbd3151e75256c9fba03d6a0f8b"
 dependencies = [
- "blake2 0.9.2",
- "borsh 1.5.1",
- "bs58 0.4.0",
- "c2-chacha",
- "curve25519-dalek",
- "derive_more",
- "ed25519-dalek",
- "hex",
- "near-account-id",
- "near-config-utils 0.20.1",
- "near-stdx 0.20.1",
- "once_cell",
- "primitive-types 0.10.1",
- "rand 0.7.3",
- "secp256k1",
- "serde",
- "serde_json",
- "subtle",
+ "anyhow",
+ "json_comments",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -3863,7 +3832,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "969d525d0e1b255f9cfbff071a66406aba2f3a89f413ac6e78e755e171e27dd1"
 dependencies = [
- "blake2 0.10.6",
+ "blake2",
  "borsh 1.5.1",
  "bs58 0.4.0",
  "curve25519-dalek",
@@ -3883,12 +3852,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-fmt"
-version = "0.20.1"
+name = "near-crypto"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d998dfc1e04001608899b2498ad5a782c7d036b73769d510de21964db99286"
+checksum = "fee0fc88667a502f7a0b58765a14e7f31e99c4b95006e8d7fb1259a0d6cbbd82"
 dependencies = [
- "near-primitives-core 0.20.1",
+ "blake2",
+ "borsh 1.5.1",
+ "bs58 0.4.0",
+ "curve25519-dalek",
+ "derive_more",
+ "ed25519-dalek",
+ "hex",
+ "near-account-id",
+ "near-config-utils 0.25.0",
+ "near-stdx 0.25.0",
+ "once_cell",
+ "primitive-types 0.10.1",
+ "rand",
+ "secp256k1",
+ "serde",
+ "serde_json",
+ "subtle",
+ "thiserror",
 ]
 
 [[package]]
@@ -3898,6 +3884,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "015244b8faaeb1affb40b26018266bb5dd189a27d6c98998466895023fb9af32"
 dependencies = [
  "near-primitives-core 0.24.1",
+]
+
+[[package]]
+name = "near-fmt"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06dca548e1323551b6ff4203725ac0cf1566fa6de8e93b8eba5baceb3fbdc06b"
+dependencies = [
+ "near-primitives-core 0.25.0",
 ]
 
 [[package]]
@@ -3960,34 +3955,6 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d20762631bc8253030013bbae9b5f0542691edc1aa6722f1e8141cc9b928ae5b"
-dependencies = [
- "actix",
- "base64 0.21.7",
- "clap",
- "near-crypto 0.20.1",
- "near-fmt 0.20.1",
- "near-primitives-core 0.20.1",
- "once_cell",
- "opentelemetry 0.17.0",
- "opentelemetry-otlp 0.10.0",
- "opentelemetry-semantic-conventions 0.9.0",
- "prometheus",
- "serde",
- "serde_json",
- "strum 0.24.1",
- "thiserror",
- "tokio",
- "tracing",
- "tracing-appender",
- "tracing-opentelemetry 0.17.4",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "near-o11y"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cb83e6d4cbdef654bc62e1ca27647419deba7787f62f33f34119ab52f347edf"
@@ -3998,9 +3965,9 @@ dependencies = [
  "near-crypto 0.24.1",
  "near-primitives-core 0.24.1",
  "once_cell",
- "opentelemetry 0.22.0",
- "opentelemetry-otlp 0.15.0",
- "opentelemetry-semantic-conventions 0.14.0",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "prometheus",
  "serde",
@@ -4009,27 +3976,35 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-appender",
- "tracing-opentelemetry 0.23.0",
+ "tracing-opentelemetry",
  "tracing-subscriber",
 ]
 
 [[package]]
-name = "near-parameters"
-version = "0.20.1"
+name = "near-o11y"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f16a59b6c3e69b0585be951af6fe42a0ba86c0e207cb8c63badd19efd16680"
+checksum = "4e2b5eb1e1a0eddfc45b1245d7d7c940f858bd3fbac0952ee239f2309cc8b74f"
 dependencies = [
- "assert_matches",
- "borsh 1.5.1",
- "enum-map",
- "near-account-id",
- "near-primitives-core 0.20.1",
- "num-rational 0.3.2",
+ "actix",
+ "base64 0.21.7",
+ "clap",
+ "near-crypto 0.25.0",
+ "near-primitives-core 0.25.0",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "prometheus",
  "serde",
- "serde_repr",
- "serde_yaml",
- "strum 0.24.1",
+ "serde_json",
  "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-appender",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4051,6 +4026,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "near-parameters"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fe415e1632a3fd6fe5d221e8ed16f92d0d1cc9a5716e6f9ff25844b242bad1b"
+dependencies = [
+ "borsh 1.5.1",
+ "enum-map",
+ "near-account-id",
+ "near-primitives-core 0.25.0",
+ "num-rational 0.3.2",
+ "serde",
+ "serde_repr",
+ "serde_yaml",
+ "strum 0.24.1",
+ "thiserror",
+]
+
+[[package]]
 name = "near-performance-metrics"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4063,49 +4056,7 @@ dependencies = [
  "libc",
  "once_cell",
  "tokio",
- "tokio-util 0.7.11",
- "tracing",
-]
-
-[[package]]
-name = "near-primitives"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0462b067732132babcc89d5577db3bfcb0a1bcfbaaed3f2db4c11cd033666314"
-dependencies = [
- "arbitrary",
- "base64 0.21.7",
- "borsh 1.5.1",
- "bytesize",
- "cfg-if 1.0.0",
- "chrono",
- "derive_more",
- "easy-ext 0.2.9",
- "enum-map",
- "hex",
- "near-crypto 0.20.1",
- "near-fmt 0.20.1",
- "near-o11y 0.20.1",
- "near-parameters 0.20.1",
- "near-primitives-core 0.20.1",
- "near-rpc-error-macro 0.20.1",
- "near-stdx 0.20.1",
- "near-vm-runner",
- "num-rational 0.3.2",
- "once_cell",
- "primitive-types 0.10.1",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "reed-solomon-erasure 4.0.2",
- "serde",
- "serde_json",
- "serde_with",
- "serde_yaml",
- "sha3",
- "smart-default 0.6.0",
- "strum 0.24.1",
- "thiserror",
- "time",
+ "tokio-util",
  "tracing",
 ]
 
@@ -4133,14 +4084,14 @@ dependencies = [
  "near-primitives-core 0.24.1",
  "near-rpc-error-macro 0.24.1",
  "near-stdx 0.24.1",
- "near-time",
+ "near-time 0.24.1",
  "num-rational 0.3.2",
  "once_cell",
  "ordered-float",
  "primitive-types 0.10.1",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "reed-solomon-erasure 6.0.0",
+ "rand",
+ "rand_chacha",
+ "reed-solomon-erasure",
  "serde",
  "serde_json",
  "serde_with",
@@ -4153,25 +4104,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-primitives-core"
-version = "0.20.1"
+name = "near-primitives"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8443eb718606f572c438be6321a097a8ebd69f8e48d953885b4f16601af88225"
+checksum = "5e4ec81b11520c89c04ff13b79a73d62bd407a8a6a9002502e557cfbc53c3961"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
  "borsh 1.5.1",
- "bs58 0.4.0",
+ "bytes",
+ "bytesize",
+ "cfg-if 1.0.0",
+ "chrono",
  "derive_more",
+ "easy-ext 0.2.9",
  "enum-map",
- "near-account-id",
+ "hex",
+ "itertools 0.10.5",
+ "near-crypto 0.25.0",
+ "near-fmt 0.25.0",
+ "near-parameters 0.25.0",
+ "near-primitives-core 0.25.0",
+ "near-rpc-error-macro 0.25.0",
+ "near-stdx 0.25.0",
+ "near-structs-checker-lib",
+ "near-time 0.25.0",
  "num-rational 0.3.2",
+ "once_cell",
+ "ordered-float",
+ "primitive-types 0.10.1",
+ "rand",
+ "rand_chacha",
  "serde",
- "serde_repr",
+ "serde_json",
  "serde_with",
- "sha2 0.10.8",
+ "sha3",
+ "smart-default 0.6.0",
  "strum 0.24.1",
  "thiserror",
+ "tracing",
+ "zstd 0.13.2",
 ]
 
 [[package]]
@@ -4195,14 +4167,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-rpc-error-core"
-version = "0.20.1"
+name = "near-primitives-core"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80fca203c51edd9595ec14db1d13359fb9ede32314990bf296b6c5c4502f6ab7"
+checksum = "05f6e4b981eb5f1a08c85ec4d4de4672da584cdb9aadff26609a7eb59db707dc"
 dependencies = [
- "quote",
+ "arbitrary",
+ "base64 0.21.7",
+ "borsh 1.5.1",
+ "bs58 0.4.0",
+ "derive_more",
+ "enum-map",
+ "near-account-id",
+ "near-structs-checker-lib",
+ "num-rational 0.3.2",
  "serde",
- "syn 2.0.77",
+ "serde_repr",
+ "sha2 0.10.8",
+ "thiserror",
 ]
 
 [[package]]
@@ -4217,13 +4199,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-rpc-error-macro"
-version = "0.20.1"
+name = "near-rpc-error-core"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897a445de2102f6732c8a185d922f5e3bf7fd0a41243ce40854df2197237f799"
+checksum = "72469e7c06bf99bb7e9d5a66438c008d3b85c8c5d8f36d8c31b35968f6f599d4"
 dependencies = [
- "fs2",
- "near-rpc-error-core 0.20.1",
+ "quote",
  "serde",
  "syn 2.0.77",
 ]
@@ -4235,6 +4216,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa5a967de9f1480140de15620926b4f5292384e8a3672683e73478594107fa0"
 dependencies = [
  "near-rpc-error-core 0.24.1",
+ "serde",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "near-rpc-error-macro"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0bd52b705619ceb5d5ea9171ecf44f00513101c903928474eca957d07f3fdb"
+dependencies = [
+ "near-rpc-error-core 0.25.0",
  "serde",
  "syn 2.0.77",
 ]
@@ -4308,15 +4300,37 @@ dependencies = [
 
 [[package]]
 name = "near-stdx"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "855fd5540e3b4ff6fedf12aba2db1ee4b371b36f465da1363a6d022b27cb43b8"
-
-[[package]]
-name = "near-stdx"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac1c4937647390c254e530ba8d3e296c192e67ea0364e3d7d4aef64563ffcf6a"
+
+[[package]]
+name = "near-stdx"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "999173ea1e88ca421ff10969273cc1ad42b291af3f5a25827be1ad080e24dd89"
+
+[[package]]
+name = "near-structs-checker-core"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9486fba198ad9369042fceacd05a6590c2e9f4d03101898e8c27738d0a50e3"
+
+[[package]]
+name = "near-structs-checker-lib"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6a89246f95d81d1a80e443b0f367c55e3e8e4177a9ddee5385906d10b57e534"
+dependencies = [
+ "near-structs-checker-core",
+ "near-structs-checker-macro",
+]
+
+[[package]]
+name = "near-structs-checker-macro"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084c673f50291300dc6c2d31b0e075289076fe18c3f0b62dc5202102f2bc463a"
 
 [[package]]
 name = "near-sys"
@@ -4329,6 +4343,18 @@ name = "near-time"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66de5e1e2b748aae827bb5dd80c715037ba7cf074f68ad5241b55bf2aaea793"
+dependencies = [
+ "once_cell",
+ "serde",
+ "time",
+ "tokio",
+]
+
+[[package]]
+name = "near-time"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b49356eacf06348b96063567f218732f56bc51968035ee38b8e656b4492cb4"
 dependencies = [
  "once_cell",
  "serde",
@@ -4358,35 +4384,108 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-vm-runner"
-version = "0.20.1"
+name = "near-vm-compiler"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56c80bdb1954808f59bd36a9112377197b38d424991383bf05f52d0fe2e0da5"
+checksum = "2badccdb3aef60e870157f67fac084c543addaaa45b33f511d3be98e84052a28"
+dependencies = [
+ "enumset",
+ "finite-wasm",
+ "near-vm-types",
+ "near-vm-vm",
+ "rkyv",
+ "target-lexicon",
+ "thiserror",
+ "tracing",
+ "wasmparser 0.99.0",
+]
+
+[[package]]
+name = "near-vm-compiler-singlepass"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065354968de7357fb87bfabb7974f98e8af323e8dec221244b6f326b51395b9a"
+dependencies = [
+ "dynasm 2.0.0",
+ "dynasmrt 2.0.0",
+ "enumset",
+ "finite-wasm",
+ "lazy_static",
+ "memoffset 0.8.0",
+ "more-asserts",
+ "near-vm-compiler",
+ "near-vm-types",
+ "near-vm-vm",
+ "rayon",
+ "smallvec",
+ "strum 0.24.1",
+ "tracing",
+]
+
+[[package]]
+name = "near-vm-engine"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b37884a019ab5304ceb1e15344deee19e8a1f9cfb3f0468ceb47fa9353159b"
+dependencies = [
+ "backtrace",
+ "cfg-if 1.0.0",
+ "enumset",
+ "finite-wasm",
+ "lazy_static",
+ "more-asserts",
+ "near-vm-compiler",
+ "near-vm-types",
+ "near-vm-vm",
+ "region",
+ "rkyv",
+ "rustc-demangle",
+ "rustix",
+ "target-lexicon",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "near-vm-runner"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4d2501d0bc7385de3f6407d8a8159346f443f8cef7af24d028df7abb830738b"
 dependencies = [
  "anyhow",
- "base64 0.21.7",
+ "blst",
  "borsh 1.5.1",
+ "bytesize",
  "ed25519-dalek",
  "enum-map",
  "finite-wasm",
+ "lru 0.12.4",
  "memoffset 0.8.0",
- "near-crypto 0.20.1",
- "near-parameters 0.20.1",
- "near-primitives-core 0.20.1",
- "near-stdx 0.20.1",
+ "near-crypto 0.25.0",
+ "near-o11y 0.25.0",
+ "near-parameters 0.25.0",
+ "near-primitives-core 0.25.0",
+ "near-stdx 0.25.0",
+ "near-vm-compiler",
+ "near-vm-compiler-singlepass",
+ "near-vm-engine",
+ "near-vm-types",
+ "near-vm-vm",
  "num-rational 0.3.2",
  "once_cell",
  "parity-wasm 0.41.0",
  "parity-wasm 0.42.2",
  "prefix-sum-vec",
+ "prometheus",
  "pwasm-utils",
  "ripemd",
+ "rustix",
  "serde",
  "serde_repr",
- "serde_with",
  "sha2 0.10.8",
  "sha3",
  "strum 0.24.1",
+ "tempfile",
  "thiserror",
  "tracing",
  "wasm-encoder 0.27.0",
@@ -4399,6 +4498,40 @@ dependencies = [
  "wasmparser 0.78.2",
  "wasmtime",
  "zeropool-bn",
+]
+
+[[package]]
+name = "near-vm-types"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed8bd23665d611601bed7cacc6c01c331426be65e790744bbfb3b2ab3e27c78"
+dependencies = [
+ "indexmap 1.9.3",
+ "num-traits",
+ "rkyv",
+ "thiserror",
+]
+
+[[package]]
+name = "near-vm-vm"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1af3e975a941a77b1d4e136d0fb687116cd7b33bb8cdc4746fe12e829caabf49"
+dependencies = [
+ "backtrace",
+ "cc",
+ "cfg-if 1.0.0",
+ "finite-wasm",
+ "indexmap 1.9.3",
+ "libc",
+ "memoffset 0.8.0",
+ "more-asserts",
+ "near-vm-types",
+ "region",
+ "rkyv",
+ "thiserror",
+ "tracing",
+ "winapi",
 ]
 
 [[package]]
@@ -4424,7 +4557,7 @@ dependencies = [
  "near-primitives 0.24.1",
  "near-sandbox-utils",
  "near-token 0.3.0",
- "rand 0.8.5",
+ "rand",
  "reqwest",
  "serde",
  "serde_json",
@@ -4628,6 +4761,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
+]
+
+[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4708,9 +4851,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.3.1+3.3.1"
+version = "300.3.2+3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7259953d42a81bf137fbbd73bd30a8e1914d6dce43c2b90ed575783a22608b91"
+checksum = "a211a18d945ef7e648cc6e0058f4c548ee46aab922ea203e0d30e966ea23647b"
 dependencies = [
  "cc",
 ]
@@ -4730,27 +4873,6 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6105e89802af13fdf48c49d7646d3b533a70e536d818aae7e78ba0433d01acb8"
-dependencies = [
- "async-trait",
- "crossbeam-channel",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "js-sys",
- "lazy_static",
- "percent-encoding",
- "pin-project",
- "rand 0.8.5",
- "thiserror",
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900d57987be3f2aeb70d385fff9b27fb74c5723cc9a52d904d4f9c807a0667bf"
@@ -4766,24 +4888,6 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1a6ca9de4c8b00aa7f1a153bd76cb263287155cec642680d79d98706f3d28a"
-dependencies = [
- "async-trait",
- "futures",
- "futures-util",
- "http 0.2.12",
- "opentelemetry 0.17.0",
- "prost 0.9.0",
- "thiserror",
- "tokio",
- "tonic 0.6.2",
- "tonic-build",
-]
-
-[[package]]
-name = "opentelemetry-otlp"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a016b8d9495c639af2145ac22387dcb88e44118e45320d9238fbf4e7889abcb"
@@ -4791,14 +4895,14 @@ dependencies = [
  "async-trait",
  "futures-core",
  "http 0.2.12",
- "opentelemetry 0.22.0",
+ "opentelemetry",
  "opentelemetry-proto",
- "opentelemetry-semantic-conventions 0.14.0",
+ "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
- "prost 0.12.6",
+ "prost",
  "thiserror",
  "tokio",
- "tonic 0.11.0",
+ "tonic",
 ]
 
 [[package]]
@@ -4807,19 +4911,10 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8fddc9b68f5b80dae9d6f510b88e02396f006ad48cac349411fbecc80caae4"
 dependencies = [
- "opentelemetry 0.22.0",
+ "opentelemetry",
  "opentelemetry_sdk",
- "prost 0.12.6",
- "tonic 0.11.0",
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "985cc35d832d412224b2cffe2f9194b1b89b6aa5d0bef76d080dce09d90e62bd"
-dependencies = [
- "opentelemetry 0.17.0",
+ "prost",
+ "tonic",
 ]
 
 [[package]]
@@ -4841,10 +4936,10 @@ dependencies = [
  "futures-util",
  "glob",
  "once_cell",
- "opentelemetry 0.22.0",
+ "opentelemetry",
  "ordered-float",
  "percent-encoding",
- "rand 0.8.5",
+ "rand",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -4864,7 +4959,7 @@ checksum = "4a91171844676f8c7990ce64959210cd2eaef32c2612c50f9fae9f8aaa6065a6"
 dependencies = [
  "borsh 1.5.1",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "serde",
 ]
 
@@ -4973,7 +5068,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
 dependencies = [
  "base64ct",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -5026,16 +5121,6 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
-
-[[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset",
- "indexmap 2.5.0",
-]
 
 [[package]]
 name = "phf"
@@ -5169,7 +5254,7 @@ dependencies = [
  "hmac 0.12.1",
  "md-5",
  "memchr",
- "rand 0.8.5",
+ "rand",
  "sha2 0.10.8",
  "stringprep",
 ]
@@ -5338,55 +5423,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
-dependencies = [
- "bytes",
- "prost-derive 0.9.0",
-]
-
-[[package]]
-name = "prost"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
- "prost-derive 0.12.6",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
-dependencies = [
- "bytes",
- "heck 0.3.3",
- "itertools 0.10.5",
- "lazy_static",
- "log",
- "multimap",
- "petgraph",
- "prost 0.9.0",
- "prost-types",
- "regex",
- "tempfile",
- "which",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
-dependencies = [
- "anyhow",
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "prost-derive",
 ]
 
 [[package]]
@@ -5400,16 +5442,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.77",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
-dependencies = [
- "bytes",
- "prost 0.9.0",
 ]
 
 [[package]]
@@ -5475,37 +5507,14 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
+ "rand_chacha",
+ "rand_core",
  "serde",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -5515,16 +5524,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -5533,17 +5533,8 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "serde",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -5590,18 +5581,9 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "libredox",
  "thiserror",
-]
-
-[[package]]
-name = "reed-solomon-erasure"
-version = "4.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a415a013dd7c5d4221382329a5a3482566da675737494935cbbbcdec04662f9d"
-dependencies = [
- "smallvec",
 ]
 
 [[package]]
@@ -5611,7 +5593,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7263373d500d4d4f505d43a2a662d475a894aa94503a1ee28e9188b5f3960d4f"
 dependencies = [
  "libm",
- "lru",
+ "lru 0.7.8",
  "parking_lot 0.11.2",
  "smallvec",
  "spin",
@@ -5747,7 +5729,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if 1.0.0",
- "getrandom 0.2.15",
+ "getrandom",
  "libc",
  "spin",
  "untrusted",
@@ -5834,7 +5816,7 @@ dependencies = [
  "borsh 1.5.1",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "rkyv",
  "serde",
  "serde_json",
@@ -6045,7 +6027,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
- "rand 0.8.5",
+ "rand",
  "secp256k1-sys",
 ]
 
@@ -6746,6 +6728,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
 name = "time"
 version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6816,7 +6807,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a56eb9e5a28c3c4f0a6aa8ea70a8ad2d6c53e4bf364571ce78f57945b6766843"
 dependencies = [
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -6887,10 +6878,10 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand 0.8.5",
+ "rand",
  "socket2",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util",
  "whoami",
 ]
 
@@ -6901,7 +6892,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
 dependencies = [
  "pin-project",
- "rand 0.8.5",
+ "rand",
  "tokio",
 ]
 
@@ -6923,20 +6914,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
 dependencies = [
  "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "log",
  "pin-project-lite",
  "tokio",
 ]
@@ -6999,37 +6976,6 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
-dependencies = [
- "async-stream",
- "async-trait",
- "base64 0.13.1",
- "bytes",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.30",
- "hyper-timeout",
- "percent-encoding",
- "pin-project",
- "prost 0.9.0",
- "prost-derive 0.9.0",
- "tokio",
- "tokio-stream",
- "tokio-util 0.6.10",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "tonic"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
@@ -7046,25 +6992,13 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.12.6",
+ "prost",
  "tokio",
  "tokio-stream",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tonic-build"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
-dependencies = [
- "proc-macro2",
- "prost-build",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -7078,10 +7012,10 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "slab",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -7105,7 +7039,6 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -7155,16 +7088,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
-]
-
-[[package]]
 name = "tracing-indicatif"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7174,17 +7097,6 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
 ]
 
 [[package]]
@@ -7200,32 +7112,18 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.17.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbbe89715c1dbbb790059e2565353978564924ee85017b5fff365c872ff6721f"
-dependencies = [
- "once_cell",
- "opentelemetry 0.17.0",
- "tracing",
- "tracing-core",
- "tracing-log 0.1.4",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "tracing-opentelemetry"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9be14ba1bbe4ab79e9229f7f89fab8d120b865859f10527f31c033e599d2284"
 dependencies = [
  "js-sys",
  "once_cell",
- "opentelemetry 0.22.0",
+ "opentelemetry",
  "opentelemetry_sdk",
  "smallvec",
  "tracing",
  "tracing-core",
- "tracing-log 0.2.0",
+ "tracing-log",
  "tracing-subscriber",
  "web-time",
 ]
@@ -7245,7 +7143,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log 0.2.0",
+ "tracing-log",
 ]
 
 [[package]]
@@ -7515,12 +7413,6 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -7648,8 +7540,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac4af0e438015585eb27b2c6f6869c58c540bfe27408b686b1778470bf301050"
 dependencies = [
  "byteorder",
- "dynasm",
- "dynasmrt",
+ "dynasm 1.2.3",
+ "dynasmrt 1.2.3",
  "lazy_static",
  "memoffset 0.6.5",
  "more-asserts",
@@ -7740,6 +7632,16 @@ name = "wasmparser"
 version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
+
+[[package]]
+name = "wasmparser"
+version = "0.99.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef3b717afc67f848f412d4f02c127dd3e35a0eecd58c684580414df4fde01d3"
+dependencies = [
+ "indexmap 1.9.3",
+ "url",
+]
 
 [[package]]
 name = "wasmparser"
@@ -7962,7 +7864,7 @@ dependencies = [
  "memfd",
  "memoffset 0.9.1",
  "paste",
- "rand 0.8.5",
+ "rand",
  "rustix",
  "sptr",
  "wasm-encoder 0.35.0",
@@ -8043,18 +7945,6 @@ dependencies = [
  "libc",
  "memory_units",
  "winapi",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
 ]
 
 [[package]]
@@ -8347,6 +8237,20 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
 
 [[package]]
 name = "zeropool-bn"
@@ -8358,7 +8262,7 @@ dependencies = [
  "byteorder",
  "crunchy",
  "lazy_static",
- "rand 0.8.5",
+ "rand",
  "rustc-hex",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,13 +43,13 @@ ibig = { version = "0.3", default-features = false, features = ["num-traits"] }
 impl-serde = { version = "0.4", default-features = false }
 lazy_static = "1"
 libsecp256k1 = { version = "0.7", default-features = false }
-near-crypto = "0.20"
+near-crypto = "0.25"
 near-gas = "0.3"
-near-parameters = "0.20"
-near-primitives = "0.20"
-near-primitives-core = "0.20"
+near-parameters = "0.25"
+near-primitives = "0.25"
+near-primitives-core = "0.25"
 near-sdk = "5"
-near-vm-runner = { version = "0.20", features = ["wasmtime_vm", "wasmer2_vm"] }
+near-vm-runner = { version = "0.25", features = ["wasmtime_vm", "wasmer2_vm", "near_vm"] }
 near-workspaces = "0.12"
 num = { version = "0.4", default-features = false, features = ["alloc"] }
 postgres = "0.19"

--- a/engine-tests/src/benches/nft_pagination.rs
+++ b/engine-tests/src/benches/nft_pagination.rs
@@ -167,8 +167,7 @@ fn initialize_evm() -> (utils::AuroraRunner, utils::Signer, Address) {
     let dest_address = utils::address_from_secret_key(&SecretKey::random(&mut rng));
     let mut signer = utils::Signer::new(source_account);
     signer.nonce = INITIAL_NONCE;
-
-    runner.wasm_config.limit_config.max_gas_burnt = u64::MAX;
+    runner.max_gas_burnt(u64::MAX);
 
     (runner, signer, dest_address)
 }

--- a/engine-tests/src/tests/erc20.rs
+++ b/engine-tests/src/tests/erc20.rs
@@ -114,13 +114,13 @@ fn profile_erc20_get_balance() {
         .unwrap();
     assert!(status.is_ok());
 
-    // call costs less than 2 Tgas
-    utils::assert_gas_bound(profile.all_gas(), 2);
-    // at least 70% of the cost is spent on wasm computation (as opposed to host functions)
+    // call costs less than 3 Tgas
+    utils::assert_gas_bound(profile.all_gas(), 3);
+    // at least 80% of the cost is spent on wasm computation (as opposed to host functions)
     let wasm_fraction = (100 * profile.wasm_gas()) / profile.all_gas();
     assert!(
-        (20..=30).contains(&wasm_fraction),
-        "{wasm_fraction}% is not between 20% and 30%",
+        (10..=20).contains(&wasm_fraction),
+        "{wasm_fraction}% is not between 10% and 20%",
     );
 }
 

--- a/engine-tests/src/tests/modexp.rs
+++ b/engine-tests/src/tests/modexp.rs
@@ -321,8 +321,8 @@ impl Default for ModExpBenchContext {
 
         // Standalone not relevant here because this is not an Aurora Engine instance
         inner.standalone_runner = None;
-        inner.wasm_config.limit_config.max_gas_burnt = u64::MAX;
-        inner.code = ContractCode::new(bench_contract_bytes, None);
+        inner.max_gas_burnt(u64::MAX);
+        inner.set_code(ContractCode::new(bench_contract_bytes, None));
 
         Self { inner }
     }

--- a/engine-tests/src/tests/multisender.rs
+++ b/engine-tests/src/tests/multisender.rs
@@ -122,7 +122,7 @@ fn send_eth_data(amounts: &[(Address, U256)]) -> Vec<u8> {
 
 fn initialize() -> (utils::AuroraRunner, utils::Signer, Address) {
     let mut runner = utils::deploy_runner();
-    runner.wasm_config.limit_config.max_gas_burnt = u64::MAX;
+    runner.max_gas_burnt(u64::MAX);
 
     let mut rng = rand::thread_rng();
     let source_account = SecretKey::random(&mut rng);

--- a/engine-tests/src/tests/one_inch.rs
+++ b/engine-tests/src/tests/one_inch.rs
@@ -26,7 +26,7 @@ fn test_1inch_liquidity_protocol() {
 
     let (result, profile, pool_factory) = helper.create_pool_factory(&deployer_address);
     assert!(result.gas_used >= 2_800_000); // more than 2.8M EVM gas used
-    assert_gas_bound(profile.all_gas(), 10); // less than 9 NEAR Tgas used
+    assert_gas_bound(profile.all_gas(), 11); // less than 11 NEAR Tgas used
 
     // create some ERC-20 tokens to have a liquidity pool for
     let signer_address = utils::address_from_secret_key(&helper.signer.secret_key);
@@ -38,7 +38,7 @@ fn test_1inch_liquidity_protocol() {
     let (result, profile, pool) =
         helper.create_pool(&pool_factory, token_a.0.address, token_b.0.address);
     assert!(result.gas_used >= 4_500_000); // more than 4.5M EVM gas used
-    assert_gas_bound(profile.all_gas(), 20);
+    assert_gas_bound(profile.all_gas(), 21);
 
     // Approve giving ERC-20 tokens to the pool
     helper.approve_erc20_tokens(&token_a, pool.address());
@@ -72,7 +72,7 @@ fn test_1inch_liquidity_protocol() {
         },
     );
     assert!(result.gas_used >= 210_000); // more than 210k EVM gas used
-    assert_gas_bound(profile.all_gas(), 24);
+    assert_gas_bound(profile.all_gas(), 25);
 
     let (result, profile) = helper.pool_withdraw(
         &pool,
@@ -83,7 +83,7 @@ fn test_1inch_liquidity_protocol() {
         },
     );
     assert!(result.gas_used >= 150_000); // more than 150k EVM gas used
-    assert_gas_bound(profile.all_gas(), 20);
+    assert_gas_bound(profile.all_gas(), 21);
 }
 
 #[test]
@@ -104,7 +104,7 @@ fn test_1_inch_limit_order_deploy() {
     // at least 45% of which is from wasm execution
     let wasm_fraction = 100 * profile.wasm_gas() / profile.all_gas();
     assert!(
-        (45..=55).contains(&wasm_fraction),
+        (40..=50).contains(&wasm_fraction),
         "{wasm_fraction}% is not between 45% and 55%",
     );
 }

--- a/engine-tests/src/tests/promise_results_precompile.rs
+++ b/engine-tests/src/tests/promise_results_precompile.rs
@@ -121,13 +121,13 @@ fn test_promise_result_gas_cost() {
     let total_gas2 = y2 + baseline.all_gas();
 
     assert!(
-        utils::within_x_percent(21, evm1, total_gas1 / NEAR_GAS_PER_EVM),
+        utils::within_x_percent(36, evm1, total_gas1 / NEAR_GAS_PER_EVM),
         "Incorrect EVM gas used. Expected: {} Actual: {}",
         evm1,
         total_gas1 / NEAR_GAS_PER_EVM
     );
     assert!(
-        utils::within_x_percent(21, evm2, total_gas2 / NEAR_GAS_PER_EVM),
+        utils::within_x_percent(36, evm2, total_gas2 / NEAR_GAS_PER_EVM),
         "Incorrect EVM gas used. Expected: {} Actual: {}",
         evm2,
         total_gas2 / NEAR_GAS_PER_EVM

--- a/engine-tests/src/tests/repro.rs
+++ b/engine-tests/src/tests/repro.rs
@@ -26,7 +26,7 @@ fn repro_GdASJ3KESs() {
         block_timestamp: 1_645_717_564_644_206_730,
         input_path: "src/tests/res/input_GdASJ3KESs.hex",
         evm_gas_used: 706_713,
-        near_gas_used: 114,
+        near_gas_used: 115,
     });
 }
 
@@ -51,7 +51,7 @@ fn repro_8ru7VEA() {
         block_timestamp: 1_648_829_935_343_349_589,
         input_path: "src/tests/res/input_8ru7VEA.hex",
         evm_gas_used: 1_732_181,
-        near_gas_used: 205,
+        near_gas_used: 206,
     });
 }
 
@@ -71,7 +71,7 @@ fn repro_FRcorNv() {
         block_timestamp: 1_650_960_438_774_745_116,
         input_path: "src/tests/res/input_FRcorNv.hex",
         evm_gas_used: 1_239_721,
-        near_gas_used: 167,
+        near_gas_used: 168,
     });
 }
 
@@ -88,7 +88,7 @@ fn repro_5bEgfRQ() {
         block_timestamp: 1_651_073_772_931_594_646,
         input_path: "src/tests/res/input_5bEgfRQ.hex",
         evm_gas_used: 6_414_105,
-        near_gas_used: 649,
+        near_gas_used: 650,
     });
 }
 
@@ -106,7 +106,7 @@ fn repro_D98vwmi() {
         block_timestamp: 1_651_753_443_421_003_245,
         input_path: "src/tests/res/input_D98vwmi.hex",
         evm_gas_used: 1_035_348,
-        near_gas_used: 168,
+        near_gas_used: 169,
     });
 }
 
@@ -125,7 +125,7 @@ fn repro_Emufid2() {
         block_timestamp: 1_662_118_048_636_713_538,
         input_path: "src/tests/res/input_Emufid2.hex",
         evm_gas_used: 1_156_364,
-        near_gas_used: 293,
+        near_gas_used: 294,
     });
 }
 
@@ -145,7 +145,7 @@ fn repro_common(context: &ReproContext) {
         standalone_runner: None, // Turn off standalone here, validated separately below
         ..Default::default()
     };
-    runner.wasm_config.limit_config.max_gas_burnt = 3_000_000_000_000_000;
+    runner.max_gas_burnt(3_000_000_000_000_000);
     runner.context.storage_usage = 1_000_000_000;
     runner.consume_json_snapshot(snapshot.clone());
     runner.context.block_height = *block_height;

--- a/engine-tests/src/tests/standard_precompiles.rs
+++ b/engine-tests/src/tests/standard_precompiles.rs
@@ -31,55 +31,55 @@ fn test_standard_precompiles() {
 #[test]
 fn profile_ecrecover() {
     let profile = precompile_execution_profile("test_ecrecover");
-    utils::assert_gas_bound(profile.all_gas(), 5);
+    utils::assert_gas_bound(profile.all_gas(), 7);
 }
 
 #[test]
 fn profile_sha256() {
     let profile = precompile_execution_profile("test_sha256");
-    utils::assert_gas_bound(profile.all_gas(), 5);
+    utils::assert_gas_bound(profile.all_gas(), 6);
 }
 
 #[test]
 fn profile_ripemd160() {
     let profile = precompile_execution_profile("test_ripemd160");
-    utils::assert_gas_bound(profile.all_gas(), 5);
+    utils::assert_gas_bound(profile.all_gas(), 6);
 }
 
 #[test]
 fn profile_identity() {
     let profile = precompile_execution_profile("test_identity");
-    utils::assert_gas_bound(profile.all_gas(), 5);
+    utils::assert_gas_bound(profile.all_gas(), 6);
 }
 
 #[test]
 fn profile_modexp() {
     let profile = precompile_execution_profile("test_modexp");
-    utils::assert_gas_bound(profile.all_gas(), 7);
+    utils::assert_gas_bound(profile.all_gas(), 8);
 }
 
 #[test]
 fn profile_ecadd() {
     let profile = precompile_execution_profile("test_ecadd");
-    utils::assert_gas_bound(profile.all_gas(), 5);
+    utils::assert_gas_bound(profile.all_gas(), 6);
 }
 
 #[test]
 fn profile_ecmul() {
     let profile = precompile_execution_profile("test_ecmul");
-    utils::assert_gas_bound(profile.all_gas(), 6);
+    utils::assert_gas_bound(profile.all_gas(), 7);
 }
 
 #[test]
 fn profile_ecpair() {
     let profile = precompile_execution_profile("test_ecpair");
-    utils::assert_gas_bound(profile.all_gas(), 115);
+    utils::assert_gas_bound(profile.all_gas(), 116);
 }
 
 #[test]
 fn profile_blake2f() {
     let profile = precompile_execution_profile("test_blake2f");
-    utils::assert_gas_bound(profile.all_gas(), 5);
+    utils::assert_gas_bound(profile.all_gas(), 6);
 }
 
 fn initialize() -> (AuroraRunner, Signer, PrecompilesContract) {

--- a/engine-tests/src/tests/uniswap.rs
+++ b/engine-tests/src/tests/uniswap.rs
@@ -12,6 +12,7 @@ use aurora_engine_types::types::Wei;
 use aurora_engine_types::H160;
 use libsecp256k1::SecretKey;
 use rand::SeedableRng;
+use std::sync::Arc;
 
 const INITIAL_BALANCE: u64 = 1000;
 const INITIAL_NONCE: u64 = 0;
@@ -38,7 +39,7 @@ fn test_uniswap_input_multihop() {
 
     let (_amount_out, _evm_gas, profile) = context.exact_input(&tokens, INPUT_AMOUNT.into());
 
-    assert_eq!(107, profile.all_gas() / 1_000_000_000_000);
+    assert_eq!(108, profile.all_gas() / 1_000_000_000_000);
 }
 
 #[test]
@@ -49,7 +50,7 @@ fn test_uniswap_exact_output() {
 
     let (_result, profile) =
         context.add_equal_liquidity(LIQUIDITY_AMOUNT.into(), &token_a, &token_b);
-    utils::assert_gas_bound(profile.all_gas(), 31);
+    utils::assert_gas_bound(profile.all_gas(), 32);
     let wasm_fraction = 100 * profile.wasm_gas() / profile.all_gas();
     assert!(
         (40..=50).contains(&wasm_fraction),
@@ -148,7 +149,9 @@ impl UniswapTestContext {
     }
 
     pub fn no_gas(&mut self) {
-        self.runner.wasm_config.regular_op_cost = 0;
+        Arc::get_mut(&mut self.runner.wasm_config)
+            .unwrap()
+            .regular_op_cost = 0;
     }
 
     pub fn create_tokens(&mut self, n: usize, mint_amount: U256) -> Vec<ERC20> {

--- a/engine-tests/src/tests/xcc.rs
+++ b/engine-tests/src/tests/xcc.rs
@@ -284,10 +284,8 @@ fn test_xcc_exec_gas() {
 }
 
 fn deploy_router() -> AuroraRunner {
-    let mut router = AuroraRunner {
-        code: ContractCode::new(contract_bytes(), None),
-        ..Default::default()
-    };
+    let mut router = AuroraRunner::default();
+    router.set_code(ContractCode::new(contract_bytes(), None));
 
     // Standalone not relevant here because this is not an Aurora Engine instance
     router.standalone_runner = None;

--- a/engine-tests/src/utils/mocked_external.rs
+++ b/engine-tests/src/utils/mocked_external.rs
@@ -93,6 +93,10 @@ impl near_vm_runner::logic::External for MockedExternalWithTrie {
         }
     }
 
+    fn get_recorded_storage_size(&self) -> usize {
+        self.underlying.get_recorded_storage_size()
+    }
+
     fn validator_stake(&self, account_id: &AccountId) -> Result<Option<Balance>, VMLogicError> {
         self.underlying.validator_stake(account_id)
     }
@@ -101,12 +105,28 @@ impl near_vm_runner::logic::External for MockedExternalWithTrie {
         self.underlying.validator_total_stake()
     }
 
-    fn create_receipt(
+    fn create_action_receipt(
         &mut self,
         receipt_indices: Vec<ReceiptIndex>,
         receiver_id: AccountId,
     ) -> Result<ReceiptIndex, VMLogicError> {
-        self.underlying.create_receipt(receipt_indices, receiver_id)
+        self.underlying
+            .create_action_receipt(receipt_indices, receiver_id)
+    }
+
+    fn create_promise_yield_receipt(
+        &mut self,
+        receiver_id: AccountId,
+    ) -> Result<(ReceiptIndex, CryptoHash), VMLogicError> {
+        self.underlying.create_promise_yield_receipt(receiver_id)
+    }
+
+    fn submit_promise_resume_data(
+        &mut self,
+        data_id: CryptoHash,
+        data: Vec<u8>,
+    ) -> Result<bool, VMLogicError> {
+        self.underlying.submit_promise_resume_data(data_id, data)
     }
 
     fn append_action_create_account(

--- a/engine-tests/src/utils/mod.rs
+++ b/engine-tests/src/utils/mod.rs
@@ -13,7 +13,6 @@ use aurora_engine_types::parameters::silo::FixedGasArgs;
 use aurora_engine_types::types::{EthGas, PromiseResult};
 use evm::ExitFatal;
 use libsecp256k1::{self, Message, PublicKey, SecretKey};
-use near_parameters::vm::VMKind;
 use near_parameters::{RuntimeConfigStore, RuntimeFeesConfig};
 use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives_core::config::ViewConfig;
@@ -21,9 +20,10 @@ use near_vm_runner::logic::errors::FunctionCallError;
 use near_vm_runner::logic::mocks::mock_external::MockedExternal;
 use near_vm_runner::logic::types::ReturnData;
 use near_vm_runner::logic::{Config, HostError, VMContext, VMOutcome};
-use near_vm_runner::{ContractCode, MockCompiledContractCache, ProfileDataV3};
+use near_vm_runner::{ContractCode, MockContractRuntimeCache, ProfileDataV3};
 use rlp::RlpStream;
 use std::borrow::Cow;
+use std::sync::Arc;
 
 #[cfg(not(feature = "ext-connector"))]
 use crate::prelude::parameters::InitCallArgs;
@@ -82,12 +82,11 @@ impl Signer {
 pub struct AuroraRunner {
     pub aurora_account_id: String,
     pub chain_id: u64,
-    pub code: ContractCode,
-    pub cache: MockCompiledContractCache,
+    pub cache: MockContractRuntimeCache,
     pub ext: mocked_external::MockedExternalWithTrie,
     pub context: VMContext,
-    pub wasm_config: Config,
-    pub fees_config: RuntimeFeesConfig,
+    pub wasm_config: Arc<Config>,
+    pub fees_config: Arc<RuntimeFeesConfig>,
     pub previous_logs: Vec<String>,
     // Use the standalone in parallel if set. This allows checking both
     // implementations give the same results.
@@ -139,15 +138,19 @@ impl<'a> OneShotAuroraRunner<'a> {
             input,
         );
 
-        let outcome = near_vm_runner::run(
-            &self.base.code,
-            method_name,
-            &mut self.ext,
-            self.context.clone(),
-            &self.base.wasm_config,
-            &self.base.fees_config,
-            &[],
+        let contract = near_vm_runner::prepare(
+            &self.ext.underlying,
+            self.base.wasm_config.clone(),
             Some(&self.base.cache),
+            self.context.make_gas_counter(&self.base.wasm_config),
+            method_name,
+        );
+
+        let outcome = near_vm_runner::run(
+            contract,
+            &mut self.ext,
+            &self.context,
+            self.base.fees_config.clone(),
         )
         .unwrap();
 
@@ -215,15 +218,22 @@ impl AuroraRunner {
                 }
             })
             .collect();
-        let outcome = near_vm_runner::run(
-            &self.code,
-            method_name,
-            &mut self.ext,
-            self.context.clone(),
-            &self.wasm_config,
-            &self.fees_config,
-            &vm_promise_results,
+
+        self.context.promise_results = vm_promise_results.into();
+
+        let contract = near_vm_runner::prepare(
+            &self.ext.underlying,
+            self.wasm_config.clone(),
             Some(&self.cache),
+            self.context.make_gas_counter(&self.wasm_config),
+            method_name,
+        );
+
+        let outcome = near_vm_runner::run(
+            contract,
+            &mut self.ext,
+            &self.context,
+            self.fees_config.clone(),
         )
         .unwrap();
 
@@ -620,6 +630,17 @@ impl AuroraRunner {
     pub const fn get_default_chain_id() -> u64 {
         DEFAULT_CHAIN_ID
     }
+
+    pub fn max_gas_burnt(&mut self, max_gas_burnt: u64) {
+        Arc::get_mut(&mut self.wasm_config)
+            .unwrap()
+            .limit_config
+            .max_gas_burnt = max_gas_burnt;
+    }
+
+    pub fn set_code(&mut self, code: ContractCode) {
+        self.ext.underlying.code = Some(Arc::new(code));
+    }
 }
 
 impl Default for AuroraRunner {
@@ -628,29 +649,25 @@ impl Default for AuroraRunner {
         // Fetch config (mainly costs) for the latest protocol version.
         let runtime_config_store = RuntimeConfigStore::test();
         let runtime_config = runtime_config_store.get_config(PROTOCOL_VERSION);
-        let mut wasm_config = runtime_config.wasm_config.clone();
-
-        if cfg!(not(target_arch = "x86_64")) {
-            wasm_config.vm_kind = VMKind::Wasmtime;
-        } else {
-            wasm_config.vm_kind = VMKind::Wasmer2;
-        }
-
+        let wasm_config = runtime_config.wasm_config.clone();
         let origin_account_id: near_primitives::types::AccountId =
             DEFAULT_AURORA_ACCOUNT_ID.parse().unwrap();
+        let mut mocked_external = MockedExternal::default();
+
+        mocked_external.code = Some(Arc::new(ContractCode::new(evm_wasm_bytes, None)));
 
         Self {
             aurora_account_id: DEFAULT_AURORA_ACCOUNT_ID.to_string(),
             chain_id: DEFAULT_CHAIN_ID,
-            code: ContractCode::new(evm_wasm_bytes, None),
-            cache: MockCompiledContractCache::default(),
-            ext: mocked_external::MockedExternalWithTrie::new(MockedExternal::default()),
+            cache: MockContractRuntimeCache::default(),
+            ext: mocked_external::MockedExternalWithTrie::new(mocked_external),
             context: VMContext {
                 current_account_id: origin_account_id.clone(),
                 signer_account_id: origin_account_id.clone(),
                 signer_account_pk: vec![],
                 predecessor_account_id: origin_account_id,
                 input: vec![],
+                promise_results: Arc::new([]),
                 block_height: 0,
                 block_timestamp: 0,
                 epoch_height: 0,
@@ -664,7 +681,7 @@ impl Default for AuroraRunner {
                 view_config: None,
             },
             wasm_config,
-            fees_config: RuntimeFeesConfig::test(),
+            fees_config: Arc::new(RuntimeFeesConfig::test()),
             previous_logs: Vec::new(),
             standalone_runner: Some(standalone::StandaloneRunner::default()),
             promise_results: Vec::new(),


### PR DESCRIPTION
## Description

After switching to the new version of the `near-vm-runner` we can see increased consumption of the NEAR gas almost in every test. The reason is expected since the amount of gas per byte of loaded contract was [increased](https://github.com/near/nearcore/blob/master/core/parameters/res/runtime_configs/66.yaml#L15) from `216750` to `1089295`. In our case it's `1220709 * 1089295` instead of `1220709 * 216750` where the difference is `1065123534405 Gas` or `1,07 TGas`. 

## Performance / NEAR gas cost considerations

NEAR gas consumption was increased for obvious reasons.