### PR TITLE
Fix: Small increase gas limit for tests alt-bn - add, mul, pairing

### DIFF
--- a/engine-tests/src/tests/alt_bn256_precompiles.rs
+++ b/engine-tests/src/tests/alt_bn256_precompiles.rs
@@ -105,7 +105,7 @@ fn test_alt_bn128_add() {
         &Bn256Add::<Istanbul>::new(),
         Bn256Add::<Istanbul>::ADDRESS,
         include_str!("res/alt_bn_128/bn256_add.json"),
-        3588, // 3.588 TGas
+        3590, // 3.590 TGas
     );
 }
 
@@ -115,7 +115,7 @@ fn test_alt_bn128_mul() {
         &Bn256Mul::<Istanbul>::new(),
         Bn256Mul::<Istanbul>::ADDRESS,
         include_str!("res/alt_bn_128/bn256_mul.json"),
-        10227, // 10.227 TGas
+        10230, // 10.230 TGas
     );
 }
 
@@ -125,6 +125,6 @@ fn test_alt_bn128_pairing() {
         &Bn256Pair::<Istanbul>::new(),
         Bn256Pair::<Istanbul>::ADDRESS,
         include_str!("res/alt_bn_128/bn256_pairing.json"),
-        44098, // 44.098 TGas
+        44100, // 44.100 TGas
     );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated gas limit bounds for alt_bn128 precompile tests to reflect current expected consumption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->