### PR TITLE
chore: update gas costs for bn256 precompile tests

### DIFF
--- a/engine-tests/src/tests/alt_bn256_precompiles.rs
+++ b/engine-tests/src/tests/alt_bn256_precompiles.rs
@@ -105,7 +105,7 @@ fn test_alt_bn128_add() {
         &Bn256Add::<Istanbul>::new(),
         Bn256Add::<Istanbul>::ADDRESS,
         include_str!("res/alt_bn_128/bn256_add.json"),
-        3587, // 3.587 TGas
+        3588, // 3.588 TGas
     );
 }
 
@@ -115,7 +115,7 @@ fn test_alt_bn128_mul() {
         &Bn256Mul::<Istanbul>::new(),
         Bn256Mul::<Istanbul>::ADDRESS,
         include_str!("res/alt_bn_128/bn256_mul.json"),
-        10226, // 10.226 TGas
+        10227, // 10.227 TGas
     );
 }
 


### PR DESCRIPTION
The changes in the gas consumption are affected by this PR #1091.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated gas-limit assertions in precompile test cases to reflect current expected gas consumption values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->