### PR TITLE
chore: add some optimisations to the AccountId creation methods

### DIFF
--- a/engine-standalone-storage/src/sync/types.rs
+++ b/engine-standalone-storage/src/sync/types.rs
@@ -381,7 +381,7 @@ impl TransactionKind {
                 )
             }
             Self::WithdrawWnearToRouter(args) => {
-                let recipient = AccountId::new(&format!(
+                let recipient = AccountId::try_from(format!(
                     "{}.{}",
                     args.target.encode(),
                     engine_account.as_ref()

--- a/engine/src/contract_methods/xcc.rs
+++ b/engine/src/contract_methods/xcc.rs
@@ -34,7 +34,7 @@ pub fn withdraw_wnear_to_router<I: IO + Copy, E: Env, H: PromiseHandler>(
         }
         let args: WithdrawWnearToRouterArgs = io.read_input_borsh()?;
         let current_account_id = env.current_account_id();
-        let recipient = AccountId::new(&format!(
+        let recipient = AccountId::try_from(format!(
             "{}.{}",
             args.target.encode(),
             current_account_id.as_ref()

--- a/engine/src/xcc.rs
+++ b/engine/src/xcc.rs
@@ -77,7 +77,7 @@ where
     E: Env,
 {
     let current_account_id = env.current_account_id();
-    let target_account_id = AccountId::new(&format!(
+    let target_account_id = AccountId::try_from(format!(
         "{}.{}",
         args.target.encode(),
         current_account_id.as_ref()
@@ -95,7 +95,7 @@ where
     if let AddressVersionStatus::DeployNeeded { create_needed } = deploy_needed {
         let code = get_router_code(io).0.into_owned();
         // wnear_account is needed for initialization so we must assume it is set
-        // in the Engine or we need to accept it as input.
+        // in the Engine, or we need to accept it as input.
         let wnear_account = if let Some(wnear_account) = args.wnear_account_id {
             wnear_account
         } else {


### PR DESCRIPTION
## Description

The PR introduces some optimisations to the creation methods of the `AccounId` struct. Namely, it gets rid of redundant heap allocations.

## Performance / NEAR gas cost considerations

There is no changes in the performance.

## Testing

The existing tests cover the changes.
