### PR TITLE
ci: rollback to github-hosted-heavy-runners for some tasks

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -7,16 +7,13 @@ name: Build
 jobs:
   build:
     name: Build contracts
-    runs-on: k8s-infrastructure-dind
+    runs-on: github-hosted-heavy-runner
     steps:
       - name: Potential broken submodules fix
         run: |
           git checkout -f $(git -c user.name=x -c user.email=x@x commit-tree $(git hash-object -t tree /dev/null) < /dev/null) || :
       - name: Clone the repository
         uses: actions/checkout@v4
-      - name: Install ci deps
-        run: |
-          sudo scripts/ci-deps/native.sh
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -36,7 +33,7 @@ jobs:
 
   publish:
     name: Publish contracts
-    runs-on: k8s-infrastructure-generic
+    runs-on: github-hosted-heavy-runner
     needs: build
     steps:
       - name: Download artifacts

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -20,6 +20,8 @@ jobs:
         run: cargo install --no-default-features --force cargo-make
       - name: Install dependencies
         run: scripts/ci-deps/install-wasm-opt.sh
+      - name: Install cargo-make
+        run: cargo +stable make -V || cargo +stable install cargo-make
       - name: Compile smart contracts
         run: |
           cargo make build-docker

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install cargo-make
         run: cargo install --no-default-features --force cargo-make
       - name: Install dependencies
-        run: sudo scripts/ci-deps/install-wasm-opt.sh
+        run: scripts/ci-deps/install-wasm-opt.sh
       - name: Compile smart contracts
         run: |
           cargo make build-docker

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -26,7 +26,7 @@ jobs:
           cache-on-failure: "true"
           cache-all-crates: "true"
       - name: Install dependencies
-        run: sudo scripts/ci-deps/install-wasm-opt.sh
+        run: scripts/ci-deps/install-wasm-opt.sh
       - name: Install Rust toolchain and components
         run: |
           rustup toolchain add nightly

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -19,14 +19,14 @@ jobs:
     steps:
       - name: Clone the repository
         uses: actions/checkout@v4
+      - name: Install dependencies
+        run: scripts/ci-deps/native.sh
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
         with:
           key: aurora-${{ matrix.command }}-check
           cache-on-failure: "true"
           cache-all-crates: "true"
-      - name: Install dependencies
-        run: scripts/ci-deps/native.sh
       - name: Install Rust toolchain and components
         run: rustup toolchain add nightly
       - name: Install cargo-make

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -10,7 +10,7 @@ name: Lints
 jobs:
   rust:
     name: Run ${{ matrix.command }}
-    runs-on: k8s-infrastructure-native
+    runs-on: selfhosted
     container: rust:latest
     strategy:
       fail-fast: false
@@ -41,7 +41,7 @@ jobs:
 
   contracts:
     name: Contracts
-    runs-on: k8s-infrastructure-native
+    runs-on: selfhosted
     container: rust:latest
     steps:
       - name: Potential broken submodules fix

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -26,14 +26,7 @@ jobs:
           cache-on-failure: "true"
           cache-all-crates: "true"
       - name: Install dependencies
