### PR TITLE
chore: replace Once with LazyLock in tests

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -13,6 +13,7 @@ WASM_FILE_TEST = "aurora-engine-test.wasm"
 XCC_ROUTER_WASM_FILE = "aurora-xcc-router.wasm"
 SWEEP_DAYS = 30
 BUILDER_HASH_COMMIT = "13430592a7be246dd5a29439791f4081e0107ff3" # https://hub.docker.com/r/nearprotocol/contract-builder/tags
+UDEPS_NIGHTLY_TOOLCHAIN = "nightly-2026-05-20" # We can't use the latest nightly because of the issue with the ambiguous name `splat` in the finite-wasm 0.5.0 crate.
 
 [tasks.sweep]
 category = "Cleanup"
@@ -67,16 +68,16 @@ args = [
     "--all",
 ]
 
-[tasks.install_nightly]
+[tasks.install_udeps_nightly]
 description = "Install the specific pinned nightly toolchain if missing"
 command = "rustup"
-args = ["toolchain", "install", "nightly-2026-05-20"]
+args = ["toolchain", "install", "${UDEPS_NIGHTLY_TOOLCHAIN}"]
 
 [tasks.udeps]
 category = "Check"
-dependencies = ["install_nightly"]
+dependencies = ["install_udeps_nightly"]
 env = { "CARGO_MAKE_CRATE_INSTALLATION_LOCKED" = "true" }
