### PR TITLE
chore: move ecrecover implementation to aurora-engine-sdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,6 @@ dependencies = [
  "ethabi",
  "evm",
  "hex",
- "libsecp256k1",
  "num",
  "rand 0.8.5",
  "ripemd",
@@ -346,6 +345,8 @@ version = "1.0.0"
 dependencies = [
  "aurora-engine-types",
  "base64 0.22.1",
+ "hex",
+ "libsecp256k1",
  "sha2 0.10.8",
  "sha3",
 ]
@@ -424,7 +425,6 @@ dependencies = [
 name = "aurora-engine-transactions"
 version = "1.0.0"
 dependencies = [
- "aurora-engine-precompiles",
  "aurora-engine-sdk",
  "aurora-engine-types",
  "evm",
@@ -853,9 +853,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.12"
+version = "1.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755717a7de9ec452bf7f3f1a3099085deabd7f2962b861dae91ecd7a365903d2"
+checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
 dependencies = [
  "jobserver",
  "libc",
@@ -997,6 +997,26 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "const_format"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -3623,9 +3643,9 @@ checksum = "b41a159cbf732acc0279febdde046d9036330a32a951796bce42f9529bce799d"
 
 [[package]]
 name = "near-sdk"
-version = "5.7.1"
+version = "5.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "988ce7b12a80883dc8b9a48441355c9b67320692ee460c1f693b5937d8169e3c"
+checksum = "1204ba6a2cfa37f6d644a5ef77067b7a049ea739861841c156c95625ffc52aee"
 dependencies = [
  "base64 0.22.1",
  "borsh 1.5.5",
@@ -3643,9 +3663,9 @@ dependencies = [
 
 [[package]]
 name = "near-sdk-macros"
-version = "5.7.1"
+version = "5.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d080babc80823326f71514e2e7a947d5fec433b93e868bb3899361cecc56f198"
+checksum = "45b43a1f6abf714ddbd9792b6b27d7b1e8ad2d3d35c352d61c3c73b2e786af85"
 dependencies = [
  "Inflector",
  "darling",
@@ -4074,9 +4094,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "oorandom"
@@ -4228,28 +4248,30 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.12"
+version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
+checksum = "c9fde3d0718baf5bc92f577d652001da0f8d54cd03a7974e118d04fc888dc23d"
 dependencies = [
  "arrayvec",
  "bitvec",
  "byte-slice-cast",
+ "const_format",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
+ "rustversion",
  "serde",
 ]
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.12"
+version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
+checksum = "581c837bb6b9541ce7faa9377c20616e4fb7650f6b0f68bc93c827ee504fb7b3"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4701,7 +4723,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.0",
- "zerocopy 0.8.16",
+ "zerocopy 0.8.17",
 ]
 
 [[package]]
@@ -4741,7 +4763,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
 dependencies = [
  "getrandom 0.3.1",
- "zerocopy 0.8.16",
+ "zerocopy 0.8.17",
 ]
 
 [[package]]
@@ -6194,6 +6216,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7098,9 +7126,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86e376c75f4f43f44db463cf729e0d3acbf954d13e22c51e26e4c264b4ab545f"
+checksum = "59690dea168f2198d1a3b0cac23b8063efcd11012f10ae4698f284808c8ef603"
 dependencies = [
  "memchr",
 ]
@@ -7182,11 +7210,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b8c07a70861ce02bad1607b5753ecb2501f67847b9f9ada7c160fff0ec6300c"
+checksum = "aa91407dacce3a68c56de03abe2760159582b846c6a4acd2f456618087f12713"
 dependencies = [
- "zerocopy-derive 0.8.16",
+ "zerocopy-derive 0.8.17",
 ]
 
 [[package]]
@@ -7202,9 +7230,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5226bc9a9a9836e7428936cde76bb6b22feea1a8bfdbc0d241136e4d13417e25"
+checksum = "06718a168365cad3d5ff0bb133aad346959a2074bd4a85c121255a11304a8626"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,6 @@ missing_panics_doc = "allow"
 module_name_repetitions = "allow"
 unreadable_literal = "allow"
 similar_names = "allow"
-too_long_first_doc_paragraph = "allow"
 
 [workspace]
 resolver = "2"

--- a/engine-precompiles/Cargo.toml
+++ b/engine-precompiles/Cargo.toml
@@ -18,7 +18,6 @@ bn.workspace = true
 ethabi.workspace = true
 evm.workspace = true
 hex.workspace = true
-libsecp256k1 = { workspace = true, features = ["static-context", "hmac"] }
 num.workspace = true
 ripemd.workspace = true
 sha2.workspace = true
@@ -33,7 +32,7 @@ workspace = true
 
 [features]
 default = ["std"]
-std = ["aurora-engine-types/std", "aurora-engine-sdk/std", "bn/std", "evm/std", "libsecp256k1/std", "ripemd/std", "sha2/std", "sha3/std", "ethabi/std"]
+std = ["aurora-engine-types/std", "aurora-engine-sdk/std", "bn/std", "evm/std", "ripemd/std", "sha2/std", "sha3/std", "ethabi/std"]
 contract = ["aurora-engine-sdk/contract"]
 log = []
 error_refund = []

--- a/engine-sdk/Cargo.toml
+++ b/engine-sdk/Cargo.toml
@@ -13,14 +13,18 @@ autobenches = false
 [dependencies]
 aurora-engine-types.workspace = true
 base64.workspace = true
+libsecp256k1 = { workspace = true, features = ["static-context", "hmac"] }
 sha2.workspace = true
 sha3.workspace = true
+
+[dev-dependencies]
+hex.workspace = true
 
 [lints]
 workspace = true
 
 [features]
-std = ["aurora-engine-types/std", "sha3/std", "sha2/std", "base64/std"]
+std = ["aurora-engine-types/std", "libsecp256k1/std", "sha3/std", "sha2/std", "base64/std"]
 contract = []
 log = []
 all-promise-actions = []

--- a/engine-sdk/src/lib.rs
+++ b/engine-sdk/src/lib.rs
@@ -2,9 +2,9 @@
 // All `as` conversions in this code base have been carefully reviewed and are safe.
 #![allow(clippy::as_conversions)]
 
+use crate::prelude::{Address, H256, STORAGE_PRICE_PER_BYTE};
 #[cfg(feature = "contract")]
-use crate::prelude::{Address, Vec, U256};
-use crate::prelude::{H256, STORAGE_PRICE_PER_BYTE};
+use crate::prelude::{Vec, U256};
 pub use types::keccak;
 
 pub mod base64;
@@ -181,6 +181,29 @@ pub fn ecrecover(hash: H256, signature: &[u8]) -> Result<Address, ECRecoverErr> 
     }
 }
 
+#[cfg(not(feature = "contract"))]
+pub fn ecrecover(hash: H256, signature: &[u8]) -> Result<Address, ECRecoverErr> {
+    use sha3::Digest;
+
+    let hash = libsecp256k1::Message::parse_slice(hash.as_bytes()).map_err(|_| ECRecoverErr)?;
+    let v = signature[64];
+    let signature = libsecp256k1::Signature::parse_standard_slice(&signature[0..64])
+        .map_err(|_| ECRecoverErr)?;
+    let bit = match v {
+        0..=26 => v,
+        _ => v - 27,
+    };
+    let recovery_id = libsecp256k1::RecoveryId::parse(bit).map_err(|_| ECRecoverErr)?;
+
+    libsecp256k1::recover(&hash, &signature, &recovery_id)
+        .map_err(|_| ECRecoverErr)
+        .and_then(|public_key| {
+            // recover returns a 65-byte key, but addresses come from the raw 64-byte key
+            let r = sha3::Keccak256::digest(&public_key.serialize()[1..]);
+            Address::try_from_slice(&r[12..]).map_err(|_| ECRecoverErr)
+        })
+}
+
 #[cfg(feature = "contract")]
 pub fn log(data: &str) {
     log_utf8(data.as_bytes());
@@ -217,5 +240,34 @@ impl ECRecoverErr {
 impl AsRef<[u8]> for ECRecoverErr {
     fn as_ref(&self) -> &[u8] {
         self.as_str().as_bytes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aurora_engine_types::types::Address;
+    use aurora_engine_types::H256;
+
+    const SIGNATURE_LENGTH: usize = 65;
+
+    fn ecverify(hash: H256, signature: &[u8], signer: Address) -> bool {
+        matches!(ecrecover(hash, signature[0..SIGNATURE_LENGTH].try_into().unwrap()), Ok(s) if s == signer)
+    }
+
+    #[test]
+    fn test_ecverify() {
+        let hash = H256::from_slice(
+            &hex::decode("1111111111111111111111111111111111111111111111111111111111111111")
+                .unwrap(),
+        );
+        let signature =
+            &hex::decode("b9f0bb08640d3c1c00761cdd0121209268f6fd3816bc98b9e6f3cc77bf82b69812ac7a61788a0fdc0e19180f14c945a8e1088a27d92a74dce81c0981fb6447441b")
+                .unwrap();
+        let signer = Address::try_from_slice(
+            &hex::decode("1563915e194D8CfBA1943570603F7606A3115508").unwrap(),
+        )
+        .unwrap();
+        assert!(ecverify(hash, signature, signer));
     }
 }

--- a/engine-tests/src/tests/uniswap.rs
+++ b/engine-tests/src/tests/uniswap.rs
@@ -39,7 +39,7 @@ fn test_uniswap_input_multihop() {
 
     let (_amount_out, _evm_gas, profile) = context.exact_input(&tokens, INPUT_AMOUNT.into());
 
-    assert_eq!(107, profile.all_gas() / 1_000_000_000_000);
+    assert_eq!(108, profile.all_gas() / 1_000_000_000_000);
 }
 
 #[test]

--- a/engine-tests/src/tests/uniswap.rs
+++ b/engine-tests/src/tests/uniswap.rs
@@ -39,7 +39,7 @@ fn test_uniswap_input_multihop() {
 
     let (_amount_out, _evm_gas, profile) = context.exact_input(&tokens, INPUT_AMOUNT.into());
 
-    assert_eq!(108, profile.all_gas() / 1_000_000_000_000);
+    assert_eq!(107, profile.all_gas() / 1_000_000_000_000);
 }
 
 #[test]

--- a/engine-transactions/Cargo.toml
+++ b/engine-transactions/Cargo.toml
@@ -11,7 +11,6 @@ publish.workspace = true
 autobenches = false
 
 [dependencies]
-aurora-engine-precompiles.workspace = true
 aurora-engine-sdk.workspace = true
 aurora-engine-types.workspace = true
 evm.workspace = true
@@ -25,6 +24,6 @@ hex.workspace = true
 workspace = true
 
 [features]
-std = ["aurora-engine-types/std", "aurora-engine-sdk/std", "aurora-engine-precompiles/std", "evm/std", "rlp/std"]
+std = ["aurora-engine-types/std", "aurora-engine-sdk/std", "evm/std", "rlp/std"]
 impl-serde = ["aurora-engine-types/impl-serde", "serde"]
-contract = ["aurora-engine-sdk/contract", "aurora-engine-precompiles/contract"]
+contract = ["aurora-engine-sdk/contract"]

--- a/engine-transactions/src/eip_1559.rs
+++ b/engine-transactions/src/eip_1559.rs
@@ -1,6 +1,6 @@
 use crate::eip_2930::AccessTuple;
 use crate::Error;
-use aurora_engine_precompiles::secp256k1::ecrecover;
+use aurora_engine_sdk as sdk;
 use aurora_engine_types::types::{Address, Wei};
 use aurora_engine_types::{Vec, U256};
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
@@ -87,11 +87,11 @@ impl SignedTransaction1559 {
         rlp_stream.append(&TYPE_BYTE);
         self.transaction.rlp_append_unsigned(&mut rlp_stream);
         let message_hash = aurora_engine_sdk::keccak(rlp_stream.as_raw());
-        ecrecover(
+        sdk::ecrecover(
             message_hash,
             &super::vrs_to_arr(self.parity, self.r, self.s),
         )
-        .map_err(|_e| Error::EcRecover)
+        .map_err(|_| Error::EcRecover)
     }
 }
 

--- a/engine-transactions/src/eip_2930.rs
+++ b/engine-transactions/src/eip_2930.rs
@@ -1,5 +1,4 @@
 use crate::Error;
-use aurora_engine_precompiles::secp256k1::ecrecover;
 use aurora_engine_sdk as sdk;
 use aurora_engine_types::types::{Address, Wei};
 use aurora_engine_types::{Vec, H160, H256, U256};
@@ -101,11 +100,11 @@ impl SignedTransaction2930 {
         rlp_stream.append(&TYPE_BYTE);
         self.transaction.rlp_append_unsigned(&mut rlp_stream);
         let message_hash = sdk::keccak(rlp_stream.as_raw());
-        ecrecover(
+        sdk::ecrecover(
             message_hash,
             &super::vrs_to_arr(self.parity, self.r, self.s),
         )
-        .map_err(|_e| Error::EcRecover)
+        .map_err(|_| Error::EcRecover)
     }
 }
 

--- a/engine-transactions/src/legacy.rs
+++ b/engine-transactions/src/legacy.rs
@@ -1,5 +1,4 @@
 use crate::Error;
-use aurora_engine_precompiles::secp256k1::ecrecover;
 use aurora_engine_sdk as sdk;
 use aurora_engine_types::types::{Address, Wei};
 use aurora_engine_types::{Vec, U256};
@@ -79,8 +78,8 @@ impl LegacyEthSignedTransaction {
         self.transaction
             .rlp_append_unsigned(&mut rlp_stream, chain_id);
         let message_hash = sdk::keccak(rlp_stream.as_raw());
-        ecrecover(message_hash, &super::vrs_to_arr(rec_id, self.r, self.s))
-            .map_err(|_e| Error::EcRecover)
+        sdk::ecrecover(message_hash, &super::vrs_to_arr(rec_id, self.r, self.s))
+            .map_err(|_| Error::EcRecover)
     }
 
     /// Returns chain id encoded in `v` parameter of the signature if that was done, otherwise None.


### PR DESCRIPTION
## Description

The PR moves the `ecrecover` implementation for not contract build (engine-standalone) to the `aurora-engine-sdk` crate. This change allows us to get rid of the `aurora-engine-precompiles` dependency in the `aurora-engine-transactions` crate. 

## Performance / NEAR gas cost considerations

No performance chaanges.

## Testing

Use existing tests.
