### PR TITLE
fix: attach one yocto to the promise to engine_storage_withdraw

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,7 +1099,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1456,7 +1456,7 @@ dependencies = [
  "cxxbridge-cmd",
  "cxxbridge-flags",
  "cxxbridge-macro",
- "foldhash",
+ "foldhash 0.1.5",
  "link-cplusplus",
 ]
 
@@ -1941,7 +1941,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2125,6 +2125,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2285,7 +2291,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 dependencies = [
  "fallible-iterator 0.2.0",
- "indexmap 1.9.3",
  "stable_deref_trait",
 ]
 
@@ -2302,7 +2307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 dependencies = [
  "fallible-iterator 0.3.0",
- "indexmap 2.9.0",
+ "indexmap 2.13.0",
  "stable_deref_trait",
 ]
 
@@ -2361,7 +2366,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.9.0",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2392,7 +2397,7 @@ checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
  "serde",
 ]
 
@@ -2401,6 +2406,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "heck"
@@ -2835,13 +2845,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.3",
+ "hashbrown 0.16.1",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -4025,7 +4036,7 @@ version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "421541287c46fd58379f9b7a84513f8499c2482a2ac67e68337d18bb4edc92f4"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.13.0",
  "num-traits",
  "rkyv",
  "thiserror 2.0.12",
@@ -4283,7 +4294,7 @@ checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "crc32fast",
  "hashbrown 0.15.3",
- "indexmap 2.9.0",
+ "indexmap 2.13.0",
  "memchr",
 ]
 
@@ -4879,7 +4890,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -5209,7 +5220,7 @@ dependencies = [
  "bytecheck",
  "bytes",
  "hashbrown 0.16.1",
- "indexmap 2.9.0",
+ "indexmap 2.13.0",
  "munge",
  "ptr_meta",
  "rancor",
@@ -5305,7 +5316,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5318,7 +5329,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5593,7 +5604,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.13.0",
  "itoa",
  "memchr",
  "serde",
@@ -5634,7 +5645,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.9.0",
+ "indexmap 2.13.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -5660,7 +5671,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.13.0",
  "itoa",
  "ryu",
  "serde",
@@ -6064,7 +6075,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6365,7 +6376,7 @@ version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.13.0",
  "toml_datetime",
  "winnow",
 ]
@@ -6404,7 +6415,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.9.0",
+ "indexmap 2.13.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -6697,25 +6708,25 @@ dependencies = [
 
 [[package]]
 name = "walrus"
-version = "0.24.4"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff282e73d21b86a9d397f42570d158eb9e5c521d0ead4d13cd049fd7cb45c467"
+checksum = "8e227b6648df548f43f267aeee20dfd74d3121ccea10f6a73ea5aa319012df20"
 dependencies = [
  "anyhow",
- "gimli 0.26.2",
+ "gimli 0.32.3",
  "id-arena",
  "leb128",
  "log",
  "walrus-macro",
- "wasm-encoder 0.240.0",
- "wasmparser 0.240.0",
+ "wasm-encoder 0.245.1",
+ "wasmparser 0.245.1",
 ]
 
 [[package]]
 name = "walrus-macro"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef06db404cbaed87cb25fd2ca3a62502af485f43383c9641ffcf1479d02fffd"
+checksum = "cef8d704ff46ad931a2cd1f7a504fe43ffb8e968d931e179ff18d0dff4949bd5"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -6845,12 +6856,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.240.0"
+version = "0.245.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d642d8c5ecc083aafe9ceb32809276a304547a3a6eeecceb5d8152598bc71f"
+checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.240.0",
+ "wasmparser 0.245.1",
 ]
 
 [[package]]
@@ -6933,7 +6944,7 @@ checksum = "4abf1132c1fdf747d56bbc1bb52152400c70f336870f968b85e89ea422198ae3"
 dependencies = [
  "bitflags 2.9.1",
  "hashbrown 0.15.3",
- "indexmap 2.9.0",
+ "indexmap 2.13.0",
  "semver",
  "serde",
 ]
