### PR TITLE
feat: rework the logic related to the silo mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changes
+
+- Reworked the logic related to the silo mode by [@aleksuss]. ([#1005])
+
+[#1005]: https://github.com/aurora-is-near/aurora-engine/pull/1005
+
 ## [3.8.0] 2025-02-05
 
 ### Changes

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -87,6 +87,7 @@ category = "Check"
 command = "${CARGO}"
 args = [
     "clippy",
+    "--workspace",
     "--all-targets",
     "--",
     "-D",
@@ -99,6 +100,7 @@ args = [
 extend = "clippy-base"
 args = [
     "clippy",
+    "--workspace",
     "--all-targets",
     "--features",
     "ext-connector",
@@ -113,6 +115,7 @@ args = [
 extend = "clippy-base"
 args = [
     "clippy",
+    "--workspace",
     "--all-targets",
     "--features",
     "contract",
@@ -127,6 +130,7 @@ args = [
 extend = "clippy-base"
 args = [
     "clippy",
+    "--workspace",
     "--all-targets",
     "--features",
     "contract,error_refund",

--- a/engine-standalone-storage/src/sync/mod.rs
+++ b/engine-standalone-storage/src/sync/mod.rs
@@ -248,6 +248,11 @@ pub fn parse_transaction_kind(
             let args = silo_params::WhitelistStatusArgs::try_from_slice(&bytes).map_err(f)?;
             TransactionKind::SetWhitelistStatus(args)
         }
+        TransactionKindTag::SetWhitelistsStatuses => {
+            let args: Vec<silo_params::WhitelistStatusArgs> =
+                BorshDeserialize::try_from_slice(&bytes).map_err(f)?;
+            TransactionKind::SetWhitelistsStatuses(args)
+        }
         TransactionKindTag::AddEntryToWhitelist => {
             let args = silo_params::WhitelistArgs::try_from_slice(&bytes).map_err(f)?;
             TransactionKind::AddEntryToWhitelist(args)
@@ -749,6 +754,10 @@ fn non_submit_execute<I: IO + Copy>(
         }
         TransactionKind::SetWhitelistStatus(args) => {
             silo::set_whitelist_status(&io, args);
+            None
+        }
+        TransactionKind::SetWhitelistsStatuses(args) => {
+            silo::set_whitelists_statuses(&io, args.clone());
             None
         }
         TransactionKind::MirrorErc20TokenCallback(_) => {

--- a/engine-standalone-storage/src/sync/types.rs
+++ b/engine-standalone-storage/src/sync/types.rs
@@ -172,6 +172,7 @@ pub enum TransactionKind {
     AddEntryToWhitelistBatch(Vec<silo::WhitelistArgs>),
     RemoveEntryFromWhitelist(silo::WhitelistArgs),
     SetWhitelistStatus(silo::WhitelistStatusArgs),
+    SetWhitelistsStatuses(Vec<silo::WhitelistStatusArgs>),
     /// Callback which mirrors existed ERC-20 contract deployed on the main contract.
     MirrorErc20TokenCallback(parameters::MirrorErc20TokenArgs),
     /// Sentinel kind for cases where a NEAR receipt caused a
@@ -453,6 +454,7 @@ impl TransactionKind {
                 Self::no_evm_execution("remove_entry_from_whitelist")
             }
             Self::SetWhitelistStatus(_) => Self::no_evm_execution("set_whitelist_status"),
+            Self::SetWhitelistsStatuses(_) => Self::no_evm_execution("set_whitelists_statuses"),
             Self::MirrorErc20TokenCallback(_) => {
                 Self::no_evm_execution("mirror_erc20_token_callback")
             }
@@ -579,6 +581,8 @@ pub enum TransactionKindTag {
     SetSiloParams,
     #[strum(serialize = "set_whitelist_status")]
     SetWhitelistStatus,
+    #[strum(serialize = "set_whitelists_statuses")]
+    SetWhitelistsStatuses,
     #[strum(serialize = "add_entry_to_whitelist")]
     AddEntryToWhitelist,
     #[strum(serialize = "add_entry_to_whitelist_batch")]
@@ -642,6 +646,7 @@ impl TransactionKind {
             }
             Self::AddEntryToWhitelistBatch(args) => to_borsh(args),
             Self::SetWhitelistStatus(args) => to_borsh(args),
+            Self::SetWhitelistsStatuses(args) => to_borsh(args),
             Self::SetEthConnectorContractAccount(args) => to_borsh(args),
             Self::MirrorErc20TokenCallback(args) => to_borsh(args),
         }
@@ -707,6 +712,7 @@ impl From<&TransactionKind> for TransactionKindTag {
             TransactionKind::AddEntryToWhitelistBatch(_) => Self::AddEntryToWhitelistBatch,
             TransactionKind::RemoveEntryFromWhitelist(_) => Self::RemoveEntryFromWhitelist,
             TransactionKind::SetWhitelistStatus(_) => Self::SetWhitelistStatus,
+            TransactionKind::SetWhitelistsStatuses(_) => Self::SetWhitelistsStatuses,
             TransactionKind::Unknown => Self::Unknown,
             TransactionKind::MirrorErc20TokenCallback(_) => Self::MirrorErc20TokenCallback,
         }
@@ -940,6 +946,7 @@ enum BorshableTransactionKind<'a> {
     MirrorErc20TokenCallback(Cow<'a, parameters::MirrorErc20TokenArgs>),
     WithdrawWnearToRouter(Cow<'a, WithdrawWnearToRouterArgs>),
     StoreRelayerKeyCallback(Cow<'a, parameters::RelayerKeyArgs>),
+    SetWhitelistsStatuses(Cow<'a, Vec<silo::WhitelistStatusArgs>>),
 }
 
 impl<'a> From<&'a TransactionKind> for BorshableTransactionKind<'a> {
@@ -1014,6 +1021,9 @@ impl<'a> From<&'a TransactionKind> for BorshableTransactionKind<'a> {
             TransactionKind::SetWhitelistStatus(x) => Self::SetWhitelistStatus(Cow::Borrowed(x)),
             TransactionKind::MirrorErc20TokenCallback(x) => {
                 Self::MirrorErc20TokenCallback(Cow::Borrowed(x))
+            }
+            TransactionKind::SetWhitelistsStatuses(x) => {
+                Self::SetWhitelistsStatuses(Cow::Borrowed(x))
             }
         }
     }
@@ -1116,6 +1126,9 @@ impl<'a> TryFrom<BorshableTransactionKind<'a>> for TransactionKind {
             }
             BorshableTransactionKind::WithdrawWnearToRouter(x) => {
                 Ok(Self::WithdrawWnearToRouter(x.into_owned()))
+            }
+            BorshableTransactionKind::SetWhitelistsStatuses(x) => {
+                Ok(Self::SetWhitelistsStatuses(x.into_owned()))
             }
         }
     }

--- a/engine-tests/src/tests/erc20_mirror.rs
+++ b/engine-tests/src/tests/erc20_mirror.rs
@@ -10,7 +10,6 @@ use aurora_engine_types::parameters::connector::{
     Erc20Identifier, Erc20Metadata, MirrorErc20TokenArgs, SetErc20MetadataArgs,
     WithdrawSerializeType,
 };
-use aurora_engine_types::parameters::silo::{SiloParamsArgs, WhitelistKind, WhitelistStatusArgs};
 use aurora_engine_workspace::account::Account;
 use aurora_engine_workspace::types::NearToken;
 use aurora_engine_workspace::{EngineContract, RawContract};
@@ -40,26 +39,6 @@ async fn test_mirroring_erc20_token() {
             },
             metadata: erc20_metadata.clone(),
         })
-        .max_gas()
-        .transact()
-        .await
-        .unwrap();
-    assert!(result.is_success());
-
-    // Try to mirror ERC-20 with silo mode off.
-    let result = silo_contract
-        .mirror_erc20_token(MirrorErc20TokenArgs {
-            contract_id: main_contract.id(),
-            nep141: nep141.id(),
-        })
-        .max_gas()
-        .transact()
-        .await;
-    assert!(result.is_err());
-
-    // Turn on silo mode by setting default params.
-    let result = silo_contract
-        .set_silo_params(Some(SiloParamsArgs::default()))
         .max_gas()
         .transact()
         .await
@@ -198,15 +177,6 @@ async fn test_transfer_from_silo_to_silo() {
         .unwrap();
     assert!(result.is_success());
 
-    // Turn on silo mode by setting default params.
-    let result = silo_contract
-        .set_silo_params(Some(SiloParamsArgs::default()))
-        .max_gas()
-        .transact()
-        .await
-        .unwrap();
-    assert!(result.is_success());
-
     // Should get ERC-20 address of mirrored contract.
     let result = silo_contract
         .mirror_erc20_token(MirrorErc20TokenArgs {
@@ -218,19 +188,6 @@ async fn test_transfer_from_silo_to_silo() {
         .await;
     let erc20_address = result.unwrap().into_value();
     assert_eq!(erc20_address, erc20.0.address);
-
-    // Disable whitelist Address to disable check if the addresses allow to receive tokens
-    // from outside.
-    let result = silo_contract
-        .set_whitelist_status(WhitelistStatusArgs {
-            kind: WhitelistKind::Address,
-            active: false,
-        })
-        .max_gas()
-        .transact()
-        .await
-        .unwrap();
-    assert!(result.is_success());
 
     let silo_erc20_metadata = silo_contract
         .get_erc20_metadata(Erc20Identifier::Erc20 {

--- a/engine-tests/src/tests/one_inch.rs
+++ b/engine-tests/src/tests/one_inch.rs
@@ -19,11 +19,11 @@ fn test_1inch_liquidity_protocol() {
 
     let (result, profile, deployer_address) = helper.create_mooniswap_deployer();
     assert!(result.gas_used >= 5_100_000); // more than 5.1M EVM gas used
-    assert_gas_bound(profile.all_gas(), 11); // less than 11 NEAR Tgas used
+    assert_gas_bound(profile.all_gas(), 12); // less than 12 NEAR TGas used
 
     let (result, profile, pool_factory) = helper.create_pool_factory(&deployer_address);
     assert!(result.gas_used >= 2_800_000); // more than 2.8M EVM gas used
-    assert_gas_bound(profile.all_gas(), 11); // less than 11 NEAR Tgas used
+    assert_gas_bound(profile.all_gas(), 11); // less than 11 NEAR TGas used
 
     // create some ERC-20 tokens to have a liquidity pool for
     let signer_address = utils::address_from_secret_key(&helper.signer.secret_key);

--- a/engine-tests/src/tests/promise_results_precompile.rs
+++ b/engine-tests/src/tests/promise_results_precompile.rs
@@ -121,13 +121,13 @@ fn test_promise_result_gas_cost() {
     let total_gas2 = y2 + baseline.all_gas();
 
     assert!(
-        utils::within_x_percent(36, evm1, total_gas1 / NEAR_GAS_PER_EVM),
+        utils::within_x_percent(39, evm1, total_gas1 / NEAR_GAS_PER_EVM),
         "Incorrect EVM gas used. Expected: {} Actual: {}",
         evm1,
         total_gas1 / NEAR_GAS_PER_EVM
     );
     assert!(
-        utils::within_x_percent(36, evm2, total_gas2 / NEAR_GAS_PER_EVM),
+        utils::within_x_percent(39, evm2, total_gas2 / NEAR_GAS_PER_EVM),
         "Incorrect EVM gas used. Expected: {} Actual: {}",
         evm2,
         total_gas2 / NEAR_GAS_PER_EVM

--- a/engine-tests/src/tests/repro.rs
+++ b/engine-tests/src/tests/repro.rs
@@ -51,7 +51,7 @@ fn repro_8ru7VEA() {
         block_timestamp: 1_648_829_935_343_349_589,
         input_path: "src/tests/res/input_8ru7VEA.hex",
         evm_gas_used: 1_732_181,
-        near_gas_used: 202,
+        near_gas_used: 203,
     });
 }
 

--- a/engine-tests/src/tests/repro.rs
+++ b/engine-tests/src/tests/repro.rs
@@ -71,6 +71,9 @@ fn repro_FRcorNv() {
         block_timestamp: 1_650_960_438_774_745_116,
         input_path: "src/tests/res/input_FRcorNv.hex",
         evm_gas_used: 1_239_721,
+        #[cfg(feature = "ext-connector")]
+        near_gas_used: 163,
+        #[cfg(not(feature = "ext-connector"))]
         near_gas_used: 164,
     });
 }

--- a/engine-tests/src/tests/repro.rs
+++ b/engine-tests/src/tests/repro.rs
@@ -71,7 +71,7 @@ fn repro_FRcorNv() {
         block_timestamp: 1_650_960_438_774_745_116,
         input_path: "src/tests/res/input_FRcorNv.hex",
         evm_gas_used: 1_239_721,
-        near_gas_used: 163,
+        near_gas_used: 164,
     });
 }
 

--- a/engine-tests/src/tests/standard_precompiles.rs
+++ b/engine-tests/src/tests/standard_precompiles.rs
@@ -61,25 +61,25 @@ fn profile_modexp() {
 #[test]
 fn profile_ecadd() {
     let profile = precompile_execution_profile("test_ecadd");
-    utils::assert_gas_bound(profile.all_gas(), 6);
+    utils::assert_gas_bound(profile.all_gas(), 7);
 }
 
 #[test]
 fn profile_ecmul() {
     let profile = precompile_execution_profile("test_ecmul");
-    utils::assert_gas_bound(profile.all_gas(), 7);
+    utils::assert_gas_bound(profile.all_gas(), 8);
 }
 
 #[test]
 fn profile_ecpair() {
     let profile = precompile_execution_profile("test_ecpair");
-    utils::assert_gas_bound(profile.all_gas(), 116);
+    utils::assert_gas_bound(profile.all_gas(), 117);
 }
 
 #[test]
 fn profile_blake2f() {
     let profile = precompile_execution_profile("test_blake2f");
-    utils::assert_gas_bound(profile.all_gas(), 6);
+    utils::assert_gas_bound(profile.all_gas(), 7);
 }
 
 fn initialize() -> (AuroraRunner, Signer, PrecompilesContract) {

--- a/engine-tests/src/tests/uniswap.rs
+++ b/engine-tests/src/tests/uniswap.rs
@@ -39,10 +39,7 @@ fn test_uniswap_input_multihop() {
 
     let (_amount_out, _evm_gas, profile) = context.exact_input(&tokens, INPUT_AMOUNT.into());
 
-    #[cfg(not(feature = "ext-connector"))]
     assert_eq!(108, profile.all_gas() / 1_000_000_000_000);
-    #[cfg(feature = "ext-connector")]
-    assert_eq!(107, profile.all_gas() / 1_000_000_000_000);
 }
 
 #[test]

--- a/engine/src/contract_methods/connector/mod.rs
+++ b/engine/src/contract_methods/connector/mod.rs
@@ -488,10 +488,6 @@ pub fn mirror_erc20_token<I: IO + Env + Copy, H: PromiseHandler>(
     // TODO: Add an admin access list of accounts allowed to do it.
     require_owner_only(&state, &io.predecessor_account_id())?;
 
-    if !crate::contract_methods::silo::is_silo_mode_on(&io) {
-        return Err(crate::errors::ERR_ALLOWED_IN_SILO_MODE_ONLY.into());
-    }
-
     let input = io.read_input().to_vec();
     let args = MirrorErc20TokenArgs::try_from_slice(&input)
         .map_err(|_| crate::errors::ERR_BORSH_DESERIALIZE)?;

--- a/engine/src/contract_methods/silo/whitelist.rs
+++ b/engine/src/contract_methods/silo/whitelist.rs
@@ -25,7 +25,7 @@ where
         Self { io: *io, kind }
     }
 
-    /// Enable a whitelist. (A whitelist is enabled after creation).
+    /// Enable a whitelist. (A whitelist is disabled after creation).
     pub fn enable(&mut self) {
         let key = self.key(STATUS);
         self.io.write_storage(&key, &[1]);
@@ -39,11 +39,11 @@ where
 
     /// Check if the whitelist is enabled.
     pub fn is_enabled(&self) -> bool {
-        // White list is enabled by default. So return `true` if the key doesn't exist.
+        // White list is disabled by default. So return `false` if the key doesn't exist.
         let key = self.key(STATUS);
         self.io
             .read_storage(&key)
-            .map_or(true, |value| value.to_vec() == [1])
+            .map_or(false, |value| value.to_vec() == [1])
     }
 
     fn key(&self, value: &[u8]) -> Vec<u8> {
@@ -140,8 +140,8 @@ mod tests {
         let io = StoragePointer(&storage);
         let mut white_list = Whitelist::init(&io, WhitelistKind::Account);
         // Whitelist is enabled after creation.
-        assert!(white_list.is_enabled());
-        white_list.disable();
         assert!(!white_list.is_enabled());
+        white_list.enable();
+        assert!(white_list.is_enabled());
     }
 }

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -1035,8 +1035,8 @@ pub fn submit_with_alt_modexp<
 
     let fixed_gas = silo::get_fixed_gas(&io);
 
-    // Check if the sender has rights to submit transactions or deploy code on SILO mode.
-    assert_access(&io, env, fixed_gas, &transaction)?;
+    // Check if the sender has rights to submit transactions or deploy code.
+    assert_access(&io, env, &transaction)?;
 
     // Validate the chain ID, if provided inside the signature:
     if let Some(chain_id) = transaction.chain_id {
@@ -1739,22 +1739,19 @@ unsafe fn schedule_promise_callback<P: PromiseHandler>(
 fn assert_access<I: IO + Copy, E: Env>(
     io: &I,
     env: &E,
-    fixed_gas: Option<EthGas>,
     transaction: &NormalizedEthTransaction,
 ) -> Result<(), EngineError> {
-    if fixed_gas.is_some() {
-        let allowed = if transaction.to.is_some() {
-            silo::is_allow_submit(io, &env.predecessor_account_id(), &transaction.address)
-        } else {
-            silo::is_allow_deploy(io, &env.predecessor_account_id(), &transaction.address)
-        };
+    let allowed = if transaction.to.is_some() {
+        silo::is_allow_submit(io, &env.predecessor_account_id(), &transaction.address)
+    } else {
+        silo::is_allow_deploy(io, &env.predecessor_account_id(), &transaction.address)
+    };
 
-        if !allowed {
-            return Err(EngineError {
-                kind: EngineErrorKind::NotAllowed,
-                gas_used: 0,
-            });
-        }
+    if !allowed {
+        return Err(EngineError {
+            kind: EngineErrorKind::NotAllowed,
+            gas_used: 0,
+        });
     }
 
     Ok(())

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -993,6 +993,16 @@ mod contract {
     }
 
     #[no_mangle]
+    pub extern "C" fn set_whitelists_statuses() {
+        let io = Runtime;
+        require_running(&state::get_state(&io).sdk_unwrap());
+        silo::assert_admin(&io).sdk_unwrap();
+
+        let args: Vec<WhitelistStatusArgs> = io.read_input_borsh().sdk_unwrap();
+        silo::set_whitelists_statuses(&io, args);
+    }
+
+    #[no_mangle]
     pub extern "C" fn get_whitelist_status() {
         let mut io = Runtime;
         let args: WhitelistKindArgs = io.read_input_borsh().sdk_unwrap();
@@ -1001,6 +1011,16 @@ mod contract {
             .sdk_unwrap();
 
         io.return_output(&status);
+    }
+
+    #[no_mangle]
+    pub extern "C" fn get_whitelists_statuses() {
+        let mut io = Runtime;
+        let statuses = borsh::to_vec(&silo::get_whitelists_statuses(&io))
+            .map_err(|e| e.to_string())
+            .sdk_unwrap();
+
+        io.return_output(&statuses);
     }
 
     #[no_mangle]


### PR DESCRIPTION
## Description

The PR makes some changes to the Silo (VC) mode:

1. The mirroring of the ERC-20 tokens doesn't require enabling the silo mode.
2. White lists work in any mode, but they are disabled by default. 
3. Intoduced a transaction for setting white list statuses by one transaction.
4. Inrodused a view method which returns statuses of all whitelists.

## Performance / NEAR gas cost considerations

Tiny NEAR gas consumption is increased because there is an additional check introduced. 

## Testing

The corresponding tests have been modified.