### PR TITLE
fix: not rich allowance by decreasing attached gas

### DIFF
--- a/engine-tests/src/tests/access_keys.rs
+++ b/engine-tests/src/tests/access_keys.rs
@@ -116,11 +116,7 @@ async fn test_submit_by_relayer() {
         .unwrap();
     assert!(result.is_success());
 
-    let result = relayer
-        .call(&aurora.id(), "submit")
-        .max_gas()
-        .transact()
-        .await;
+    let result = relayer.call(&aurora.id(), "submit").transact().await;
     assert!(result.is_ok());
 }
 
@@ -156,11 +152,7 @@ async fn test_delete_relayer_key() {
         .unwrap();
     assert!(result.is_success());
 
-    let result = relayer
-        .call(&aurora.id(), "submit")
-        .max_gas()
-        .transact()
-        .await;
+    let result = relayer.call(&aurora.id(), "submit").transact().await;
     assert!(result.is_ok());
 
     let result = manager


### PR DESCRIPTION
The neacore 2.13.0 introduces changes to the transaction cost calculation, as proposed in [NEP-642](https://github.com/near/NEPs/pull/642). The tests fail on nearcore 2.13.0 because the allowance set for the function access key is insufficient after those changes. The current allowance is 0.5 N, while the total transaction cost exceeds 1 N on neacore 2.13.0. The fix removes the MAX_GAS attachment, which is 1PGas now, thereby decreasing the total cost of the transaction, since the default amount of attached gas is 10TGas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated transaction-related test coverage to match the current relayer flow.
  * Verified successful submission behavior remains intact after simplifying test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->