@@ -6946,20 +6957,20 @@ checksum = "a9b1e81f3eb254cf7404a82cee6926a4a3ccc5aad80cc3d43608a070c67aa1d7"
 dependencies = [
  "bitflags 2.9.1",
  "hashbrown 0.15.3",
- "indexmap 2.9.0",
+ "indexmap 2.13.0",
  "semver",
  "serde",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.240.0"
+version = "0.245.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b722dcf61e0ea47440b53ff83ccb5df8efec57a69d150e4f24882e4eba7e24a4"
+checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
 dependencies = [
  "bitflags 2.9.1",
- "hashbrown 0.15.3",
- "indexmap 2.9.0",
+ "hashbrown 0.16.1",
+ "indexmap 2.13.0",
  "semver",
  "serde",
 ]
@@ -6998,7 +7009,7 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "hashbrown 0.15.3",
- "indexmap 2.9.0",
+ "indexmap 2.13.0",
  "libc",
  "log",
  "mach2",
@@ -7037,7 +7048,7 @@ dependencies = [
  "cranelift-bitset",
  "cranelift-entity",
  "gimli 0.32.3",
- "indexmap 2.9.0",
+ "indexmap 2.13.0",
  "log",
  "object 0.37.3",
  "postcard",
@@ -7246,7 +7257,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ strum = { version = "0.27", features = ["derive"] }
 tempfile = "3"
 test-case = "3"
 tokio = { version = "1", default-features = false, features = ["macros"] }
-walrus = "0.24"
+walrus = "0.25"
 wee_alloc = { version = "0.4", default-features = false }
 
 [workspace.lints.clippy]

--- a/engine-tests-connector/Cargo.toml
+++ b/engine-tests-connector/Cargo.toml
@@ -13,8 +13,8 @@ autobenches = false
 [dev-dependencies]
 aurora-engine-types = { workspace = true, features = ["std", "impl-serde"] }
 anyhow.workspace = true
-cargo-near-build.workspace = true
-near-sdk.workspace = true
+cargo-near-build = { workspace = true, features = ["build_internal"] }
+near-sdk = { workspace = true, features = ["non-contract-usage"] }
 near-workspaces.workspace = true
 tokio = { workspace = true, features = ["macros"] }
 serde = { workspace = true, features = ["derive"] }
@@ -23,4 +23,3 @@ serde = { workspace = true, features = ["derive"] }
 workspace = true
 
 [features]
-

--- a/engine-tests-connector/src/connector.rs
+++ b/engine-tests-connector/src/connector.rs
@@ -837,6 +837,24 @@ async fn test_storage_unregister() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn test_storage_withdraw() -> anyhow::Result<()> {
+    let contract = TestContract::new().await?;
+
+    let res = contract
+        .engine_contract
+        .call("storage_withdraw")
+        .args_json(json!({
+            "amount": None::<U128>,
+        }))
+        .deposit(NearToken::from_yoctonear(1))
+        .max_gas()
+        .transact()
+        .await?;
+    assert!(res.is_success(), "{res:#?}");
+    Ok(())
+}
+
 async fn dummy_contract(contract: &TestContract) -> anyhow::Result<Contract> {
     contract
         .create_sub_account("ft-rec")

--- a/engine/src/contract_methods/connector.rs
+++ b/engine/src/contract_methods/connector.rs
@@ -335,7 +335,7 @@ pub fn storage_withdraw<I: IO + PromiseHandler + Copy, E: Env>(
             .map_err(Into::<ParseArgsError>::into)
     })?;
 
-    return_promise(io, env, "engine_storage_withdraw", args, ZERO_YOCTO)
+    return_promise(io, env, "engine_storage_withdraw", args, ONE_YOCTO)
 }
 
 pub fn storage_balance_of<I: IO + Copy + PromiseHandler + Env>(io: I) -> Result<(), ContractError> {

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -480,8 +480,8 @@ impl<'env, I: IO + Copy, E: Env, M: ModExpAlgorithm> Engine<'env, I, E, M> {
             price.min(priority_fee_per_gas)
         });
         let effective_gas_price = priority_fee_per_gas + self.block_base_fee_per_gas();
-        // First we try to use `fixed_gas`. At this point we already know that the `fixed_gas` is
-        // less than the `gas_limit`. It allows to avoid refund unused gas to the sender later.
+        // First, we try to use `fixed_gas`. At this point we already know that the `fixed_gas` is
+        // less than the `gas_limit`. It allows avoiding refunding unused gas to the sender later.
         let prepaid_amount = fixed_gas
             .map_or(transaction.gas_limit, EthGas::as_u256)
             .checked_mul(effective_gas_price)
@@ -641,6 +641,7 @@ impl<'env, I: IO + Copy, E: Env, M: ModExpAlgorithm> Engine<'env, I, E, M> {
 
         let (values, logs) = executor.into_state().deconstruct();
         let logs = filter_promises_from_logs(&self.io, handler, logs, &self.current_account_id);
+
         // The logs could be encoded as base64 or hex string.
         self.apply(values, Vec::<Log>::new(), true);
 
@@ -2048,7 +2049,7 @@ impl<J: IO + Copy, E: Env, M: ModExpAlgorithm> ApplyBackend for Engine<'_, J, E,
                 }
             }
         }
-        // These variable are only used if logging feature is enabled.
+        // These variables are only used if the logging feature is enabled.
         // In production logging is always enabled, so we can ignore the warnings.
         #[allow(unused_variables)]
         let total_bytes = 32 * writes_counter + code_bytes_written;

--- a/engine/src/xcc.rs
+++ b/engine/src/xcc.rs
@@ -155,7 +155,7 @@ where
     let promise_id = handler.promise_create_batch(&batch);
 
     if let AddressVersionStatus::DeployNeeded { .. } = deploy_needed {
-        // If a create and/or deploy was needed then we must attach a callback to update
+        // If a creation and/or deployment were needed, then we must attach a callback to update
         // the Engine's record of the account.
 
         let args = AddressVersionUpdateArgs {

--- a/etc/xcc-router/Cargo.lock
+++ b/etc/xcc-router/Cargo.lock
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "aurora-engine-types"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "borsh",
  "bs58 0.5.1",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated walrus dependency to version 0.25
  * Improved testing infrastructure configuration with enhanced feature support

* **Tests**
  * Added comprehensive test coverage for storage withdrawal operations

* **Bug Fixes**
  * Fixed storage withdrawal deposit requirement to ensure proper contract interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->