### PR TITLE
ci: skip security analysis for dependabot PRs

### DIFF
--- a/.github/workflows/contract-analysis.yml
+++ b/.github/workflows/contract-analysis.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   contract_analysis:
+    if: github.actor != 'dependabot[bot]'
     name: "Shared"
     uses: aurora-is-near/.github/.github/workflows/security_analysis.yml@master
     secrets: inherit


### PR DESCRIPTION
Dependabot PRs don't have access to repo secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to skip contract analysis checks for automated dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->