### PR TITLE
Chore: add precompiles evm reexports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-engine-precompiles"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "aurora-engine-modexp",
  "aurora-engine-sdk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-engine-precompiles"
-version = "2.0.2"
+version = "2.1.0"
 dependencies = [
  "aurora-engine-modexp",
  "aurora-engine-sdk",

--- a/engine-precompiles/Cargo.toml
+++ b/engine-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aurora-engine-precompiles"
-version = "2.0.2"
+version = "2.1.0"
 description = "Set of precompiles used in Aurora Engine"
 authors.workspace = true
 edition.workspace = true

--- a/engine-precompiles/Cargo.toml
+++ b/engine-precompiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aurora-engine-precompiles"
-version = "2.0.1"
+version = "2.0.2"
 description = "Set of precompiles used in Aurora Engine"
 authors.workspace = true
 edition.workspace = true

--- a/engine-precompiles/src/lib.rs
+++ b/engine-precompiles/src/lib.rs
@@ -9,7 +9,9 @@ use aurora_evm::executor::{
     self,
     stack::{PrecompileFailure, PrecompileHandle},
 };
-use aurora_evm::{Context, ExitError, ExitFatal, ExitSucceed};
+
+pub use aurora_engine_types::types::EthGas;
+pub use aurora_evm::{Context, ExitError, ExitFatal, ExitSucceed};
 
 use crate::account_ids::{CurrentAccount, PredecessorAccount, predecessor_account};
 use crate::alt_bn256::{Bn256Add, Bn256Mul, Bn256Pair};
@@ -18,7 +20,6 @@ use crate::hash::{RIPEMD160, SHA256};
 use crate::identity::Identity;
 use crate::modexp::ModExp;
 use crate::native::{ExitToEthereum, ExitToNear, exit_to_ethereum, exit_to_near};
-use crate::prelude::types::EthGas;
 use crate::prelude::{H256, Vec};
 use crate::prepaid_gas::PrepaidGas;
 use crate::promise_result::PromiseResult;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Package version bumped to 2.1.0

* **New Features**
  * EthGas type is now publicly exported for external use

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->