### PR TITLE
fix: access to silo transactions to the owner only

### DIFF
--- a/engine/src/contract_methods/connector.rs
+++ b/engine/src/contract_methods/connector.rs
@@ -64,6 +64,7 @@ pub fn ft_on_transfer<I: IO + Copy, E: Env, H: PromiseHandler>(
     handler: &mut H,
 ) -> Result<Option<SubmitResult>, ContractError> {
     with_hashchain(io, env, function_name!(), |mut io| {
+        require_running(&state::get_state(&io)?)?;
         let current_account_id = env.current_account_id();
         let predecessor_account_id = env.predecessor_account_id();
         let mut engine: Engine<_, _> = Engine::new(

--- a/engine/src/contract_methods/mod.rs
+++ b/engine/src/contract_methods/mod.rs
@@ -62,27 +62,37 @@ impl AsRef<[u8]> for ErrorMessage {
     }
 }
 
-fn require_running(state: &state::EngineState) -> Result<(), ContractError> {
+pub fn require_running(state: &state::EngineState) -> Result<(), ContractError> {
     if state.is_paused {
         return Err(errors::ERR_PAUSED.into());
     }
     Ok(())
 }
 
-fn require_paused(state: &state::EngineState) -> Result<(), ContractError> {
+pub fn require_paused(state: &state::EngineState) -> Result<(), ContractError> {
     if !state.is_paused {
         return Err(errors::ERR_RUNNING.into());
     }
     Ok(())
 }
 
-fn require_owner_only(
+pub fn require_owner_only(
     state: &state::EngineState,
     predecessor_account_id: &AccountId,
 ) -> Result<(), ContractError> {
     if &state.owner_id != predecessor_account_id {
         return Err(errors::ERR_NOT_ALLOWED.into());
     }
+    Ok(())
+}
+
+pub fn require_owner_and_running(
+    state: &state::EngineState,
+    predecessor_account_id: &AccountId,
+) -> Result<(), ContractError> {
+    require_running(state)?;
+    require_owner_only(state, predecessor_account_id)?;
+
     Ok(())
 }
 

--- a/engine/src/contract_methods/silo/mod.rs
+++ b/engine/src/contract_methods/silo/mod.rs
@@ -1,6 +1,4 @@
 use aurora_engine_sdk::io::{StorageIntermediate, IO};
-#[cfg(feature = "contract")]
-use aurora_engine_sdk::{env::Env, types::SdkUnwrap};
 use aurora_engine_types::account_id::AccountId;
 use aurora_engine_types::parameters::silo::{
     SiloParamsArgs, WhitelistArgs, WhitelistKind, WhitelistKindArgs, WhitelistStatusArgs,
@@ -9,8 +7,6 @@ use aurora_engine_types::storage::{bytes_to_key, KeyPrefix};
 use aurora_engine_types::types::{Address, EthGas};
 use aurora_engine_types::AsBytes;
 
-#[cfg(feature = "contract")]
-use crate::engine::EngineErrorKind;
 use crate::prelude::Vec;
 
 use whitelist::Whitelist;
@@ -48,7 +44,7 @@ pub fn get_fixed_gas<I: IO>(io: &I) -> Option<EthGas> {
         .and_then(|bytes| bytes.to_value().ok())
 }
 
-/// Set gas amount per transaction.
+/// Set an amount of gas per transaction.
 pub fn set_fixed_gas<I: IO>(io: &mut I, gas: Option<EthGas>) {
     let key = fixed_gas_key();
 
@@ -76,13 +72,13 @@ pub fn set_erc20_fallback_address<I: IO>(io: &mut I, address: Option<Address>) {
     }
 }
 
-/// Add an entry to a white list depending on a kind of list types in provided arguments.
+/// Add an entry to a whitelist depending on a kind of list types in provided arguments.
 pub fn add_entry_to_whitelist<I: IO + Copy>(io: &I, args: &WhitelistArgs) {
     let (kind, entry) = get_kind_and_entry(args);
     Whitelist::init(io, kind).add(entry);
 }
 
-/// Add an entries to a white list depending on a kind of list types in provided arguments.
+/// Add entries to a whitelist depending on a kind of list types in provided arguments.
 pub fn add_entry_to_whitelist_batch<I: IO + Copy, A: IntoIterator<Item = WhitelistArgs>>(
     io: &I,
     entries: A,
@@ -92,18 +88,18 @@ pub fn add_entry_to_whitelist_batch<I: IO + Copy, A: IntoIterator<Item = Whiteli
     }
 }
 
-/// Remove an entries to a white list depending on a kind of list types in provided arguments.
+/// Remove an entry from a whitelist depending on a kind of list types in provided arguments.
 pub fn remove_entry_from_whitelist<I: IO + Copy>(io: &I, args: &WhitelistArgs) {
     let (kind, entry) = get_kind_and_entry(args);
     Whitelist::init(io, kind).remove(entry);
 }
 
-/// Set status of the provided white list.
+/// Set the given status of the provided whitelist.
 pub fn set_whitelist_status<I: IO + Copy>(io: &I, args: &WhitelistStatusArgs) {
     whitelist::set_whitelist_status(io, args);
 }
 
-/// Set status of the provided white lists.
+/// Set given statuses of the provided whitelists.
 pub fn set_whitelists_statuses<I: IO + Copy, A: IntoIterator<Item = WhitelistStatusArgs>>(
     io: &I,
     args: A,
@@ -113,12 +109,12 @@ pub fn set_whitelists_statuses<I: IO + Copy, A: IntoIterator<Item = WhitelistSta
     }
 }
 
-/// Return status of the provided white list.
+/// Return a status of the given whitelist.
 pub fn get_whitelist_status<I: IO + Copy>(io: &I, args: &WhitelistKindArgs) -> WhitelistStatusArgs {
     whitelist::get_whitelist_status(io, args)
 }
 
-/// Return status of the all white list.
+/// Return status of the all whitelists.
 pub fn get_whitelists_statuses<I: IO + Copy>(io: &I) -> Vec<WhitelistStatusArgs> {
     [
         WhitelistKind::Admin,
@@ -131,21 +127,9 @@ pub fn get_whitelists_statuses<I: IO + Copy>(io: &I) -> Vec<WhitelistStatusArgs>
     .collect()
 }
 
-/// Check if the calling user is admin or owner of the contract.
-#[cfg(feature = "contract")]
-pub fn assert_admin<I: IO + Env + Copy>(io: &I) -> Result<(), EngineErrorKind> {
-    let predecessor = io.predecessor_account_id();
-
-    if is_owner(io, &predecessor) || is_admin(io, &predecessor) {
-        return Ok(());
-    }
-
-    Err(EngineErrorKind::NotAllowed)
-}
-
 /// Check if a user has the right to deploy EVM code.
 pub fn is_allow_deploy<I: IO + Copy>(io: &I, account: &AccountId, address: &Address) -> bool {
-    is_admin(io, account) && is_evm_admin(io, address)
+    is_account_allowed_deploy(io, account) && is_address_allowed_deploy(io, address)
 }
 
 /// Check if a user has the right to submit transactions.
@@ -158,20 +142,14 @@ pub fn is_allow_receive_erc20_tokens<I: IO + Copy>(io: &I, address: &Address) ->
     is_address_allowed(io, address)
 }
 
-fn is_admin<I: IO + Copy>(io: &I, account_id: &AccountId) -> bool {
+fn is_account_allowed_deploy<I: IO + Copy>(io: &I, account_id: &AccountId) -> bool {
     let list = Whitelist::init(io, WhitelistKind::Admin);
     !list.is_enabled() || list.is_exist(account_id)
 }
 
-fn is_evm_admin<I: IO + Copy>(io: &I, address: &Address) -> bool {
+fn is_address_allowed_deploy<I: IO + Copy>(io: &I, address: &Address) -> bool {
     let list = Whitelist::init(io, WhitelistKind::EvmAdmin);
     !list.is_enabled() || list.is_exist(address)
-}
-
-#[cfg(feature = "contract")]
-fn is_owner<I: IO + Copy>(io: &I, account_id: &AccountId) -> bool {
-    let state = crate::state::get_state(io).sdk_unwrap();
-    &state.owner_id == account_id
 }
 
 fn is_address_allowed<I: IO + Copy>(io: &I, address: &Address) -> bool {

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -46,6 +46,7 @@ pub unsafe fn on_panic(info: &::core::panic::PanicInfo) -> ! {
 
 #[cfg(feature = "contract")]
 mod contract {
+    use crate::contract_methods::{require_owner_and_running, require_running};
     use crate::engine::{self, Engine};
     use crate::errors;
     use crate::parameters::{GetStorageAtArgs, ViewCallArgs};
@@ -172,7 +173,9 @@ mod contract {
         // because it only makes sense in the context of the NEAR runtime.
         let mut io = Runtime;
         let state = state::get_state(&io).sdk_unwrap();
-        require_running(&state);
+        require_running(&state)
+            .map_err(ContractError::msg)
+            .sdk_unwrap();
         let index = internal_get_upgrade_index();
         if io.block_height() <= index {
             sdk::panic_utf8(errors::ERR_NOT_ALLOWED_TOO_EARLY);
@@ -780,8 +783,10 @@ mod contract {
     #[no_mangle]
     pub extern "C" fn set_fixed_gas() {
         let mut io = Runtime;
-        require_running(&state::get_state(&io).sdk_unwrap());
-        silo::assert_admin(&io).sdk_unwrap();
+        let state = state::get_state(&io).sdk_unwrap();
+        require_owner_and_running(&state, &io.predecessor_account_id())
+            .map_err(ContractError::msg)
+            .sdk_unwrap();
 
         let args: FixedGasArgs = io.read_input_borsh().sdk_unwrap();
         silo::set_fixed_gas(&mut io, args.fixed_gas);
@@ -800,8 +805,10 @@ mod contract {
     #[no_mangle]
     pub extern "C" fn set_erc20_fallback_address() {
         let mut io = Runtime;
-        require_running(&state::get_state(&io).sdk_unwrap());
-        silo::assert_admin(&io).sdk_unwrap();
+        let state = state::get_state(&io).sdk_unwrap();
+        require_owner_and_running(&state, &io.predecessor_account_id())
+            .map_err(ContractError::msg)
+            .sdk_unwrap();
 
         let args: Erc20FallbackAddressArgs = io.read_input_borsh().sdk_unwrap();
         silo::set_erc20_fallback_address(&mut io, args.address);
@@ -822,8 +829,10 @@ mod contract {
     #[no_mangle]
     pub extern "C" fn set_silo_params() {
         let mut io = Runtime;
-        require_running(&state::get_state(&io).sdk_unwrap());
-        silo::assert_admin(&io).sdk_unwrap();
+        let state = state::get_state(&io).sdk_unwrap();
+        require_owner_and_running(&state, &io.predecessor_account_id())
+            .map_err(ContractError::msg)
+            .sdk_unwrap();
 
         let args: Option<SiloParamsArgs> = io.read_input_borsh().sdk_unwrap();
         silo::set_silo_params(&mut io, args);
@@ -832,8 +841,10 @@ mod contract {
     #[no_mangle]
     pub extern "C" fn set_whitelist_status() {
         let io = Runtime;
-        require_running(&state::get_state(&io).sdk_unwrap());
-        silo::assert_admin(&io).sdk_unwrap();
+        let state = state::get_state(&io).sdk_unwrap();
+        require_owner_and_running(&state, &io.predecessor_account_id())
+            .map_err(ContractError::msg)
+            .sdk_unwrap();
 
         let args: WhitelistStatusArgs = io.read_input_borsh().sdk_unwrap();
         silo::set_whitelist_status(&io, &args);
@@ -842,8 +853,10 @@ mod contract {
     #[no_mangle]
     pub extern "C" fn set_whitelists_statuses() {
         let io = Runtime;
-        require_running(&state::get_state(&io).sdk_unwrap());
-        silo::assert_admin(&io).sdk_unwrap();
+        let state = state::get_state(&io).sdk_unwrap();
+        require_owner_and_running(&state, &io.predecessor_account_id())
+            .map_err(ContractError::msg)
+            .sdk_unwrap();
 
         let args: Vec<WhitelistStatusArgs> = io.read_input_borsh().sdk_unwrap();
         silo::set_whitelists_statuses(&io, args);
@@ -873,8 +886,10 @@ mod contract {
     #[no_mangle]
     pub extern "C" fn add_entry_to_whitelist() {
         let io = Runtime;
-        require_running(&state::get_state(&io).sdk_unwrap());
-        silo::assert_admin(&io).sdk_unwrap();
+        let state = state::get_state(&io).sdk_unwrap();
+        require_owner_and_running(&state, &io.predecessor_account_id())
+            .map_err(ContractError::msg)
+            .sdk_unwrap();
 
         let args: WhitelistArgs = io.read_input_borsh().sdk_unwrap();
         silo::add_entry_to_whitelist(&io, &args);
@@ -883,8 +898,10 @@ mod contract {
     #[no_mangle]
     pub extern "C" fn add_entry_to_whitelist_batch() {
         let io = Runtime;
-        require_running(&state::get_state(&io).sdk_unwrap());
-        silo::assert_admin(&io).sdk_unwrap();
+        let state = state::get_state(&io).sdk_unwrap();
+        require_owner_and_running(&state, &io.predecessor_account_id())
+            .map_err(ContractError::msg)
+            .sdk_unwrap();
 
         let args: Vec<WhitelistArgs> = io.read_input_borsh().sdk_unwrap();
         silo::add_entry_to_whitelist_batch(&io, args);
@@ -893,8 +910,10 @@ mod contract {
     #[no_mangle]
     pub extern "C" fn remove_entry_from_whitelist() {
         let io = Runtime;
-        require_running(&state::get_state(&io).sdk_unwrap());
-        silo::assert_admin(&io).sdk_unwrap();
+        let state = state::get_state(&io).sdk_unwrap();
+        require_owner_and_running(&state, &io.predecessor_account_id())
+            .map_err(ContractError::msg)
+            .sdk_unwrap();
 
         let args: WhitelistArgs = io.read_input_borsh().sdk_unwrap();
         silo::remove_entry_from_whitelist(&io, &args);
@@ -909,12 +928,6 @@ mod contract {
                 sdk::panic_utf8(errors::ERR_INVALID_UPGRADE)
             }
             Err(sdk::error::ReadU64Error::MissingValue) => sdk::panic_utf8(errors::ERR_NO_UPGRADE),
-        }
-    }
-
-    fn require_running(state: &state::EngineState) {
-        if state.is_paused {
-            sdk::panic_utf8(errors::ERR_PAUSED);
         }
     }
 }


### PR DESCRIPTION
## Description

The PR fixes the vulnerability that allows running silo related transactions by anyone.

## Performance / NEAR gas cost considerations

There are no changes in the performance.

## Testing

Added new and modified existing tests.

## Additional information

Also, the PR adds a possibility to pause `ft_on_transfer` cc @karim-en.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new tests to verify whitelist access control and owner-only restrictions for contract actions.
  * Improved error handling for administrative actions by requiring both contract ownership and a running state.

* **Bug Fixes**
  * Enforced contract running state before processing certain transfer operations.

* **Refactor**
  * Renamed helper functions and updated comments for clarity regarding whitelist and deployer checks.
  * Standardized administrative permission checks to use a unified owner-and-running-state requirement.
  * Removed redundant whitelist additions in tests and improved test clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->