### PR TITLE
feat: adapt the exitToNear precompile to be compatible with OMNI bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
  "actix-macros",
  "actix-rt",
  "actix_derive",
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "bytes",
  "crossbeam-channel",
  "futures-core",
@@ -44,7 +44,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -65,7 +65,7 @@ checksum = "b6ac1e58cded18cb28ddc17143c4dea5345b3ad575e14f32f66e4054a56eb271"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -109,7 +109,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
 ]
@@ -123,7 +123,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -203,11 +203,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
+ "once_cell",
  "windows-sys 0.59.0",
 ]
 
@@ -257,18 +258,18 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.85"
+version = "0.1.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
+checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -332,7 +333,7 @@ dependencies = [
  "hex",
  "libsecp256k1",
  "num",
- "rand",
+ "rand 0.8.5",
  "ripemd",
  "sha2 0.10.8",
  "sha3",
@@ -374,7 +375,7 @@ dependencies = [
  "aurora-engine-transactions",
  "aurora-engine-types",
  "aurora-engine-workspace",
- "borsh 1.5.3",
+ "borsh 1.5.5",
  "bstr",
  "criterion",
  "engine-standalone-storage",
@@ -390,7 +391,7 @@ dependencies = [
  "near-primitives-core 0.27.0",
  "near-sdk",
  "near-vm-runner",
- "rand",
+ "rand 0.8.5",
  "reqwest",
  "rlp",
  "serde",
@@ -437,11 +438,11 @@ name = "aurora-engine-types"
 version = "1.0.0"
 dependencies = [
  "base64 0.22.1",
- "borsh 1.5.3",
+ "borsh 1.5.5",
  "bs58 0.5.1",
  "hex",
  "primitive-types 0.13.1",
- "rand",
+ "rand 0.8.5",
  "rlp",
  "serde",
  "serde_json",
@@ -463,13 +464,13 @@ dependencies = [
 
 [[package]]
 name = "auto_impl"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
+checksum = "e12882f59de5360c748c4cbf569a042d5fb0eb515f7bea9c1f470b47f6ffbd73"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -601,13 +602,13 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
- "prettyplease 0.2.27",
+ "prettyplease 0.2.29",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -618,9 +619,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "bitvec"
@@ -685,11 +686,11 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.5.3"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2506947f73ad44e344215ccd6403ac2ae18cd8e046e581a441bf8d199f257f03"
+checksum = "5430e3be710b68d984d1391c854eb431a9d548640711faa54eecb1df93db91cc"
 dependencies = [
- "borsh-derive 1.5.3",
+ "borsh-derive 1.5.5",
  "cfg_aliases",
 ]
 
@@ -708,15 +709,15 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.5.3"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2593a3b8b938bd68373196c9832f516be11fa487ef4ae745eb282e6a56a7244"
+checksum = "f8b668d39970baad5356d7c83a86fee3a539e6f93bf6764c97368243e17a0487"
 dependencies = [
  "once_cell",
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -770,9 +771,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "byte-slice-cast"
@@ -810,9 +811,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
 name = "bytesize"
@@ -852,9 +853,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.7"
+version = "1.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
+checksum = "755717a7de9ec452bf7f3f1a3099085deabd7f2962b861dae91ecd7a365903d2"
 dependencies = [
  "jobserver",
  "libc",
@@ -953,9 +954,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.23"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
+checksum = "3e77c3243bd94243c03672cb5154667347c457ca271254724f9f393aee1c05ff"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -963,9 +964,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.23"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -975,14 +976,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.18"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1042,9 +1043,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -1239,9 +1240,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-common"
@@ -1287,7 +1288,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1311,7 +1312,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1322,7 +1323,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1352,20 +1353,20 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "derive_more"
-version = "0.99.18"
+version = "0.99.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
+checksum = "3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f"
 dependencies = [
  "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1385,7 +1386,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1437,7 +1438,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1448,9 +1449,9 @@ checksum = "59f8e79d1fbf76bdfbde321e902714bf6c49df88a7dda6fc682fc2979226962d"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+checksum = "feeef44e73baff3a26d371801df019877a9866a8c493d315ab00177843314f35"
 
 [[package]]
 name = "dynasm"
@@ -1528,7 +1529,7 @@ checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "sha2 0.10.8",
  "subtle",
 ]
@@ -1596,7 +1597,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1617,7 +1618,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1806,7 +1807,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand",
+ "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
 ]
@@ -1932,7 +1933,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1977,7 +1978,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27d12c0aed7f1e24276a241aadc4cb8ea9f83000f34bc062b7cc2d51e3b0fabd"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "debugid",
  "fxhash",
  "serde",
@@ -2002,7 +2003,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2023,7 +2036,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 dependencies = [
  "fallible-iterator 0.3.0",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "stable_deref_trait",
 ]
 
@@ -2039,7 +2052,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fda788993cc341f69012feba8bf45c0ba4f3291fcc08e214b4d5a7332d88aff"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "libc",
  "libgit2-sys",
  "log",
@@ -2066,7 +2079,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -2085,7 +2098,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.2.0",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -2280,9 +2293,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.5"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
 
 [[package]]
 name = "httpdate"
@@ -2316,9 +2329,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2342,7 +2355,7 @@ checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
  "http 1.2.0",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
@@ -2371,7 +2384,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2390,7 +2403,7 @@ dependencies = [
  "futures-util",
  "http 1.2.0",
  "http-body 1.0.1",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2547,7 +2560,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2636,7 +2649,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2652,9 +2665,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -2672,19 +2685,19 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.10.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
 dependencies = [
  "hermit-abi 0.4.0",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2737,9 +2750,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2840,7 +2853,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "libc",
  "redox_syscall",
 ]
@@ -2874,7 +2887,7 @@ dependencies = [
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
- "rand",
+ "rand 0.8.5",
  "serde",
  "sha2 0.9.9",
  "typenum",
@@ -2911,9 +2924,9 @@ dependencies = [
 
 [[package]]
 name = "libssh2-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
 dependencies = [
  "cc",
  "libc",
@@ -2937,9 +2950,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "litemap"
@@ -2959,9 +2972,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "lru"
@@ -3096,9 +3109,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
  "adler2",
 ]
@@ -3110,7 +3123,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -3122,9 +3135,9 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
 name = "native-tls"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+checksum = "0dab59f8e050d5df8e4dd87d9206fb6f65a483e20ac9fda365ade4fab353196c"
 dependencies = [
  "libc",
  "log",
@@ -3143,7 +3156,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c49593c9e94454a2368a4c0a511bf4bf1413aff4d23f16e1d8f4e64b5215351"
 dependencies = [
- "borsh 1.5.3",
+ "borsh 1.5.5",
  "schemars",
  "semver",
  "serde",
@@ -3195,7 +3208,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35cbb989542587b47205e608324ddd391f0cee1c22b4b64ae49f458334b95907"
 dependencies = [
- "borsh 1.5.3",
+ "borsh 1.5.5",
  "serde",
 ]
 
@@ -3208,7 +3221,7 @@ dependencies = [
  "anyhow",
  "bytesize",
  "chrono",
- "derive_more 0.99.18",
+ "derive_more 0.99.19",
  "near-config-utils 0.28.0",
  "near-crypto 0.28.0",
  "near-parameters 0.28.0",
@@ -3243,7 +3256,7 @@ checksum = "bedc768765dd8229a1d960c94f517317f40771a003e78916124784c7d6ea9d74"
 dependencies = [
  "anyhow",
  "json_comments",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
  "tracing",
 ]
 
@@ -3254,10 +3267,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b17944c8d0f274c684227d79fcd46d583b1e36064b597c53a9ebec187a86f3"
 dependencies = [
  "blake2",
- "borsh 1.5.3",
+ "borsh 1.5.5",
  "bs58 0.4.0",
  "curve25519-dalek",
- "derive_more 0.99.18",
+ "derive_more 0.99.19",
  "ed25519-dalek",
  "hex",
  "near-account-id",
@@ -3265,7 +3278,7 @@ dependencies = [
  "near-schema-checker-lib 0.27.0",
  "near-stdx 0.27.0",
  "primitive-types 0.10.1",
- "rand",
+ "rand 0.8.5",
  "secp256k1",
  "serde",
  "serde_json",
@@ -3280,10 +3293,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4374804fdd45ac84c9e7cc3183312c98560c5518d81e6d8e2d92b77587e5a9f3"
 dependencies = [
  "blake2",
- "borsh 1.5.3",
+ "borsh 1.5.5",
  "bs58 0.4.0",
  "curve25519-dalek",
- "derive_more 0.99.18",
+ "derive_more 0.99.19",
  "ed25519-dalek",
  "hex",
  "near-account-id",
@@ -3291,12 +3304,12 @@ dependencies = [
  "near-schema-checker-lib 0.28.0",
  "near-stdx 0.28.0",
  "primitive-types 0.10.1",
- "rand",
+ "rand 0.8.5",
  "secp256k1",
  "serde",
  "serde_json",
  "subtle",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -3323,7 +3336,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180edcc7dc2fac41f93570d0c7b759c1b6d492f6ad093d749d644a40b4310a97"
 dependencies = [
- "borsh 1.5.3",
+ "borsh 1.5.5",
  "schemars",
  "serde",
 ]
@@ -3334,7 +3347,7 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e66a0c4c47f2fbbfa11ea8317fce2288d70d4aa8231e77fd213721ffcc1c334f"
 dependencies = [
- "borsh 1.5.3",
+ "borsh 1.5.5",
  "lazy_static",
  "log",
  "near-chain-configs",
@@ -3344,7 +3357,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -3360,7 +3373,7 @@ dependencies = [
  "near-schema-checker-lib 0.28.0",
  "serde",
  "serde_json",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
  "time",
 ]
 
@@ -3396,7 +3409,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d4b4d014ac9f46baf0eeac7214567a08db97d5fd26157ea13edfbb8ffc5fd8c"
 dependencies = [
- "borsh 1.5.3",
+ "borsh 1.5.5",
  "enum-map",
  "near-account-id",
  "near-primitives-core 0.27.0",
@@ -3415,7 +3428,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1279baa276725971d5e2b80c524d1aa42d5ad8bccf8901466fd579374cf58a14"
 dependencies = [
- "borsh 1.5.3",
+ "borsh 1.5.5",
  "enum-map",
  "near-account-id",
  "near-primitives-core 0.28.0",
@@ -3425,7 +3438,7 @@ dependencies = [
  "serde_repr",
  "serde_yaml",
  "strum 0.24.1",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -3437,12 +3450,12 @@ dependencies = [
  "arbitrary",
  "base64 0.21.7",
  "bitvec",
- "borsh 1.5.3",
+ "borsh 1.5.5",
  "bytes",
  "bytesize",
  "cfg-if 1.0.0",
  "chrono",
- "derive_more 0.99.18",
+ "derive_more 0.99.19",
  "easy-ext",
  "enum-map",
  "hex",
@@ -3476,12 +3489,12 @@ dependencies = [
  "arbitrary",
  "base64 0.21.7",
  "bitvec",
- "borsh 1.5.3",
+ "borsh 1.5.5",
  "bytes",
  "bytesize",
  "cfg-if 1.0.0",
  "chrono",
- "derive_more 0.99.18",
+ "derive_more 0.99.19",
  "easy-ext",
  "enum-map",
  "hex",
@@ -3496,15 +3509,15 @@ dependencies = [
  "num-rational 0.3.2",
  "ordered-float",
  "primitive-types 0.10.1",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "serde",
  "serde_json",
  "serde_with",
  "sha3",
  "smart-default",
  "strum 0.24.1",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
  "tracing",
  "zstd 0.13.2",
 ]
@@ -3517,9 +3530,9 @@ checksum = "0de2c9da5de096b5cd4786a270900ff32a49d267e442a2e7f271fb23eb925c87"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
- "borsh 1.5.3",
+ "borsh 1.5.5",
  "bs58 0.4.0",
- "derive_more 0.99.18",
+ "derive_more 0.99.19",
  "enum-map",
  "near-account-id",
  "near-schema-checker-lib 0.27.0",
@@ -3538,9 +3551,9 @@ checksum = "d597af103bb7881d1fb9031fb126cfe6c1acb9c9a6c8296dca45b5b3beb0893d"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
- "borsh 1.5.3",
+ "borsh 1.5.5",
  "bs58 0.4.0",
- "derive_more 0.99.18",
+ "derive_more 0.99.19",
  "enum-map",
  "near-account-id",
  "near-schema-checker-lib 0.28.0",
@@ -3548,7 +3561,7 @@ dependencies = [
  "serde",
  "serde_repr",
  "sha2 0.10.8",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -3610,12 +3623,12 @@ checksum = "b41a159cbf732acc0279febdde046d9036330a32a951796bce42f9529bce799d"
 
 [[package]]
 name = "near-sdk"
-version = "5.7.0"
+version = "5.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "befb9df6da1a6a0b6656388c0db76084867062a87f1cbc066c188a8e360b6463"
+checksum = "988ce7b12a80883dc8b9a48441355c9b67320692ee460c1f693b5937d8169e3c"
 dependencies = [
  "base64 0.22.1",
- "borsh 1.5.3",
+ "borsh 1.5.5",
  "bs58 0.5.1",
  "near-account-id",
  "near-gas",
@@ -3630,9 +3643,9 @@ dependencies = [
 
 [[package]]
 name = "near-sdk-macros"
-version = "5.7.0"
+version = "5.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1268c4fc56bf53d70c200261fb8d57c6c1c6692243660f5f889c7fa4cf5771d2"
+checksum = "d080babc80823326f71514e2e7a947d5fec433b93e868bb3899361cecc56f198"
 dependencies = [
  "Inflector",
  "darling",
@@ -3642,7 +3655,7 @@ dependencies = [
  "serde_json",
  "strum 0.26.3",
  "strum_macros 0.26.4",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3689,7 +3702,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd3e60aa26a74dc514b1b6408fdd06cefe2eb0ff029020956c1c6517594048fd"
 dependencies = [
- "borsh 1.5.3",
+ "borsh 1.5.5",
  "serde",
 ]
 
@@ -3762,7 +3775,7 @@ checksum = "7f31fac542ba77915f4f63ec1ba79edc559dd03ba471bf1feb08fcb434e5187f"
 dependencies = [
  "anyhow",
  "blst",
- "borsh 1.5.3",
+ "borsh 1.5.5",
  "bytesize",
  "ed25519-dalek",
  "enum-map",
@@ -3845,9 +3858,9 @@ dependencies = [
 
 [[package]]
 name = "near-workspaces"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e5804591268264c4e308cc84a54f4c7416da6ad34f8ea5c5a4b1842bc5462de"
+checksum = "62747c03bbf62783be1829f57d427ca86005d15c03badefab163e5d0ed956756"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3865,7 +3878,7 @@ dependencies = [
  "near-primitives 0.28.0",
  "near-sandbox-utils",
  "near-token",
- "rand",
+ "rand 0.8.5",
  "reqwest",
  "serde",
  "serde_json",
@@ -4046,7 +4059,7 @@ checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "crc32fast",
  "hashbrown 0.14.5",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "memchr",
 ]
 
@@ -4079,11 +4092,11 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.68"
+version = "0.10.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
+checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
@@ -4100,20 +4113,20 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.104"
+version = "0.9.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
 dependencies = [
  "cc",
  "libc",
@@ -4189,7 +4202,7 @@ dependencies = [
  "opentelemetry",
  "ordered-float",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
@@ -4201,9 +4214,9 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
- "borsh 1.5.3",
+ "borsh 1.5.5",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "serde",
 ]
 
@@ -4281,7 +4294,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -4335,22 +4348,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
+checksum = "dfe2e71e1471fe07709406bf725f710b02927c9c54b2b5b2ec0e8087d97c327d"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
+checksum = "f6e859e6e5bd50440ab63c47e3ebabc90f26251f7c73c3d3e837b74a1cc3fa67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4401,9 +4414,9 @@ dependencies = [
 
 [[package]]
 name = "postgres"
-version = "0.19.9"
+version = "0.19.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95c918733159f4d55d2ceb262950f00b0aebd6af4aa97b5a47bb0655120475ed"
+checksum = "363e6dfbdd780d3aa3597b6eb430db76bb315fa9bad7fae595bb8def808b8470"
 dependencies = [
  "bytes",
  "fallible-iterator 0.2.0",
@@ -4415,9 +4428,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acda0ebdebc28befa84bee35e651e4c5f09073d668c7aed4cf7e23c3cda84b23"
+checksum = "76ff0abab4a9b844b93ef7b81f1efc0a366062aaef2cd702c76256b5dc075c54"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -4426,16 +4439,16 @@ dependencies = [
  "hmac 0.12.1",
  "md-5",
  "memchr",
- "rand",
+ "rand 0.9.0",
  "sha2 0.10.8",
  "stringprep",
 ]
 
 [[package]]
 name = "postgres-types"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66ea23a2d0e5734297357705193335e0a957696f34bed2f2faefacb2fec336f"
+checksum = "613283563cd90e1dfc3518d548caee47e0e725455ed619881f5cf21f36de4b48"
 dependencies = [
  "bytes",
  "fallible-iterator 0.2.0",
@@ -4454,7 +4467,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -4475,12 +4488,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "483f8c21f64f3ea09fe0f30f5d48c3e8eefe5dac9129f0075f76593b4c1da705"
+checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
 dependencies = [
  "proc-macro2",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4562,9 +4575,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -4604,7 +4617,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4675,9 +4688,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "serde",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.0",
+ "zerocopy 0.8.16",
 ]
 
 [[package]]
@@ -4687,7 +4711,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.0",
 ]
 
 [[package]]
@@ -4696,8 +4730,18 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "serde",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
+dependencies = [
+ "getrandom 0.3.1",
+ "zerocopy 0.8.16",
 ]
 
 [[package]]
@@ -4726,7 +4770,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -4735,7 +4779,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -4833,7 +4877,7 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
@@ -4870,7 +4914,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if 1.0.0",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "spin",
  "untrusted",
@@ -4934,7 +4978,7 @@ checksum = "652db34deaaa57929e10ca18e5454a32cb0efc351ae80d320334bbf907b908b3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4976,11 +5020,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.42"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4989,9 +5033,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.20"
+version = "0.23.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
+checksum = "9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7"
 dependencies = [
  "log",
  "once_cell",
@@ -5013,9 +5057,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 
 [[package]]
 name = "rustls-webpki"
@@ -5036,9 +5080,9 @@ checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "same-file"
@@ -5071,7 +5115,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -5104,7 +5148,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -5125,7 +5169,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
- "rand",
+ "rand 0.8.5",
  "secp256k1-sys",
 ]
 
@@ -5144,7 +5188,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -5153,9 +5197,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1863fd3768cd83c56a7f60faa4dc0d403f1b6df0a38c3c25f44b7894e45370d5"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5163,9 +5207,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"
@@ -5184,7 +5228,7 @@ checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -5195,14 +5239,14 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.135"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "itoa",
  "memchr",
@@ -5218,7 +5262,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -5243,7 +5287,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "serde",
  "serde_derive",
  "serde_json",
@@ -5260,7 +5304,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -5269,7 +5313,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "itoa",
  "ryu",
  "serde",
@@ -5493,7 +5537,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -5515,9 +5559,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.95"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5547,7 +5591,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -5556,7 +5600,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -5596,13 +5640,13 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.15.0"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
+checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
- "getrandom",
+ "getrandom 0.3.1",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -5626,7 +5670,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -5637,7 +5681,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
  "test-case-core",
 ]
 
@@ -5652,11 +5696,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.9"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
- "thiserror-impl 2.0.9",
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -5667,18 +5711,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.9"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -5777,9 +5821,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.42.0"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "bytes",
@@ -5805,13 +5849,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -5826,9 +5870,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b5d3742945bc7d7f210693b0c58ae542c6fd47b17adbbda0885f3dcb34a6bdb"
+checksum = "6c95d533c83082bb6490e0189acaa0bbeef9084e60471b696ca6988cd0541fb0"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -5843,7 +5887,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand",
+ "rand 0.9.0",
  "socket2",
  "tokio",
  "tokio-util",
@@ -5857,7 +5901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
 dependencies = [
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "tokio",
 ]
 
@@ -5912,11 +5956,11 @@ checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "02a8b472d1a3d7c18e2d61a489aee3453fd9031c33e4f55bd533f4a7adca1bee"
 dependencies = [
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "toml_datetime",
  "winnow",
 ]
@@ -5959,7 +6003,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -6026,7 +6070,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -6130,9 +6174,9 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "unicode-normalization"
@@ -6225,15 +6269,15 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.11.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -6282,7 +6326,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -6301,6 +6345,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6308,34 +6361,35 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if 1.0.0",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.49"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -6346,9 +6400,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6356,22 +6410,25 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-encoder"
@@ -6536,7 +6593,7 @@ version = "0.115.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e06c0641a4add879ba71ccb3a1e4278fd546f76f1eafb21d8f7b07733b547cd5"
 dependencies = [
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "semver",
 ]
 
@@ -6547,9 +6604,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5309c1090e3e84dad0d382f42064e9933fdaedb87e468cc239f0eabea73ddcb6"
 dependencies = [
  "ahash 0.8.11",
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "hashbrown 0.14.5",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "semver",
  "serde",
 ]
@@ -6575,7 +6632,7 @@ dependencies = [
  "bumpalo",
  "cfg-if 1.0.0",
  "fxprof-processed-profile",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "libc",
  "log",
  "object 0.32.2",
@@ -6654,7 +6711,7 @@ dependencies = [
  "anyhow",
  "cranelift-entity",
  "gimli 0.28.1",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "log",
  "object 0.32.2",
  "serde",
@@ -6720,14 +6777,14 @@ dependencies = [
  "anyhow",
  "cc",
  "cfg-if 1.0.0",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "libc",
  "log",
  "mach",
  "memfd",
  "memoffset 0.9.1",
  "paste",
- "rand",
+ "rand 0.8.5",
  "rustix",
  "sptr",
  "wasm-encoder 0.35.0",
@@ -6760,7 +6817,7 @@ checksum = "09b5575a75e711ca6c36bb9ad647c93541cdc8e34218031acba5da3f35919dd3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -6771,9 +6828,9 @@ checksum = "9dafab2db172a53e23940e0fa3078c202f567ee5f13f4b42f66b694fab43c658"
 
 [[package]]
 name = "web-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6791,9 +6848,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.7"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
+checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -7041,11 +7098,20 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.22"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39281189af81c07ec09db316b302a3e67bf9bd7cbf6c820b50e35fee9c2fa980"
+checksum = "86e376c75f4f43f44db463cf729e0d3acbf954d13e22c51e26e4c264b4ab545f"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -7100,7 +7166,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
  "synstructure",
 ]
 
@@ -7111,7 +7177,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b8c07a70861ce02bad1607b5753ecb2501f67847b9f9ada7c160fff0ec6300c"
+dependencies = [
+ "zerocopy-derive 0.8.16",
 ]
 
 [[package]]
@@ -7122,7 +7197,18 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5226bc9a9a9836e7428936cde76bb6b22feea1a8bfdbc0d241136e4d13417e25"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -7142,7 +7228,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
  "synstructure",
 ]
 
@@ -7163,7 +7249,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -7176,7 +7262,7 @@ dependencies = [
  "byteorder",
  "crunchy",
  "lazy_static",
- "rand",
+ "rand 0.8.5",
  "rustc-hex",
 ]
 
@@ -7199,7 +7285,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.98",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ near-primitives = "0.27"
 near-primitives-core = "0.27"
 near-sdk = "5"
 near-vm-runner = { version = "0.27", features = ["wasmtime_vm", "wasmer2_vm", "near_vm"] }
-near-workspaces = "0.16"
+near-workspaces = "0.17"
 num = { version = "0.4", default-features = false, features = ["alloc"] }
 postgres = "0.19"
 primitive-types = { version = "0.13", default-features = false, features = ["rlp", "serde_no_std"] }

--- a/engine-precompiles/src/lib.rs
+++ b/engine-precompiles/src/lib.rs
@@ -348,10 +348,7 @@ impl<'a, I: IO + Copy, E: Env, H: ReadOnlyPromiseHandler> Precompiles<'a, I, E, 
         ctx: PrecompileConstructorContext<'a, I, E, H, M>,
     ) -> Self {
         let near_exit = ExitToNear::new(ctx.current_account_id.clone(), ctx.io);
-        #[cfg(not(feature = "ext-connector"))]
         let ethereum_exit = ExitToEthereum::new(ctx.current_account_id.clone(), ctx.io);
-        #[cfg(feature = "ext-connector")]
-        let ethereum_exit = ExitToEthereum::new(ctx.io);
         let cross_contract_call = CrossContractCall::new(ctx.current_account_id, ctx.io);
         let predecessor_account_id = PredecessorAccount::new(ctx.env);
         let prepaid_gas = PrepaidGas::new(ctx.env);

--- a/engine-precompiles/src/native.rs
+++ b/engine-precompiles/src/native.rs
@@ -1188,10 +1188,10 @@ mod tests {
         #[cfg(feature = "error_refund")]
         let refund_address = Address::from_array([1; 20]);
 
-        fn assert_input(input: impl AsRef<[u8]>, expected: ExitToNearParams) {
-            let actual = ExitToNearParams::try_from(input.as_ref()).unwrap();
+        let assert_input = |input: Vec<u8>, expected| {
+            let actual = ExitToNearParams::try_from(input.as_slice()).unwrap();
             assert_eq!(actual, expected);
-        }
+        };
 
         let input = [
             &[0],

--- a/engine-precompiles/src/native.rs
+++ b/engine-precompiles/src/native.rs
@@ -1,4 +1,5 @@
 use super::{EvmPrecompileResult, Precompile};
+use crate::native::events::{ExitToNearLegacy, ExitToNearOmni};
 use crate::prelude::types::EthGas;
 use crate::prelude::{
     format,
@@ -7,21 +8,20 @@ use crate::prelude::{
     storage::{bytes_to_key, KeyPrefix},
     str,
     types::{Address, Yocto},
-    vec, Cow, ToString, Vec, H256, U256,
+    vec, Cow, String, ToString, Vec, H256, U256,
 };
 #[cfg(feature = "error_refund")]
 use crate::prelude::{parameters::RefundCallArgs, types};
 use crate::xcc::state::get_wnear_address;
 use crate::PrecompileOutput;
-use aurora_engine_types::parameters::connector::WithdrawSerializeType;
-use aurora_engine_types::parameters::WithdrawCallArgs;
-use aurora_engine_types::storage::EthConnectorStorageId;
 use aurora_engine_types::{
     account_id::AccountId,
     borsh,
     parameters::{
-        ExitToNearPrecompileCallbackCallArgs, PromiseWithCallbackArgs, TransferNearCallArgs,
+        connector::WithdrawSerializeType, ExitToNearPrecompileCallbackCallArgs,
+        PromiseWithCallbackArgs, TransferNearCallArgs, WithdrawCallArgs,
     },
+    storage::EthConnectorStorageId,
     types::NEP141Wei,
 };
 use evm::backend::Log;
@@ -42,6 +42,8 @@ mod costs {
     /// Value determined experimentally based on tests and mainnet data. Example:
     /// `https://explorer.mainnet.near.org/transactions/5CD7NrqWpK3H8MAAU4mYEPuuWz9AqR9uJkkZJzw5b8PM#D1b5NVRrAsJKUX2ZGs3poKViu1Rgt4RJZXtTfMgdxH4S`
     pub(super) const FT_TRANSFER_GAS: NearGas = NearGas::new(10_000_000_000_000);
+
+    pub(super) const FT_TRANSFER_CALL_GAS: NearGas = NearGas::new(70_000_000_000_000);
 
     /// Value determined experimentally based on tests.
     pub(super) const EXIT_TO_NEAR_CALLBACK_GAS: NearGas = NearGas::new(10_000_000_000_000);
@@ -80,14 +82,29 @@ pub mod events {
     /// the ERC-20 contract which calls the exit precompile. However, in the case
     /// of ETH exit the sender will give the true sender (and the `erc20_address`
     /// will not be meaningful because ETH is not an ERC-20 token).
-    pub struct ExitToNear {
+    pub enum ExitToNear {
+        Legacy(ExitToNearLegacy),
+        Omni(ExitToNearOmni),
+    }
+
+    impl ExitToNear {
+        #[must_use]
+        pub fn encode(self) -> ethabi::RawLog {
+            match self {
+                Self::Legacy(legacy) => legacy.encode(),
+                Self::Omni(omni) => omni.encode(),
+            }
+        }
+    }
+
+    pub struct ExitToNearLegacy {
         pub sender: Address,
         pub erc20_address: Address,
         pub dest: String,
         pub amount: U256,
     }
 
-    impl ExitToNear {
+    impl ExitToNearLegacy {
         #[must_use]
         pub fn encode(self) -> ethabi::RawLog {
             let data = ethabi::encode(&[ethabi::Token::Uint(self.amount.to_big_endian().into())]);
@@ -101,6 +118,64 @@ pub mod events {
             ];
 
             ethabi::RawLog { topics, data }
+        }
+    }
+
+    pub struct ExitToNearOmni {
+        pub sender: Address,
+        pub erc20_address: Address,
+        pub dest: String,
+        pub amount: U256,
+        pub msg: String,
+    }
+
+    impl ExitToNearOmni {
+        #[must_use]
+        pub fn encode(self) -> ethabi::RawLog {
+            let data = ethabi::encode(&[
+                ethabi::Token::Uint(self.amount.to_big_endian().into()),
+                ethabi::Token::String(self.msg),
+            ]);
+            let topics = vec![
+                EXIT_TO_NEAR_SIGNATURE.0.into(),
+                encode_address(self.sender),
+                encode_address(self.erc20_address),
+                aurora_engine_sdk::keccak(&ethabi::encode(&[ethabi::Token::String(self.dest)]))
+                    .0
+                    .into(),
+            ];
+
+            ethabi::RawLog { topics, data }
+        }
+    }
+
+    #[must_use]
+    pub fn exit_to_near_schema() -> ethabi::Event {
+        ethabi::Event {
+            name: "ExitToNear".to_string(),
+            inputs: vec![
+                ethabi::EventParam {
+                    name: "sender".to_string(),
+                    kind: ethabi::ParamType::Address,
+                    indexed: true,
+                },
+                ethabi::EventParam {
+                    name: "erc20_address".to_string(),
+                    kind: ethabi::ParamType::Address,
+                    indexed: true,
+                },
+                ethabi::EventParam {
+                    name: "dest".to_string(),
+                    kind: ethabi::ParamType::String,
+                    indexed: true,
+                },
+                ethabi::EventParam {
+                    name: "amount".to_string(),
+                    kind: ethabi::ParamType::Uint(256),
+                    indexed: false,
+                },
+            ],
+            anonymous: false,
         }
     }
 
@@ -136,42 +211,6 @@ pub mod events {
         }
     }
 
-    fn encode_address(a: Address) -> ethabi::Hash {
-        let mut result = [0u8; 32];
-        result[12..].copy_from_slice(a.as_bytes());
-        result.into()
-    }
-
-    #[must_use]
-    pub fn exit_to_near_schema() -> ethabi::Event {
-        ethabi::Event {
-            name: "ExitToNear".to_string(),
-            inputs: vec![
-                ethabi::EventParam {
-                    name: "sender".to_string(),
-                    kind: ethabi::ParamType::Address,
-                    indexed: true,
-                },
-                ethabi::EventParam {
-                    name: "erc20_address".to_string(),
-                    kind: ethabi::ParamType::Address,
-                    indexed: true,
-                },
-                ethabi::EventParam {
-                    name: "dest".to_string(),
-                    kind: ethabi::ParamType::String,
-                    indexed: true,
-                },
-                ethabi::EventParam {
-                    name: "amount".to_string(),
-                    kind: ethabi::ParamType::Uint(256),
-                    indexed: false,
-                },
-            ],
-            anonymous: false,
-        }
-    }
-
     #[must_use]
     pub fn exit_to_eth_schema() -> ethabi::Event {
         ethabi::Event {
@@ -201,9 +240,19 @@ pub mod events {
             anonymous: false,
         }
     }
+
+    fn encode_address(a: Address) -> ethabi::Hash {
+        let mut result = [0u8; 32];
+        result[12..].copy_from_slice(a.as_bytes());
+        result.into()
+    }
 }
 
-//TransferEthToNear
+trait EthConnector {
+    fn get_eth_connector_contract_account(&self) -> Result<AccountId, ExitError>;
+}
+
+/// Transfer ETH(base) or ERC-20 tokens to NEAR.
 pub struct ExitToNear<I> {
     current_account_id: AccountId,
     io: I,
@@ -225,6 +274,17 @@ impl<I> ExitToNear<I> {
             current_account_id,
             io,
         }
+    }
+}
+
+impl<I: IO> EthConnector for ExitToNear<I> {
+    fn get_eth_connector_contract_account(&self) -> Result<AccountId, ExitError> {
+        #[cfg(not(feature = "ext-connector"))]
+        let eth_connector_account_id = self.current_account_id.clone();
+        #[cfg(feature = "ext-connector")]
+        let eth_connector_account_id = get_eth_connector_contract_account(&self.io)?;
+
+        Ok(eth_connector_account_id)
     }
 }
 
@@ -281,7 +341,13 @@ fn validate_amount(amount: U256) -> Result<(), ExitError> {
 #[derive(Debug, PartialEq)]
 struct Recipient<'a> {
     receiver_account_id: AccountId,
-    message: Option<&'a str>,
+    message: Option<Message<'a>>,
+}
+
+#[derive(Debug, PartialEq)]
+enum Message<'a> {
+    UnwrapWnear,
+    Omni(&'a str),
 }
 
 fn parse_recipient(recipient: &[u8]) -> Result<Recipient<'_>, ExitError> {
@@ -289,7 +355,13 @@ fn parse_recipient(recipient: &[u8]) -> Result<Recipient<'_>, ExitError> {
         .map_err(|_| ExitError::Other(Cow::from("ERR_INVALID_RECEIVER_ACCOUNT_ID")))?;
     let (receiver_account_id, message) = recipient.split_once(':').map_or_else(
         || (recipient, None),
-        |(recipient, msg)| (recipient, Some(msg)),
+        |(recipient, msg)| {
+            if msg == UNWRAP_WNEAR_MSG {
+                (recipient, Some(Message::UnwrapWnear))
+            } else {
+                (recipient, Some(Message::Omni(msg)))
+            }
+        },
     );
 
     Ok(Recipient {
@@ -313,29 +385,16 @@ impl<I: IO> Precompile for ExitToNear<I> {
         context: &Context,
         is_static: bool,
     ) -> EvmPrecompileResult {
-        // ETH transfer input format: (85 bytes)
+        // ETH (base) transfer input format: (85 bytes)
         //  - flag (1 byte)
         //  - refund_address (20 bytes)
         //  - recipient_account_id (max 64 bytes)
-        // ERC20 transfer input format: (117 bytes)
+        // ERC-20 transfer input format: (124 bytes)
         //  - flag (1 byte)
         //  - refund_address (20 bytes)
         //  - amount (32 bytes)
         //  - recipient_account_id (max 64 bytes)
-        #[cfg(feature = "error_refund")]
-        fn parse_input(input: &[u8]) -> Result<(Address, &[u8]), ExitError> {
-            validate_input_size(input, 21, 117)?;
-            let mut buffer = [0; 20];
-            buffer.copy_from_slice(&input[1..21]);
-            let refund_address = Address::from_array(buffer);
-            Ok((refund_address, &input[21..]))
-        }
-        #[cfg(not(feature = "error_refund"))]
-        fn parse_input(input: &[u8]) -> Result<&[u8], ExitError> {
-            validate_input_size(input, 3, 117)?;
-            Ok(&input[1..])
-        }
-
+        //  - `:unwrap` suffix in a case of wNEAR (7 bytes)
         if let Some(target_gas) = target_gas {
             if Self::required_gas(input)? > target_gas {
                 return Err(ExitError::OutOfGas);
@@ -349,144 +408,51 @@ impl<I: IO> Precompile for ExitToNear<I> {
             return Err(ExitError::Other(Cow::from("ERR_INVALID_IN_DELEGATE")));
         }
 
-        // First byte of the input is a flag, selecting the behavior to be triggered:
-        //      0x0 -> Eth transfer
-        //      0x1 -> Erc20 transfer
-        let flag = input.first().copied().unwrap_or_default();
-        #[cfg(feature = "error_refund")]
-        let (refund_address, mut input) = parse_input(input)?;
-        #[cfg(not(feature = "error_refund"))]
-        let mut input = parse_input(input)?;
-        #[cfg(not(feature = "ext-connector"))]
-        let eth_connector_account_id = self.current_account_id.clone();
-        #[cfg(feature = "ext-connector")]
-        let eth_connector_account_id = get_eth_connector_contract_account(&self.io)?;
+        let exit_to_near_params = ExitToNearParams::try_from(input)?;
 
-        let (nep141_address, args, exit_event, method, transfer_near_args) = match flag {
-            0x0 => {
-                // ETH transfer
+        let (nep141_address, args, exit_event, method, transfer_near_args) =
+            match exit_to_near_params {
+                // ETH(base) token transfer
                 //
                 // Input slice format:
-                // recipient_account_id (bytes) - the NEAR recipient account which will receive NEP-141 ETH tokens
-
-                if let Ok(dest_account) = AccountId::try_from(input) {
-                    (
-                        eth_connector_account_id,
-                        // There is no way to inject json, given the encoding of both arguments
-                        // as decimal and valid account id respectively.
-                        format!(
-                            r#"{{"receiver_id": "{}", "amount": "{}", "memo": null}}"#,
-                            dest_account,
-                            context.apparent_value.as_u128()
-                        ),
-                        events::ExitToNear {
-                            sender: Address::new(context.caller),
-                            erc20_address: events::ETH_ADDRESS,
-                            dest: dest_account.to_string(),
-                            amount: context.apparent_value,
-                        },
-                        "ft_transfer",
-                        None,
-                    )
-                } else {
-                    return Err(ExitError::Other(Cow::from(
-                        "ERR_INVALID_RECEIVER_ACCOUNT_ID",
-                    )));
+                //  recipient_account_id (bytes) - the NEAR recipient account which will receive
+                // NEP-141 ETH (base) tokens
+                ExitToNearParams::BaseToken(ref exit_params) => {
+                    let eth_connector_account_id = self.get_eth_connector_contract_account()?;
+                    exit_base_token_to_near(eth_connector_account_id, context, exit_params)?
                 }
-            }
-            0x1 => {
-                // ERC-20 transfer
+                // ERC-20 token transfer
                 //
-                // This precompile branch is expected to be called from the ERC20 burn function.
+                // This precompile branch is expected to be called from the ERC-20 burn function.
                 //
                 // Input slice format:
-                //      amount (U256 big-endian bytes) - the amount that was burned
-                //      recipient_account_id (bytes) - the NEAR recipient account which will receive NEP-141 tokens
-
-                if context.apparent_value != U256::from(0) {
-                    return Err(ExitError::Other(Cow::from(
-                        "ERR_ETH_ATTACHED_FOR_ERC20_EXIT",
-                    )));
+                //  amount (U256 big-endian bytes) - the amount that was burned
+                //  recipient_account_id (bytes) - the NEAR recipient account which will receive
+                // NEP-141 tokens
+                ExitToNearParams::Erc20TokenParams(ref exit_params) => {
+                    exit_erc20_token_to_near(context, exit_params, &self.io)?
                 }
-
-                let erc20_address = context.caller;
-                let nep141_address = get_nep141_from_erc20(erc20_address.as_bytes(), &self.io)?;
-
-                let amount = U256::from_big_endian(&input[..32]);
-                input = &input[32..];
-
-                validate_amount(amount)?;
-                let recipient = parse_recipient(input)?;
-
-                let (args, method, transfer_near_args) = if recipient.message
-                    == Some(UNWRAP_WNEAR_MSG)
-                    && erc20_address == get_wnear_address(&self.io).raw()
-                {
-                    (
-                        format!(r#"{{"amount": "{}"}}"#, amount.as_u128()),
-                        "near_withdraw",
-                        Some(TransferNearCallArgs {
-                            target_account_id: recipient.receiver_account_id.clone(),
-                            amount: amount.as_u128(),
-                        }),
-                    )
-                } else {
-                    // There is no way to inject json, given the encoding of both arguments
-                    // as decimal and valid account id respectively.
-                    (
-                        format!(
-                            r#"{{"receiver_id": "{}", "amount": "{}", "memo": null}}"#,
-                            recipient.receiver_account_id,
-                            amount.as_u128()
-                        ),
-                        "ft_transfer",
-                        None,
-                    )
-                };
-
-                (
-                    nep141_address,
-                    args,
-                    events::ExitToNear {
-                        sender: Address::new(erc20_address),
-                        erc20_address: Address::new(erc20_address),
-                        dest: recipient.receiver_account_id.to_string(),
-                        amount,
-                    },
-                    method,
-                    transfer_near_args,
-                )
-            }
-            _ => return Err(ExitError::Other(Cow::from("ERR_INVALID_FLAG"))),
-        };
-
-        #[cfg(feature = "error_refund")]
-        let erc20_address = if flag == 0 {
-            None
-        } else {
-            Some(exit_event.erc20_address)
-        };
-        #[cfg(feature = "error_refund")]
-        let refund_args = RefundCallArgs {
-            recipient_address: refund_address,
-            erc20_address,
-            amount: types::u256_to_arr(&exit_event.amount),
-        };
+            };
 
         let callback_args = ExitToNearPrecompileCallbackCallArgs {
             #[cfg(feature = "error_refund")]
-            refund: Some(refund_args),
+            refund: refund_call_args(&exit_to_near_params, &exit_event),
             #[cfg(not(feature = "error_refund"))]
             refund: None,
             transfer_near: transfer_near_args,
         };
+        let attached_gas = if method == "ft_transfer_call" {
+            costs::FT_TRANSFER_CALL_GAS
+        } else {
+            costs::FT_TRANSFER_GAS
+        };
 
         let transfer_promise = PromiseCreateArgs {
             target_account_id: nep141_address,
-            method: method.to_string(),
-            args: args.as_bytes().to_vec(),
+            method,
+            args: args.into_bytes(),
             attached_balance: Yocto::new(1),
-            attached_gas: costs::FT_TRANSFER_GAS,
+            attached_gas,
         };
 
         let promise = if callback_args == ExitToNearPrecompileCallbackCallArgs::default() {
@@ -508,15 +474,11 @@ impl<I: IO> Precompile for ExitToNear<I> {
             topics: Vec::new(),
             data: borsh::to_vec(&promise).unwrap(),
         };
-        let exit_event_log = exit_event.encode();
+        let ethabi::RawLog { topics, data } = exit_event.encode();
         let exit_event_log = Log {
             address: exit_to_near::ADDRESS.raw(),
-            topics: exit_event_log
-                .topics
-                .into_iter()
-                .map(|h| H256::from(h.0))
-                .collect(),
-            data: exit_event_log.data,
+            topics: topics.into_iter().map(|h| H256::from(h.0)).collect(),
+            data,
         };
 
         Ok(PrecompileOutput {
@@ -525,6 +487,290 @@ impl<I: IO> Precompile for ExitToNear<I> {
             output: Vec::new(),
         })
     }
+}
+
+fn exit_base_token_to_near(
+    eth_connector_account_id: AccountId,
+    context: &Context,
+    exit_params: &BaseTokenParams,
+) -> Result<
+    (
+        AccountId,
+        String,
+        events::ExitToNear,
+        String,
+        Option<TransferNearCallArgs>,
+    ),
+    ExitError,
+> {
+    match exit_params.message {
+        Some(Message::Omni(msg)) => Ok((
+            eth_connector_account_id,
+            format!(
+                r#"{{"receiver_id":"{}","amount":"{}","msg":"{msg}"}}"#,
+                exit_params.receiver_account_id,
+                context.apparent_value.as_u128(),
+            ),
+            events::ExitToNear::Omni(ExitToNearOmni {
+                sender: Address::new(context.caller),
+                erc20_address: events::ETH_ADDRESS,
+                dest: exit_params.receiver_account_id.to_string(),
+                amount: context.apparent_value,
+                msg: msg.to_string(),
+            }),
+            "ft_transfer_call".to_string(),
+            None,
+        )),
+        None => Ok((
+            eth_connector_account_id,
+            // There is no way to inject json, given the encoding of both arguments
+            // as decimal and valid account id respectively.
+            format!(
+                r#"{{"receiver_id":"{}","amount":"{}"}}"#,
+                exit_params.receiver_account_id,
+                context.apparent_value.as_u128()
+            ),
+            events::ExitToNear::Legacy(ExitToNearLegacy {
+                sender: Address::new(context.caller),
+                erc20_address: events::ETH_ADDRESS,
+                dest: exit_params.receiver_account_id.to_string(),
+                amount: context.apparent_value,
+            }),
+            "ft_transfer".to_string(),
+            None,
+        )),
+        _ => Err(ExitError::Other(Cow::from("ERR_INVALID_MESSAGE"))),
+    }
+}
+
+fn exit_erc20_token_to_near<I: IO>(
+    context: &Context,
+    exit_params: &Erc20TokenParams,
+    io: &I,
+) -> Result<
+    (
+        AccountId,
+        String,
+        events::ExitToNear,
+        String,
+        Option<TransferNearCallArgs>,
+    ),
+    ExitError,
+> {
+    if context.apparent_value != U256::from(0) {
+        return Err(ExitError::Other(Cow::from(
+            "ERR_ETH_ATTACHED_FOR_ERC20_EXIT",
+        )));
+    }
+
+    let erc20_address = context.caller;
+    let nep141_account_id = get_nep141_from_erc20(erc20_address.as_bytes(), io)?;
+
+    let (nep141_account_id, args, method, transfer_near_args, event) = match exit_params.message {
+        Some(Message::UnwrapWnear) => {
+            if erc20_address == get_wnear_address(io).raw() {
+                (
+                    nep141_account_id,
+                    format!(r#"{{"amount":"{}"}}"#, exit_params.amount.as_u128()),
+                    "near_withdraw",
+                    Some(TransferNearCallArgs {
+                        target_account_id: exit_params.receiver_account_id.clone(),
+                        amount: exit_params.amount.as_u128(),
+                    }),
+                    events::ExitToNear::Legacy(ExitToNearLegacy {
+                        sender: Address::new(erc20_address),
+                        erc20_address: Address::new(erc20_address),
+                        dest: exit_params.receiver_account_id.to_string(),
+                        amount: exit_params.amount,
+                    }),
+                )
+            } else {
+                return Err(ExitError::Other(Cow::from("ERR_INVALID_ERC20_FOR_UNWRAP")));
+            }
+        }
+        Some(Message::Omni(msg)) => (
+            nep141_account_id,
+            format!(
+                r#"{{"receiver_id":"{}","amount":"{}","msg":"{msg}"}}"#,
+                exit_params.receiver_account_id, // The locker account id
+                exit_params.amount.as_u128(),
+            ),
+            "ft_transfer_call",
+            None,
+            events::ExitToNear::Omni(ExitToNearOmni {
+                sender: Address::new(erc20_address),
+                erc20_address: Address::new(erc20_address),
+                dest: exit_params.receiver_account_id.to_string(),
+                amount: exit_params.amount,
+                msg: msg.to_string(),
+            }),
+        ),
+        None => {
+            // There is no way to inject json, given the encoding of both arguments
+            // as decimal and valid account id respectively.
+            (
+                nep141_account_id,
+                format!(
+                    r#"{{"receiver_id":"{}","amount":"{}"}}"#,
+                    exit_params.receiver_account_id,
+                    exit_params.amount.as_u128()
+                ),
+                "ft_transfer",
+                None,
+                events::ExitToNear::Legacy(ExitToNearLegacy {
+                    sender: Address::new(erc20_address),
+                    erc20_address: Address::new(erc20_address),
+                    dest: exit_params.receiver_account_id.to_string(),
+                    amount: exit_params.amount,
+                }),
+            )
+        }
+    };
+
+    Ok((
+        nep141_account_id,
+        args,
+        event,
+        method.to_string(),
+        transfer_near_args,
+    ))
+}
+
+#[allow(clippy::unnecessary_wraps)]
+fn json_args(address: Address, amount: U256) -> Result<Vec<u8>, ExitError> {
+    Ok(format!(
+        r#"{{"amount":"{}","recipient":"{}"}}"#,
+        amount.as_u128(),
+        address.encode(),
+    )
+    .into_bytes())
+}
+
+fn borsh_args(address: Address, amount: U256) -> Result<Vec<u8>, ExitError> {
+    borsh::to_vec(&WithdrawCallArgs {
+        recipient_address: address,
+        amount: NEP141Wei::new(amount.as_u128()),
+    })
+    .map_err(|_| ExitError::Other(Cow::from("ERR_BORSH_SERIALIZE")))
+}
+
+#[cfg_attr(test, derive(Debug, PartialEq))]
+enum ExitToNearParams<'a> {
+    BaseToken(BaseTokenParams<'a>),
+    Erc20TokenParams(Erc20TokenParams<'a>),
+}
+
+#[cfg_attr(test, derive(Debug, PartialEq))]
+struct BaseTokenParams<'a> {
+    #[cfg(feature = "error_refund")]
+    refund_address: Address,
+    receiver_account_id: AccountId,
+    message: Option<Message<'a>>,
+}
+
+#[cfg_attr(test, derive(Debug, PartialEq))]
+struct Erc20TokenParams<'a> {
+    #[cfg(feature = "error_refund")]
+    refund_address: Address,
+    receiver_account_id: AccountId,
+    amount: U256,
+    message: Option<Message<'a>>,
+}
+
+#[cfg(feature = "error_refund")]
+#[allow(clippy::unnecessary_wraps)]
+fn refund_call_args(
+    params: &ExitToNearParams,
+    event: &events::ExitToNear,
+) -> Option<RefundCallArgs> {
+    Some(RefundCallArgs {
+        recipient_address: match params {
+            ExitToNearParams::BaseToken(params) => params.refund_address,
+            ExitToNearParams::Erc20TokenParams(params) => params.refund_address,
+        },
+        erc20_address: match params {
+            ExitToNearParams::BaseToken(_) => None,
+            ExitToNearParams::Erc20TokenParams(_) => {
+                let erc20_address = match event {
+                    events::ExitToNear::Legacy(ref legacy) => legacy.erc20_address,
+                    events::ExitToNear::Omni(ref omni) => omni.erc20_address,
+                };
+                Some(erc20_address)
+            }
+        },
+        amount: types::u256_to_arr(&match event {
+            events::ExitToNear::Legacy(ref legacy) => legacy.amount,
+            events::ExitToNear::Omni(ref omni) => omni.amount,
+        }),
+    })
+}
+
+impl<'a> TryFrom<&'a [u8]> for ExitToNearParams<'a> {
+    type Error = ExitError;
+
+    fn try_from(input: &'a [u8]) -> Result<Self, Self::Error> {
+        // First byte of the input is a flag, selecting the behavior to be triggered:
+        // 0x00 -> Eth(base) token withdrawal
+        // 0x01 -> ERC-20 token withdrawal
+        let flag = input
+            .first()
+            .copied()
+            .ok_or_else(|| ExitError::Other(Cow::from("ERR_MISSING_FLAG")))?;
+
+        #[cfg(feature = "error_refund")]
+        let (refund_address, input) = parse_input(input)?;
+        #[cfg(not(feature = "error_refund"))]
+        let input = parse_input(input)?;
+
+        match flag {
+            0x0 => {
+                let Recipient {
+                    receiver_account_id,
+                    message,
+                } = parse_recipient(input)?;
+
+                Ok(Self::BaseToken(BaseTokenParams {
+                    #[cfg(feature = "error_refund")]
+                    refund_address,
+                    receiver_account_id,
+                    message,
+                }))
+            }
+            0x1 => {
+                let amount = U256::from_big_endian(&input[..32]);
+                validate_amount(amount)?;
+
+                let Recipient {
+                    receiver_account_id,
+                    message,
+                } = parse_recipient(&input[32..])?;
+
+                Ok(Self::Erc20TokenParams(Erc20TokenParams {
+                    #[cfg(feature = "error_refund")]
+                    refund_address,
+                    receiver_account_id,
+                    amount,
+                    message,
+                }))
+            }
+            _ => Err(ExitError::Other(Cow::from("ERR_INVALID_FLAG"))),
+        }
+    }
+}
+
+#[cfg(feature = "error_refund")]
+fn parse_input(input: &[u8]) -> Result<(Address, &[u8]), ExitError> {
+    validate_input_size(input, 21, 1024)?;
+    let mut buffer = [0; 20];
+    buffer.copy_from_slice(&input[1..21]);
+    let refund_address = Address::from_array(buffer);
+    Ok((refund_address, &input[21..]))
+}
+
+#[cfg(not(feature = "error_refund"))]
+fn parse_input(input: &[u8]) -> Result<&[u8], ExitError> {
+    validate_input_size(input, 3, 1024)?;
+    Ok(&input[1..])
 }
 
 pub struct ExitToEthereum<I> {
@@ -544,17 +790,32 @@ pub mod exit_to_ethereum {
 }
 
 impl<I> ExitToEthereum<I> {
-    #[cfg(not(feature = "ext-connector"))]
-    pub const fn new(current_account_id: AccountId, io: I) -> Self {
-        Self {
-            io,
-            current_account_id,
+    #[allow(clippy::missing_const_for_fn, clippy::needless_pass_by_value)]
+    pub fn new(current_account_id: AccountId, io: I) -> Self {
+        #[cfg(not(feature = "ext-connector"))]
+        {
+            Self {
+                io,
+                current_account_id,
+            }
+        }
+
+        #[cfg(feature = "ext-connector")]
+        {
+            let _ = current_account_id;
+            Self { io }
         }
     }
+}
 
-    #[cfg(feature = "ext-connector")]
-    pub const fn new(io: I) -> Self {
-        Self { io }
+impl<I: IO> EthConnector for ExitToEthereum<I> {
+    fn get_eth_connector_contract_account(&self) -> Result<AccountId, ExitError> {
+        #[cfg(not(feature = "ext-connector"))]
+        let eth_connector_account_id = self.current_account_id.clone();
+        #[cfg(feature = "ext-connector")]
+        let eth_connector_account_id = get_eth_connector_contract_account(&self.io)?;
+
+        Ok(eth_connector_account_id)
     }
 }
 
@@ -571,10 +832,10 @@ impl<I: IO> Precompile for ExitToEthereum<I> {
         context: &Context,
         is_static: bool,
     ) -> EvmPrecompileResult {
-        // ETH transfer input format (min size 21 bytes)
+        // ETH (Base token) transfer input format (min size 21 bytes)
         //  - flag (1 byte)
         //  - eth_recipient (20 bytes)
-        // ERC20 transfer input format: max 53 bytes
+        // ERC-20 transfer input format: max 53 bytes
         //  - flag (1 byte)
         //  - amount (32 bytes)
         //  - eth_recipient (20 bytes)
@@ -593,22 +854,18 @@ impl<I: IO> Precompile for ExitToEthereum<I> {
         }
 
         // First byte of the input is a flag, selecting the behavior to be triggered:
-        //      0x0 -> Eth transfer
-        //      0x1 -> Erc20 transfer
+        //  0x00 -> ETH (Base token) token transfer
+        //  0x01 -> ERC-20 transfer
         let mut input = input;
         let flag = input[0];
         input = &input[1..];
-        #[cfg(not(feature = "ext-connector"))]
-        let eth_connector_account_id = self.current_account_id.clone();
-        #[cfg(feature = "ext-connector")]
-        let eth_connector_account_id = get_eth_connector_contract_account(&self.io)?;
 
         let (nep141_address, serialized_args, exit_event) = match flag {
             0x0 => {
-                // ETH transfer
+                // ETH (base) transfer
                 //
                 // Input slice format:
-                //      eth_recipient (20 bytes) - the address of recipient which will receive ETH on Ethereum
+                //  eth_recipient (20 bytes) - the address of recipient which will receive ETH on Ethereum
                 let recipient_address: Address = input
                     .try_into()
                     .map_err(|_| ExitError::Other(Cow::from("ERR_INVALID_RECIPIENT_ADDRESS")))?;
@@ -616,6 +873,8 @@ impl<I: IO> Precompile for ExitToEthereum<I> {
                     WithdrawSerializeType::Json => json_args,
                     WithdrawSerializeType::Borsh => borsh_args,
                 };
+                let eth_connector_account_id = self.get_eth_connector_contract_account()?;
+
                 (
                     eth_connector_account_id,
                     // There is no way to inject json, given the encoding of both arguments
@@ -636,8 +895,8 @@ impl<I: IO> Precompile for ExitToEthereum<I> {
                 // (or burn function with some flag provided that this is expected to be withdrawn)
                 //
                 // Input slice format:
-                //      amount (U256 big-endian bytes) - the amount that was burned
-                //      eth_recipient (20 bytes) - the address of recipient which will receive ETH on Ethereum
+                //  amount (U256 big-endian bytes) - the amount that was burned
+                //  eth_recipient (20 bytes) - the address of recipient which will receive ETH on Ethereum
 
                 if context.apparent_value != U256::from(0) {
                     return Err(ExitError::Other(Cow::from(
@@ -649,9 +908,9 @@ impl<I: IO> Precompile for ExitToEthereum<I> {
                 let nep141_address = get_nep141_from_erc20(erc20_address.as_bytes(), &self.io)?;
 
                 let amount = U256::from_big_endian(&input[..32]);
-                input = &input[32..];
-
                 validate_amount(amount)?;
+
+                input = &input[32..];
 
                 if input.len() == 20 {
                     // Parse ethereum address in hex
@@ -707,15 +966,11 @@ impl<I: IO> Precompile for ExitToEthereum<I> {
             topics: Vec::new(),
             data: promise,
         };
-        let exit_event_log = exit_event.encode();
+        let ethabi::RawLog { topics, data } = exit_event.encode();
         let exit_event_log = Log {
             address: exit_to_ethereum::ADDRESS.raw(),
-            topics: exit_event_log
-                .topics
-                .into_iter()
-                .map(|h| H256::from(h.0))
-                .collect(),
-            data: exit_event_log.data,
+            topics: topics.into_iter().map(|h| H256::from(h.0)).collect(),
+            data,
         };
 
         Ok(PrecompileOutput {
@@ -726,30 +981,15 @@ impl<I: IO> Precompile for ExitToEthereum<I> {
     }
 }
 
-#[allow(clippy::unnecessary_wraps)]
-fn json_args(address: Address, amount: U256) -> Result<Vec<u8>, ExitError> {
-    Ok(format!(
-        r#"{{"amount": "{}", "recipient": "{}"}}"#,
-        amount.as_u128(),
-        address.encode(),
-    )
-    .into_bytes())
-}
-
-fn borsh_args(address: Address, amount: U256) -> Result<Vec<u8>, ExitError> {
-    borsh::to_vec(&WithdrawCallArgs {
-        recipient_address: address,
-        amount: NEP141Wei::new(amount.as_u128()),
-    })
-    .map_err(|_| ExitError::Other(Cow::from("ERR_BORSH_SERIALIZE")))
-}
-
 #[cfg(test)]
 mod tests {
     use super::{
-        exit_to_ethereum, exit_to_near, parse_recipient, validate_amount, validate_input_size,
+        exit_to_ethereum, exit_to_near, parse_input, parse_recipient, validate_amount,
+        validate_input_size, BaseTokenParams, Erc20TokenParams, ExitToNearParams, Message,
     };
     use crate::{native::Recipient, prelude::sdk::types::near_account_to_evm_address};
+    #[cfg(feature = "error_refund")]
+    use aurora_engine_types::types::Address;
     use aurora_engine_types::U256;
 
     #[test]
@@ -830,7 +1070,21 @@ mod tests {
             parse_recipient(b"test.near:unwrap").unwrap(),
             Recipient {
                 receiver_account_id: "test.near".parse().unwrap(),
-                message: Some("unwrap"),
+                message: Some(Message::UnwrapWnear),
+            }
+        );
+
+        assert_eq!(
+            parse_recipient(
+                b"e523efec9b66c4c8f6e708f1cf56be1399181e5b7c1e35f845670429faf143c2:unwrap"
+            )
+            .unwrap(),
+            Recipient {
+                receiver_account_id:
+                    "e523efec9b66c4c8f6e708f1cf56be1399181e5b7c1e35f845670429faf143c2"
+                        .parse()
+                        .unwrap(),
+                message: Some(Message::UnwrapWnear),
             }
         );
 
@@ -838,7 +1092,7 @@ mod tests {
             parse_recipient(b"test.near:some_msg:with_extra_colon").unwrap(),
             Recipient {
                 receiver_account_id: "test.near".parse().unwrap(),
-                message: Some("some_msg:with_extra_colon"),
+                message: Some(Message::Omni("some_msg:with_extra_colon")),
             }
         );
 
@@ -846,7 +1100,7 @@ mod tests {
             parse_recipient(b"test.near:").unwrap(),
             Recipient {
                 receiver_account_id: "test.near".parse().unwrap(),
-                message: Some(""),
+                message: Some(Message::Omni("")),
             }
         );
     }
@@ -856,5 +1110,145 @@ mod tests {
         assert!(parse_recipient(b"test@.near").is_err());
         assert!(parse_recipient(b"test@.near:msg").is_err());
         assert!(parse_recipient(&[0xc2]).is_err());
+    }
+
+    #[test]
+    fn test_parse_input() {
+        #[cfg(feature = "error_refund")]
+        let refund_address = Address::zero();
+        let amount = U256::from(100);
+        let input = [
+            &[1],
+            #[cfg(feature = "error_refund")]
+            refund_address.as_bytes(),
+            amount.to_big_endian().as_slice(),
+            b"test.near",
+        ]
+        .concat();
+        assert!(parse_input(&input).is_ok());
+
+        let input = [
+            &[0],
+            #[cfg(feature = "error_refund")]
+            refund_address.as_bytes(),
+            b"test.near:unwrap".as_slice(),
+        ]
+        .concat();
+        assert!(parse_input(&input).is_ok());
+
+        let input = [
+            &[1],
+            #[cfg(feature = "error_refund")]
+            refund_address.as_bytes(),
+            amount.to_big_endian().as_slice(),
+            b"e523efec9b66c4c8f6e708f1cf56be1399181e5b7c1e35f845670429faf143c2:unwrap",
+        ]
+        .concat();
+        assert!(parse_input(&input).is_ok());
+
+        let input = [
+            &[1], // flag
+            #[cfg(feature = "error_refund")]
+            refund_address.as_bytes(),
+            amount.to_big_endian().as_slice(), // amount
+            b"e523efec9b66c4c8f6e708f1cf56be1399181e5b7c1e35f845670429faf143c2:unwrap",
+        ]
+        .concat();
+        assert!(parse_input(&input).is_ok());
+    }
+
+    #[test]
+    fn test_parse_exit_to_near_params() {
+        let amount = U256::from(100);
+        #[cfg(feature = "error_refund")]
+        let refund_address = Address::from_array([1; 20]);
+
+        let input = [
+            &[0u8],
+            #[cfg(feature = "error_refund")]
+            refund_address.as_bytes(),
+            b"test.near".as_slice(),
+        ]
+        .concat();
+
+        let params = ExitToNearParams::try_from(input.as_slice()).unwrap();
+        assert_eq!(
+            params,
+            ExitToNearParams::BaseToken(BaseTokenParams {
+                #[cfg(feature = "error_refund")]
+                refund_address,
+                receiver_account_id: "test.near".parse().unwrap(),
+                message: None,
+            })
+        );
+
+        let input = [
+            &[1],
+            #[cfg(feature = "error_refund")]
+            refund_address.as_bytes(),
+            amount.to_big_endian().as_slice(),
+            b"test.near:unwrap",
+        ]
+        .concat();
+        let params = ExitToNearParams::try_from(input.as_slice()).unwrap();
+        assert_eq!(
+            params,
+            ExitToNearParams::Erc20TokenParams(Erc20TokenParams {
+                #[cfg(feature = "error_refund")]
+                refund_address,
+                receiver_account_id: "test.near".parse().unwrap(),
+                amount,
+                message: Some(Message::UnwrapWnear),
+            })
+        );
+
+        let input = [
+            &[1],
+            #[cfg(feature = "error_refund")]
+            refund_address.as_bytes(),
+            amount.to_big_endian().as_slice(),
+            b"e523efec9b66c4c8f6e708f1cf56be1399181e5b7c1e35f845670429faf143c2:unwrap",
+        ]
+        .concat();
+        let params = ExitToNearParams::try_from(input.as_slice()).unwrap();
+        assert_eq!(
+            params,
+            ExitToNearParams::Erc20TokenParams(Erc20TokenParams {
+                #[cfg(feature = "error_refund")]
+                refund_address,
+                receiver_account_id:
+                    "e523efec9b66c4c8f6e708f1cf56be1399181e5b7c1e35f845670429faf143c2"
+                        .parse()
+                        .unwrap(),
+                amount,
+                message: Some(Message::UnwrapWnear),
+            })
+        );
+
+        let input = [
+            &[1], // flag
+            #[cfg(feature = "error_refund")]
+            refund_address.as_bytes(),
+            amount.to_big_endian().as_slice(), // amount
+            b"e523efec9b66c4c8f6e708f1cf56be1399181e5b7c1e35f845670429faf143c2",
+            b":",
+            "{\\\"recipient\\\":\\\"eth:013fe02fb1470d0f4ff072f40960658c4ec8139a\\\",\\\"fee\\\":\\\"0\\\",\\\"native_token_fee\\\":\\\"0\\\"}".as_bytes(),
+        ]
+        .concat();
+        dbg!(input.len());
+        let params = ExitToNearParams::try_from(input.as_slice()).unwrap();
+        assert_eq!(
+            params,
+            ExitToNearParams::Erc20TokenParams(Erc20TokenParams {
+                #[cfg(feature = "error_refund")]
+                refund_address,
+                receiver_account_id:
+                    "e523efec9b66c4c8f6e708f1cf56be1399181e5b7c1e35f845670429faf143c2"
+                        .parse()
+                        .unwrap(),
+                amount,
+                message: Some(Message::Omni("{\\\"recipient\\\":\\\"eth:013fe02fb1470d0f4ff072f40960658c4ec8139a\\\",\\\"fee\\\":\\\"0\\\",\\\"native_token_fee\\\":\\\"0\\\"}")),
+            })
+        );
     }
 }

--- a/engine-tests/src/tests/erc20_mirror.rs
+++ b/engine-tests/src/tests/erc20_mirror.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::too_many_lines)]
 use crate::prelude::U256;
 use crate::tests::erc20_connector::workspace::{erc20_balance, exit_to_near};
 use crate::utils::workspace::{
@@ -9,7 +10,7 @@ use aurora_engine_types::parameters::connector::{
     Erc20Identifier, Erc20Metadata, MirrorErc20TokenArgs, SetErc20MetadataArgs,
     WithdrawSerializeType,
 };
-use aurora_engine_types::parameters::silo::SiloParamsArgs;
+use aurora_engine_types::parameters::silo::{SiloParamsArgs, WhitelistKind, WhitelistStatusArgs};
 use aurora_engine_workspace::account::Account;
 use aurora_engine_workspace::types::NearToken;
 use aurora_engine_workspace::{EngineContract, RawContract};
@@ -18,7 +19,6 @@ const AURORA_VERSION: &str = include_str!("../../../VERSION");
 const TRANSFER_AMOUNT: u128 = 1000;
 
 #[tokio::test]
-#[allow(clippy::too_many_lines)]
 async fn test_mirroring_erc20_token() {
     let main_contract = deploy_main_contract().await;
     let silo_contract = deploy_silo_contract(&main_contract).await;
@@ -166,6 +166,139 @@ async fn test_mirroring_erc20_token() {
         0.into()
     );
     assert_eq!(nep_141_balance_of(&nep141, &ft_owner.id()).await, 1_000_000);
+}
+
+// The goal of the test is to demonstrate that the new logic of the `exit_to_near` precompile allows
+// to transfer ERC-20 tokens between Aurora Engine contracts, including Silos.
+#[tokio::test]
+async fn test_transfer_from_silo_to_silo() {
+    let main_contract = deploy_main_contract().await;
+    let silo_contract = deploy_silo_contract(&main_contract).await;
+    let (nep141, ft_owner) = deploy_nep141(&main_contract).await;
+    let erc20 = deploy_erc20_from_nep_141(nep141.id().as_ref(), &main_contract)
+        .await
+        .unwrap();
+    let erc20_metadata = Erc20Metadata {
+        name: "USD Tether".to_string(),
+        symbol: "USDT".to_string(),
+        decimals: 18,
+    };
+
+    // Set ERC-20 metadata.
+    let result = main_contract
+        .set_erc20_metadata(SetErc20MetadataArgs {
+            erc20_identifier: Erc20Identifier::Erc20 {
+                address: erc20.0.address,
+            },
+            metadata: erc20_metadata.clone(),
+        })
+        .max_gas()
+        .transact()
+        .await
+        .unwrap();
+    assert!(result.is_success());
+
+    // Turn on silo mode by setting default params.
+    let result = silo_contract
+        .set_silo_params(Some(SiloParamsArgs::default()))
+        .max_gas()
+        .transact()
+        .await
+        .unwrap();
+    assert!(result.is_success());
+
+    // Should get ERC-20 address of mirrored contract.
+    let result = silo_contract
+        .mirror_erc20_token(MirrorErc20TokenArgs {
+            contract_id: main_contract.id(),
+            nep141: nep141.id(),
+        })
+        .max_gas()
+        .transact()
+        .await;
+    let erc20_address = result.unwrap().into_value();
+    assert_eq!(erc20_address, erc20.0.address);
+
+    // Disable whitelist Address to disable check if the addresses allow to receive tokens
+    // from outside.
+    let result = silo_contract
+        .set_whitelist_status(WhitelistStatusArgs {
+            kind: WhitelistKind::Address,
+            active: false,
+        })
+        .max_gas()
+        .transact()
+        .await
+        .unwrap();
+    assert!(result.is_success());
+
+    let silo_erc20_metadata = silo_contract
+        .get_erc20_metadata(Erc20Identifier::Erc20 {
+            address: erc20_address,
+        })
+        .await
+        .unwrap()
+        .result;
+    assert_eq!(silo_erc20_metadata, erc20_metadata);
+
+    // We need to storage_deposit to register account id of the silo contract in the nep-141.
+    let result = silo_contract
+        .root()
+        .call(&nep141.id(), "storage_deposit")
+        .args_json(serde_json::json!({
+            "account_id": silo_contract.id(),
+        }))
+        .deposit(NearToken::from_near(2))
+        .transact()
+        .await
+        .unwrap();
+    assert!(result.is_success());
+
+    assert_eq!(nep_141_balance_of(&nep141, &ft_owner.id()).await, 1_000_000);
+
+    let address = aurora_engine_sdk::types::near_account_to_evm_address(ft_owner.id().as_bytes());
+    // Deposit address `address` via ft_transfer_call.
+    let result = ft_owner
+        .call(&nep141.id(), "ft_transfer_call")
+        .args_json(serde_json::json!({
+            "receiver_id": main_contract.id(),
+            "amount": TRANSFER_AMOUNT.to_string(),
+            "msg": address.encode(),
+        }))
+        .max_gas()
+        .deposit(NearToken::from_yoctonear(1))
+        .transact()
+        .await
+        .unwrap();
+    assert!(result.is_success());
+
+    assert_eq!(
+        erc20_balance(&erc20, address, &main_contract).await,
+        TRANSFER_AMOUNT.into()
+    );
+
+    let dst = format!("{}:{}", silo_contract.id().as_ref(), address.encode());
+    let withdraw_amount = 100;
+    let result = exit_to_near(&ft_owner, &dst, withdraw_amount, &erc20, &main_contract).await;
+    assert!(result.is_success());
+
+    assert_eq!(
+        nep_141_balance_of(&nep141, &main_contract.id()).await,
+        TRANSFER_AMOUNT - withdraw_amount
+    );
+    assert_eq!(
+        erc20_balance(&erc20, address, &main_contract).await,
+        (TRANSFER_AMOUNT - withdraw_amount).into()
+    );
+
+    assert_eq!(
+        nep_141_balance_of(&nep141, &silo_contract.id()).await,
+        withdraw_amount
+    );
+    assert_eq!(
+        erc20_balance(&erc20, address, &silo_contract).await,
+        withdraw_amount.into()
+    );
 }
 
 async fn deploy_main_contract() -> EngineContract {

--- a/engine-tests/src/tests/sanity.rs
+++ b/engine-tests/src/tests/sanity.rs
@@ -303,7 +303,7 @@ fn test_deploy_largest_contract() {
     );
 
     // Less than 12 NEAR Tgas
-    utils::assert_gas_bound(profile.all_gas(), 11);
+    utils::assert_gas_bound(profile.all_gas(), 12);
 }
 
 #[test]

--- a/engine-types/src/types/mod.rs
+++ b/engine-types/src/types/mod.rs
@@ -31,9 +31,9 @@ pub const ERC20_NAME_SELECTOR: &[u8] = &[6, 253, 222, 3];
 /// Selector to call `symbol` function in ERC-20 contact.
 /// `keccak(b"symbol()")[..4];`
 pub const ERC20_SYMBOL_SELECTOR: &[u8] = &[149, 216, 155, 65];
-/// Selector to call `digits` function in ERC-20 contact.
-/// `keccak(b"digits()")[..4];`
-pub const ERC20_DIGITS_SELECTOR: &[u8] = &[49, 60, 229, 103];
+/// Selector to call `decimals` function in ERC-20 contact.
+/// `keccak(b"decimals()")[..4];`
+pub const ERC20_DECIMALS_SELECTOR: &[u8] = &[49, 60, 229, 103];
 
 #[derive(Debug)]
 pub enum AddressValidationError {

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -30,7 +30,7 @@ use crate::prelude::transactions::{EthTransactionKind, NormalizedEthTransaction}
 use crate::prelude::{
     address_to_key, bytes_to_key, format, sdk, storage_to_key, u256_to_arr, vec, AccountId,
     Address, BTreeMap, BorshDeserialize, Cow, KeyPrefix, PromiseArgs, PromiseCreateArgs, String,
-    Vec, Wei, Yocto, ERC20_DIGITS_SELECTOR, ERC20_MINT_SELECTOR, ERC20_NAME_SELECTOR,
+    Vec, Wei, Yocto, ERC20_DECIMALS_SELECTOR, ERC20_MINT_SELECTOR, ERC20_NAME_SELECTOR,
     ERC20_SET_METADATA_SELECTOR, ERC20_SYMBOL_SELECTOR, H160, H256, U256,
 };
 use crate::state::EngineState;
@@ -776,7 +776,7 @@ impl<'env, I: IO + Copy, E: Env, M: ModExpAlgorithm> Engine<'env, I, E, M> {
         // Parse message to determine recipient
         let mut recipient = {
             // Message format:
-            //      Recipient of the transaction - 40 characters (Address in hex)
+            // Recipient of the transaction - 40 characters (Address in hex)
             let message = args.msg.as_bytes();
             if message.len() < 40 {
                 return Err(engine_err(INVALID_MESSAGE));
@@ -853,7 +853,7 @@ impl<'env, I: IO + Copy, E: Env, M: ModExpAlgorithm> Engine<'env, I, E, M> {
         let decimals = self
             .view_with_selector(
                 erc20_address,
-                ERC20_DIGITS_SELECTOR,
+                ERC20_DECIMALS_SELECTOR,
                 &[ethabi::ParamType::Uint(8)],
             )?
             .into_uint()


### PR DESCRIPTION
## Description

The PR introduces changes to the `exitToNear` precompile, which allows the withdrawal of tokens via the OMNI bridge.

## Performance / NEAR gas cost considerations

There is no performance changes.

## Testing

Added tests for parsing new type of incoming arguments.