-toolchain = "nightly-2026-05-20" # We can't use the latest nightly because of the issue with the ambiguous name `splat` in the finite-wasm 0.5.0 crate.
+toolchain = "${UDEPS_NIGHTLY_TOOLCHAIN}"
 install_crate = { crate_name = "cargo-udeps", binary = "cargo", min_version = "0.1.61", test_arg = ["udeps", "-h"], force = true }
 command = "${CARGO}"
 args = [

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -67,11 +67,17 @@ args = [
     "--all",
 ]
 
+[tasks.install_nightly]
+description = "Install the specific pinned nightly toolchain if missing"
+command = "rustup"
+args = ["toolchain", "install", "nightly-2026-05-20"]
+
 [tasks.udeps]
 category = "Check"
+dependencies = ["install_nightly"]
 env = { "CARGO_MAKE_CRATE_INSTALLATION_LOCKED" = "true" }
-toolchain = "nightly"
-install_crate = { crate_name = "cargo-udeps", binary = "cargo", min_version = "0.1.55", test_arg = ["udeps", "-h"], force = true }
+toolchain = "nightly-2026-05-20" # We can't use the latest nightly because of the issue with the ambiguous name `splat` in the finite-wasm 0.5.0 crate.
+install_crate = { crate_name = "cargo-udeps", binary = "cargo", min_version = "0.1.61", test_arg = ["udeps", "-h"], force = true }
 command = "${CARGO}"
 args = [
     "udeps",

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -69,6 +69,7 @@ args = [
 ]
 
 [tasks.install_udeps_nightly]
+category = "Tools"
 description = "Install the specific pinned nightly toolchain if missing"
 command = "rustup"
 args = ["toolchain", "install", "${UDEPS_NIGHTLY_TOOLCHAIN}"]

--- a/engine-tests/src/benches/nft_pagination.rs
+++ b/engine-tests/src/benches/nft_pagination.rs
@@ -2,7 +2,7 @@ use aurora_engine_transactions::legacy::TransactionLegacy;
 use aurora_engine_types::parameters::engine::TransactionStatus;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::Once;
+use std::sync::LazyLock;
 
 use crate::prelude::{Address, U256, Wei};
 use crate::utils::{self, solidity};
@@ -10,8 +10,10 @@ use crate::utils::{self, solidity};
 const INITIAL_BALANCE: Wei = Wei::new_u64(1_000);
 const INITIAL_NONCE: u64 = 0;
 
-static DOWNLOAD_ONCE: Once = Once::new();
-static COMPILE_ONCE: Once = Once::new();
+static COMPILE_ARTIFACT_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
+    let sources_path = MarketPlaceConstructor::download_solidity_sources();
+    MarketPlaceConstructor::truffle_compile(sources_path)
+});
 
 pub fn measure_gas_usage(total_tokens: usize, data_size: usize, tokens_per_page: usize) -> u64 {
     let (mut runner, mut source_account, dest_address) = initialize_evm();
@@ -57,43 +59,39 @@ struct MarketPlace(solidity::DeployedContract);
 
 impl MarketPlaceConstructor {
     pub fn load() -> Self {
-        let sources_path = Self::download_solidity_sources();
-        let compile_artifact = Self::truffle_compile(sources_path);
         Self(solidity::ContractConstructor::compile_from_extended_json(
-            compile_artifact,
+            COMPILE_ARTIFACT_PATH.as_path(),
         ))
     }
 
     fn truffle_compile<P: AsRef<Path>>(contracts_dir: P) -> PathBuf {
-        COMPILE_ONCE.call_once(|| {
-            // install npm packages
-            let status = Command::new("/usr/bin/env")
-                .current_dir(contracts_dir.as_ref())
-                .args(["npm", "install"])
-                .status()
-                .unwrap();
-            assert!(status.success());
+        // install npm packages
+        let status = Command::new("/usr/bin/env")
+            .current_dir(contracts_dir.as_ref())
+            .args(["npm", "install"])
+            .status()
+            .unwrap();
+        assert!(status.success());
 
-            // install truffle
-            let status = Command::new("/usr/bin/env")
-                .current_dir(contracts_dir.as_ref())
-                .args(["npm", "install", "--save-dev", "truffle"])
-                .status()
-                .unwrap();
-            assert!(status.success());
+        // install truffle
+        let status = Command::new("/usr/bin/env")
+            .current_dir(contracts_dir.as_ref())
+            .args(["npm", "install", "--save-dev", "truffle"])
+            .status()
+            .unwrap();
+        assert!(status.success());
 
-            // compile
-            let status = Command::new("/usr/bin/env")
-                .current_dir(contracts_dir.as_ref())
-                .args([
-                    "node_modules/truffle/build/cli.bundled.js",
-                    "compile",
-                    "--all",
-                ])
-                .status()
-                .unwrap();
-            assert!(status.success());
-        });
+        // compile
+        let status = Command::new("/usr/bin/env")
+            .current_dir(contracts_dir.as_ref())
+            .args([
+                "node_modules/truffle/build/cli.bundled.js",
+                "compile",
+                "--all",
+            ])
+            .status()
+            .unwrap();
+        assert!(status.success());
 
         // compile artifacts are saved to this path
         // (specified in truffle config of `NFT-culturas-latinas` repo)
@@ -111,10 +109,8 @@ impl MarketPlaceConstructor {
         if !contracts_dir.exists() {
             // Contracts not already present, so download them (but only once, even
             // if multiple tests running in parallel saw `contracts_dir` does not exist).
-            DOWNLOAD_ONCE.call_once(|| {
-                let url = "https://github.com/birchmd/NFT-culturas-latinas.git";
-                git2::Repository::clone(url, sources_dir).unwrap();
-            });
+            let url = "https://github.com/birchmd/NFT-culturas-latinas.git";
+            git2::Repository::clone(url, sources_dir).unwrap();
         }
 
         contracts_dir

--- a/engine-tests/src/tests/modexp.rs
+++ b/engine-tests/src/tests/modexp.rs
@@ -125,7 +125,7 @@ fn bench_modexp_standalone() {
             .unwrap();
         let duration = start.elapsed().as_millis();
 
-        assert!(duration < 2000, "{path} failed to run in under 2 second");
+        assert!(duration < 2000, "{path} failed to run in under 2 seconds");
     };
 
     // These contracts run the modexp precompile in an infinite loop using strategically selecting

--- a/engine-tests/src/tests/modexp.rs
+++ b/engine-tests/src/tests/modexp.rs
@@ -125,7 +125,7 @@ fn bench_modexp_standalone() {
             .unwrap();
         let duration = start.elapsed().as_millis();
 
-        assert!(duration < 1000, "{path} failed to run in under 1 second");
+        assert!(duration < 2000, "{path} failed to run in under 2 second");
     };
 
     // These contracts run the modexp precompile in an infinite loop using strategically selecting

--- a/engine-tests/src/utils/solidity/erc20.rs
+++ b/engine-tests/src/utils/solidity/erc20.rs
@@ -1,7 +1,7 @@
 use aurora_engine_transactions::NormalizedEthTransaction;
 use aurora_engine_types::types::Wei;
 use std::path::{Path, PathBuf};
-use std::sync::Once;
+use std::sync::LazyLock;
 
 use crate::prelude::{Address, U256, transactions::legacy::TransactionLegacy};
 use crate::utils::solidity;
@@ -16,12 +16,13 @@ impl From<ERC20Constructor> for solidity::ContractConstructor {
     }
 }
 
-static DOWNLOAD_ONCE: Once = Once::new();
+static SOLIDITY_SOURCES: LazyLock<PathBuf> =
+    LazyLock::new(ERC20Constructor::download_solidity_sources);
 
 impl ERC20Constructor {
     pub fn load() -> Self {
         Self(solidity::ContractConstructor::compile_from_source(
-            Self::download_solidity_sources(),
+            SOLIDITY_SOURCES.as_path(),
             Self::solidity_artifacts_path(),
             "token/ERC20/presets/ERC20PresetMinterPauser.sol",
             "ERC20PresetMinterPauser",
@@ -59,18 +60,16 @@ impl ERC20Constructor {
         if !contracts_dir.exists() {
             // Contracts not already present, so download them (but only once, even
             // if multiple tests running in parallel saw `contracts_dir` does not exist).
-            DOWNLOAD_ONCE.call_once(|| {
-                let url = "https://github.com/OpenZeppelin/openzeppelin-contracts";
-                let repo = git2::Repository::clone(url, sources_dir).unwrap();
-                // We need to checkout a specific commit hash because the preset contract we use
-                // was removed from the repo later
-                // (https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3637).
-                let commit_hash =
-                    git2::Oid::from_str("dfef6a68ee18dbd2e1f5a099061a3b8a0e404485").unwrap();
-                repo.set_head_detached(commit_hash).unwrap();
-                let mut opts = git2::build::CheckoutBuilder::new();
-                repo.checkout_head(Some(opts.force())).unwrap();
-            });
+            let url = "https://github.com/OpenZeppelin/openzeppelin-contracts";
+            let repo = git2::Repository::clone(url, sources_dir).unwrap();
+            // We need to checkout a specific commit hash because the preset contract we use
+            // was removed from the repo later
+            // (https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3637).
+            let commit_hash =
+                git2::Oid::from_str("dfef6a68ee18dbd2e1f5a099061a3b8a0e404485").unwrap();
+            repo.set_head_detached(commit_hash).unwrap();
+            let mut opts = git2::build::CheckoutBuilder::new();
+            repo.checkout_head(Some(opts.force())).unwrap();
         }
 
         contracts_dir


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tests now use a lazy, memoized cache for compiled smart‑contract artifacts to avoid redundant compilation across concurrent runs.
  * Some external tool steps (install/compile/clone) are executed on each invocation while benefiting from the shared compilation cache.
  * Added a pinned nightly toolchain installer and updated the dependency‑check task to use the pinned toolchain and a newer checker minimum version.

* **Tests**
  * Increased a standalone benchmark threshold from 1s to 2s to reduce flaky failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->