-        run: scripts/ci-deps/install-wasm-opt.sh
-      - name: Update Node and Yarn
-        run: |
-          export NVM_DIR="$HOME/.nvm"
-          [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-          nvm install 18 && nvm alias default 18
-          npm install -g yarn
-          echo "$(dirname $(nvm which node))" >> $GITHUB_PATH
+        run: scripts/ci-deps/native.sh
       - name: Install Rust toolchain and components
         run: rustup toolchain add nightly
       - name: Install cargo-make
@@ -48,6 +41,8 @@ jobs:
     steps:
       - name: Clone the repository
         uses: actions/checkout@v4
+      - name: Install dependencies
+        run: scripts/ci-deps/native.sh
       - name: Setup Node and cache
         uses: actions/setup-node@v4
         with:
@@ -56,13 +51,6 @@ jobs:
           cache-dependency-path: |
             etc/eth-contracts/yarn.lock
             etc/tests/uniswap/yarn.lock
-      - name: Update Node and Yarn
-        run: |
-          export NVM_DIR="$HOME/.nvm"
-          [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-          nvm install 18 && nvm alias default 18
-          npm install -g yarn
-          echo "$(dirname $(nvm which node))" >> $GITHUB_PATH
       - name: Install cargo-make
         run: cargo +stable make -V || cargo +stable install cargo-make
       - name: Run yarn lint

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -28,8 +28,9 @@ jobs:
       - name: Install dependencies
         run: scripts/ci-deps/install-wasm-opt.sh
       - name: Install Rust toolchain and components
-        run: |
-          rustup toolchain add nightly
+        run: rustup toolchain add nightly
+      - name: Install cargo-make
+        run: cargo +stable make -V || cargo +stable install cargo-make
       - name: Run ${{ matrix.command }}
         run: cargo make ${{ matrix.command }}
 
@@ -48,6 +49,8 @@ jobs:
           cache-dependency-path: |
             etc/eth-contracts/yarn.lock
             etc/tests/uniswap/yarn.lock
+      - name: Install cargo-make
+        run: cargo +stable make -V || cargo +stable install cargo-make
       - name: Run yarn lint
         run: cargo make check-contracts
       - name: Check committed EvmErc20.bin

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -27,6 +27,13 @@ jobs:
           cache-all-crates: "true"
       - name: Install dependencies
         run: scripts/ci-deps/install-wasm-opt.sh
+      - name: Update Node and Yarn
+        run: |
+          export NVM_DIR="$HOME/.nvm"
+          [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+          nvm install 18 && nvm alias default 18
+          npm install -g yarn
+          echo "$(dirname $(nvm which node))" >> $GITHUB_PATH
       - name: Install Rust toolchain and components
         run: rustup toolchain add nightly
       - name: Install cargo-make
@@ -49,6 +56,13 @@ jobs:
           cache-dependency-path: |
             etc/eth-contracts/yarn.lock
             etc/tests/uniswap/yarn.lock
+      - name: Update Node and Yarn
+        run: |
+          export NVM_DIR="$HOME/.nvm"
+          [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+          nvm install 18 && nvm alias default 18
+          npm install -g yarn
+          echo "$(dirname $(nvm which node))" >> $GITHUB_PATH
       - name: Install cargo-make
         run: cargo +stable make -V || cargo +stable install cargo-make
       - name: Run yarn lint

--- a/.github/workflows/scheduled_lints.yml
+++ b/.github/workflows/scheduled_lints.yml
@@ -40,6 +40,8 @@ jobs:
         run: scripts/build-neard-sandbox.sh ${{ matrix.version }}
       - name: Install wasm-opt
         run: scripts/ci-deps/install-wasm-opt.sh
+      - name: Install cargo-make
+        run: cargo +stable make -V || cargo +stable install cargo-make
       - name: Run tests
         run: cargo make test
       - uses: 8398a7/action-slack@v3
@@ -65,6 +67,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 18
+      - name: Install cargo-make
+        run: cargo +stable make -V || cargo +stable install cargo-make
       - name: Run checks
         run: cargo make check
       - name: Run build XCC router

--- a/.github/workflows/scheduled_lints.yml
+++ b/.github/workflows/scheduled_lints.yml
@@ -2,7 +2,6 @@
 on:
   schedule:
     - cron: '0 8 * * 1-5'
-  pull_request:
 
 name: Scheduled checks
 jobs:

--- a/.github/workflows/scheduled_lints.yml
+++ b/.github/workflows/scheduled_lints.yml
@@ -2,12 +2,13 @@
 on:
   schedule:
     - cron: '0 8 * * 1-5'
+  pull_request:
 
 name: Scheduled checks
 jobs:
   tests:
     name: Run tests (${{ matrix.version }} neard)
-    runs-on: k8s-infrastructure-dind
+    runs-on: github-hosted-heavy-runner
     strategy:
       fail-fast: false
       matrix:
@@ -18,8 +19,6 @@ jobs:
           git checkout -f $(git -c user.name=x -c user.email=x@x commit-tree $(git hash-object -t tree /dev/null) < /dev/null) || :
       - name: Clone the repository
         uses: actions/checkout@v4
-      - name: Install ci deps
-        run: sudo scripts/ci-deps/native.sh
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -58,7 +57,7 @@ jobs:
 
   checks:
     name: Run checks
-    runs-on: k8s-infrastructure-native
+    runs-on: selfhosted
     container: rust:latest
     steps:
       - name: Potential broken submodules fix

--- a/.github/workflows/scheduled_lints.yml
+++ b/.github/workflows/scheduled_lints.yml
@@ -69,6 +69,8 @@ jobs:
           node-version: 18
       - name: Install cargo-make
         run: cargo +stable make -V || cargo +stable install cargo-make
+      - name: Install dependencies
+        run: scripts/ci-deps/native.sh
       - name: Run checks
         run: cargo make check
       - name: Run build XCC router

--- a/.github/workflows/scheduled_lints.yml
+++ b/.github/workflows/scheduled_lints.yml
@@ -59,6 +59,8 @@ jobs:
     steps:
       - name: Clone the repository
         uses: actions/checkout@v4
+      - name: Install dependencies
+        run: scripts/ci-deps/native.sh
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -69,8 +71,8 @@ jobs:
           node-version: 18
       - name: Install cargo-make
         run: cargo +stable make -V || cargo +stable install cargo-make
-      - name: Install dependencies
-        run: scripts/ci-deps/native.sh
+      - name: Install nightly rust toolchain
+        run: rustup toolchain add nightly
       - name: Run checks
         run: cargo make check
       - name: Run build XCC router

--- a/.github/workflows/scheduled_lints.yml
+++ b/.github/workflows/scheduled_lints.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build actual neard-sandbox
         run: scripts/build-neard-sandbox.sh ${{ matrix.version }}
       - name: Install wasm-opt
-        run: sudo scripts/ci-deps/install-wasm-opt.sh
+        run: scripts/ci-deps/install-wasm-opt.sh
       - name: Run tests
         run: cargo make test
       - uses: 8398a7/action-slack@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
           cache-dependency-path: |
             etc/eth-contracts
             etc/tests/uniswap
-      - name: Install dependencies
+      - name: Install cargo-make
         run: cargo +stable make -V || cargo +stable install cargo-make
       - name: Install wasm-opt
         run: scripts/ci-deps/install-wasm-opt.sh
@@ -55,6 +55,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 18
+      - name: Install cargo-make
+        run: cargo +stable make -V || cargo +stable install cargo-make
       - name: Run bench-modexp tests
         run: cargo make bench-modexp
 
@@ -73,6 +75,8 @@ jobs:
           key: cargo-build-xcc-router
           cache-on-failure: "true"
           cache-all-crates: "true"
+      - name: Install cargo-make
+        run: cargo +stable make -V || cargo +stable install cargo-make
       - name: Build XCC router
         run: cargo make build-xcc-router
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,12 +10,10 @@ name: Tests
 jobs:
   test:
     name: Test suite
-    runs-on: k8s-infrastructure-dind  # strong main container and weak docker container
+    runs-on: github-hosted-heavy-runner
     steps:
       - name: Clone the repository
         uses: actions/checkout@v4
-      - name: Install CI deps
-        run: sudo scripts/ci-deps/native.sh
       - uses: dtolnay/rust-toolchain@stable
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
@@ -31,16 +29,17 @@ jobs:
           cache-dependency-path: |
             etc/eth-contracts
             etc/tests/uniswap
-      - name: Install cargo-make
-        run: sudo cargo +stable install cargo-make
-      - name: Run tests
-        run: sudo cargo make test-flow
+      - name: Install dependencies
+        run: cargo +stable make -V || cargo +stable install cargo-make
+      - name: Install wasm-opt
+        run: scripts/ci-deps/install-wasm-opt.sh
+      - name: Tests
+        run: cargo make test-flow
 
   test_modexp:
     name: Test modexp suite
-    runs-on: k8s-infrastructure-native
-    container:
-      image: rust:latest
+    runs-on: selfhosted-heavy
+    container: rust:latest
     steps:
       - name: Potential broken submodules fix
         run: |
@@ -66,9 +65,8 @@ jobs:
 
   build_xcc_router:
     name: Build XCC router
-    runs-on: k8s-infrastructure-native
-    container:
-      image: rust:latest
+    runs-on: selfhosted
+    container: rust:latest
     steps:
       - name: Potential broken submodules fix
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Clone the repository
         uses: actions/checkout@v4
       - name: Install dependencies
-        run: sudo scripts/ci-deps/install-wasm-opt.sh
+        run: scripts/ci-deps/install-wasm-opt.sh
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -66,7 +66,7 @@ jobs:
       - name: Clone the repository
         uses: actions/checkout@v4
       - name: Install dependencies
-        run: sudo scripts/ci-deps/install-wasm-opt.sh
+        run: scripts/ci-deps/install-wasm-opt.sh
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Clone the repository
         uses: actions/checkout@v4
       - name: Install dependencies
-        run: scripts/ci-deps/install-wasm-opt.sh
+        run: scripts/ci-deps/native.sh
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -68,7 +68,7 @@ jobs:
       - name: Clone the repository
         uses: actions/checkout@v4
       - name: Install dependencies
-        run: scripts/ci-deps/install-wasm-opt.sh
+        run: scripts/ci-deps/native.sh
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
         with:

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "1.86.0"
 targets = ["wasm32-unknown-unknown"]
+components = ["rustfmt", "clippy"]

--- a/scripts/ci-deps/native.sh
+++ b/scripts/ci-deps/native.sh
@@ -3,10 +3,13 @@
 export DEBIAN_FRONTEND=noninteractive
 
 apt update
-apt install -y build-essential pkg-config libclang-dev libssl-dev gnupg curl git
-curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-apt update
+apt install -y build-essential pkg-config libclang-dev libssl-dev gnupg curl git gpg
+
+mkdir -p /etc/apt/keyrings
+curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor -o /etc/apt/keyrings/yarn.gpg
+chmod a+r /etc/apt/keyrings/yarn.gpg
+echo "deb [signed-by=/etc/apt/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian stable main" \
+  | tee /etc/apt/sources.list.d/yarn.list >/dev/null
 apt install -y yarn
 yarn install
 scripts/ci-deps/install-wasm-opt.sh

--- a/scripts/ci-deps/native.sh
+++ b/scripts/ci-deps/native.sh
@@ -4,6 +4,9 @@ export DEBIAN_FRONTEND=noninteractive
 
 apt update
 apt install -y build-essential pkg-config libclang-dev libssl-dev gnupg curl git
-curl -o- -L https://yarnpkg.com/install.sh | bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+\. "$HOME/.nvm/nvm.sh"
+nvm install 18
+npm install --global yarn
 yarn install
 scripts/ci-deps/install-wasm-opt.sh

--- a/scripts/ci-deps/native.sh
+++ b/scripts/ci-deps/native.sh
@@ -4,9 +4,9 @@ export DEBIAN_FRONTEND=noninteractive
 
 apt update
 apt install -y build-essential pkg-config libclang-dev libssl-dev gnupg curl git
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
-\. "$HOME/.nvm/nvm.sh"
-nvm install 18
-npm install --global yarn
+curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+apt update
+apt install -y yarn
 yarn install
 scripts/ci-deps/install-wasm-opt.sh

--- a/scripts/ci-deps/native.sh
+++ b/scripts/ci-deps/native.sh
@@ -8,8 +8,8 @@ apt install -y build-essential pkg-config libclang-dev libssl-dev gnupg curl git
 mkdir -p /etc/apt/keyrings
 curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor -o /etc/apt/keyrings/yarn.gpg
 chmod a+r /etc/apt/keyrings/yarn.gpg
-echo "deb [signed-by=/etc/apt/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian stable main" \
-  | tee /etc/apt/sources.list.d/yarn.list >/dev/null
+echo "deb [signed-by=/etc/apt/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian stable main" | tee /etc/apt/sources.list.d/yarn.list >/dev/null
+apt update
 apt install -y yarn
 yarn install
 scripts/ci-deps/install-wasm-opt.sh

--- a/scripts/ci-deps/native.sh
+++ b/scripts/ci-deps/native.sh
@@ -4,9 +4,6 @@ export DEBIAN_FRONTEND=noninteractive
 
 apt update
 apt install -y build-essential pkg-config libclang-dev libssl-dev gnupg curl git
-curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-apt update
-apt install -y yarn
+curl -o- -L https://yarnpkg.com/install.sh | bash
 yarn install
 scripts/ci-deps/install-wasm-opt.sh


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Migrated CI workflows to new runners and introduced containerized Rust environments for consistency.
  - Standardized Rust/tooling installs and added rustfmt and clippy to the toolchain.
  - Bootstrapped Node 18 and Yarn where needed; added cargo-make bootstrap steps and removed sudo-based wasm-opt installs.
  - Added pull_request trigger to scheduled linting.
  - No user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->