### PR TITLE
Chore: re-export modexp for precompiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-engine-modexp"
-version = "1.3.0"
+version = "1.2.0"
 dependencies = [
  "hex",
  "ibig",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-engine-precompiles"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "aurora-engine-modexp",
  "aurora-engine-sdk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-engine-modexp"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "hex",
  "ibig",

--- a/engine-modexp/Cargo.toml
+++ b/engine-modexp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aurora-engine-modexp"
-version = "1.2.0"
+version = "1.3.0"
 description = "Custom ModExp implementation used in Aurora Engine"
 keywords = ["modexp", "aurora", "engine"]
 authors.workspace = true

--- a/engine-modexp/Cargo.toml
+++ b/engine-modexp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aurora-engine-modexp"
-version = "1.3.0"
+version = "1.2.0"
 description = "Custom ModExp implementation used in Aurora Engine"
 keywords = ["modexp", "aurora", "engine"]
 authors.workspace = true

--- a/engine-precompiles/Cargo.toml
+++ b/engine-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aurora-engine-precompiles"
-version = "2.0.0"
+version = "2.0.1"
 description = "Set of precompiles used in Aurora Engine"
 authors.workspace = true
 edition.workspace = true

--- a/engine-precompiles/src/lib.rs
+++ b/engine-precompiles/src/lib.rs
@@ -62,7 +62,7 @@ impl PrecompileOutput {
     }
 }
 
-type EvmPrecompileResult = Result<PrecompileOutput, ExitError>;
+pub type EvmPrecompileResult = Result<PrecompileOutput, ExitError>;
 
 /// A precompiled function for use in the EVM.
 pub trait Precompile {

--- a/engine-precompiles/src/modexp.rs
+++ b/engine-precompiles/src/modexp.rs
@@ -1,4 +1,3 @@
-use aurora_engine_modexp::{AuroraModExp, ModExpAlgorithm};
 use aurora_evm::{Context, ExitError};
 use num::{Integer, Zero};
 
@@ -7,6 +6,8 @@ use crate::prelude::{Cow, PhantomData, U256, Vec};
 use crate::{
     Berlin, Byzantium, EvmPrecompileResult, HardFork, Osaka, Precompile, PrecompileOutput, utils,
 };
+
+pub use aurora_engine_modexp::{AuroraModExp, ModExpAlgorithm};
 
 #[derive(Default)]
 pub struct ModExp<HF: HardFork, M = AuroraModExp>(PhantomData<HF>, PhantomData<M>);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated engine-modexp package version to 1.3.0
  * Updated engine-precompiles package version to 2.0.1

* **New Features**
  * Expanded public API exports from the precompiles module for external access

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->