### PR TITLE
Feat: Bump to Rust 1.97

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -7,7 +7,7 @@ CARGO = "cargo"
 CARGO_TARGET = "wasm32-unknown-unknown"
 CARGO_FEATURES_BUILD = "contract"
 CARGO_FEATURES_BUILD_TEST = "contract,integration-test"
-RUSTC_FLAGS_BUILD = "-C link-arg=-s"
+RUSTC_FLAGS_BUILD = "-C link-arg=-s -C link-arg=--import-undefined"
 WASM_FILE = "aurora-engine.wasm"
 WASM_FILE_TEST = "aurora-engine-test.wasm"
 XCC_ROUTER_WASM_FILE = "aurora-xcc-router.wasm"
@@ -259,7 +259,7 @@ dependencies = [
 
 [tasks.build-xcc-router-inner]
 category = "Build"
-env = { "RUSTFLAGS" = "-C strip=symbols --remap-path-prefix ${HOME}=/path/to/home/ --remap-path-prefix ${PWD}=/path/to/source/", "RELEASE" = "--release", "TARGET_DIR" = "release" }
+env = { "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS" = "-C strip=symbols --remap-path-prefix ${HOME}=/path/to/home/ --remap-path-prefix ${PWD}=/path/to/source/ -C link-arg=--import-undefined", "RELEASE" = "--release", "TARGET_DIR" = "release" }
 script = '''
 cd etc/xcc-router
 cargo build --target ${CARGO_TARGET} --release
@@ -281,7 +281,7 @@ category = "Build"
 alias = "build-xcc-router"
 
 [tasks.build-test]
-env = { "RUSTFLAGS" = "${RUSTC_FLAGS_BUILD}", "CARGO_FEATURES" = "${CARGO_FEATURES_BUILD_TEST}", "WASM_FILE" = "${WASM_FILE_TEST}", "RELEASE" = "--release", "TARGET_DIR" = "release" }
+env = { "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS" = "${RUSTC_FLAGS_BUILD}", "CARGO_FEATURES" = "${CARGO_FEATURES_BUILD_TEST}", "WASM_FILE" = "${WASM_FILE_TEST}", "RELEASE" = "--release", "TARGET_DIR" = "release" }
 category = "Build"
 run_task = "build-engine-flow"
 
@@ -305,12 +305,12 @@ category = "Build"
 run_task = "wasm-opt-common"
 
 [tasks.build]
-env = { "RUSTFLAGS" = "-C strip=symbols --remap-path-prefix ${HOME}=/path/to/home/ --remap-path-prefix ${PWD}=/path/to/source/", "CARGO_FEATURES" = "${CARGO_FEATURES_BUILD}", "RELEASE" = "--release", "TARGET_DIR" = "release" }
+env = { "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS" = "-C strip=symbols --remap-path-prefix ${HOME}=/path/to/home/ --remap-path-prefix ${PWD}=/path/to/source/ -C link-arg=--import-undefined", "CARGO_FEATURES" = "${CARGO_FEATURES_BUILD}", "RELEASE" = "--release", "TARGET_DIR" = "release" }
 category = "Build"
 run_task = "build-engine-flow"
 
 [tasks.build-docker-inner]
-env = { "RUSTFLAGS" = "-C strip=symbols --remap-path-prefix ${HOME}=/path/to/home/ --remap-path-prefix ${PWD}=/path/to/source/", "CARGO_FEATURES" = "${CARGO_FEATURES_BUILD}", "RELEASE" = "--release", "TARGET_DIR" = "release" }
+env = { "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS" = "-C strip=symbols --remap-path-prefix ${HOME}=/path/to/home/ --remap-path-prefix ${PWD}=/path/to/source/ -C link-arg=--import-undefined", "CARGO_FEATURES" = "${CARGO_FEATURES_BUILD}", "RELEASE" = "--release", "TARGET_DIR" = "release" }
 category = "Build"
 run_task = "build-engine-flow-docker"
 
@@ -321,7 +321,7 @@ docker run --volume $PWD:/host -w /host -i --rm nearprotocol/contract-builder:ma
 '''
 
 [tasks.build-xcc-router-docker-inner]
-env = { "RUSTFLAGS" = "-C strip=symbols --remap-path-prefix ${HOME}=/path/to/home/ --remap-path-prefix ${PWD}=/path/to/source/", "CARGO_FEATURES" = "${CARGO_FEATURES_BUILD}", "RELEASE" = "--release", "TARGET_DIR" = "release" }
+env = { "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS" = "-C strip=symbols --remap-path-prefix ${HOME}=/path/to/home/ --remap-path-prefix ${PWD}=/path/to/source/ -C link-arg=--import-undefined", "CARGO_FEATURES" = "${CARGO_FEATURES_BUILD}", "RELEASE" = "--release", "TARGET_DIR" = "release" }
 category = "Build"
 run_task = "build-xcc-router-flow-docker"
 

--- a/engine-modexp/src/arith.rs
+++ b/engine-modexp/src/arith.rs
@@ -317,7 +317,7 @@ pub fn in_place_shr(a: &mut [Word], shift: u32) -> Word {
 
 // Performs a += b, returning if there was overflow
 pub fn in_place_add(a: &mut [Word], b: &[Word]) -> bool {
-    debug_assert!(a.len() == b.len());
+    debug_assert_eq!(a.len(), b.len());
 
     let mut c = false;
     for (a_digit, b_digit) in a.iter_mut().zip(b) {
@@ -331,7 +331,7 @@ pub fn in_place_add(a: &mut [Word], b: &[Word]) -> bool {
 
 // Performs `a -= xy`, returning the "borrow".
 pub fn in_place_mul_sub(a: &mut [Word], x: &[Word], y: Word) -> Word {
-    debug_assert!(a.len() == x.len());
+    debug_assert_eq!(a.len(), x.len());
 
     // a -= x*0 leaves a unchanged, so return early
     if y == 0 {

--- a/engine-precompiles/src/modexp.rs
+++ b/engine-precompiles/src/modexp.rs
@@ -990,7 +990,7 @@ mod tests_osaka {
         let res = run_modexp(&input, 10_000_000);
         match res {
             Err(ExitError::Other(msg)) => assert_eq!(msg, "ERR_MODEXP_SIZE_LIMIT"),
-            _ => panic!("Expected ERR_MODEXP_SIZE_LIMIT for huge base length, got {res:?}",),
+            _ => panic!("Expected ERR_MODEXP_SIZE_LIMIT for huge base length, got {res:?}"),
         }
     }
 

--- a/engine-precompiles/src/native.rs
+++ b/engine-precompiles/src/native.rs
@@ -1288,7 +1288,7 @@ mod tests {
 
         let args = super::ft_transfer_call_args(&receiver_id, amount, msg).unwrap();
         let expected =
-            format!(r#"{{"receiver_id":"{receiver_id}","amount":"{amount}","msg":"{msg}"}}"#,);
+            format!(r#"{{"receiver_id":"{receiver_id}","amount":"{amount}","msg":"{msg}"}}"#);
         assert_eq!(args, expected);
     }
 

--- a/engine-tests-connector/src/rust.rs
+++ b/engine-tests-connector/src/rust.rs
@@ -13,6 +13,14 @@ pub fn compile<P: AsRef<Path>>(manifest_path: P) -> PathBuf {
             .unwrap(),
         ),
         skip_rust_version_check: true,
+        // The newer wasm linker (rust-lld) no longer auto-imports the undefined NEAR host
+        // functions, so we must pass `--import-undefined` explicitly. This overrides
+        // cargo-near-build's default rustflags (`-C link-arg=-s`), which we keep, and
+        // `--cfg near` is still force-appended by the builder afterwards.
+        env: vec![(
+            "RUSTFLAGS".to_string(),
+            "-C link-arg=-s -C link-arg=--import-undefined".to_string(),
+        )],
         ..Default::default()
     };
 

--- a/engine-tests/src/tests/one_inch.rs
+++ b/engine-tests/src/tests/one_inch.rs
@@ -98,11 +98,11 @@ fn test_1inch_limit_order_deploy() {
     assert!(result.gas_used > 3_500_000);
     // less than 10 NEAR TGas used
     assert_gas_bound(profile.all_gas(), 9);
-    // at least 45% of which is from wasm execution
+    // at least 35% of which is from wasm execution
     let wasm_fraction = 100 * profile.wasm_gas() / profile.all_gas();
     assert!(
-        (40..=52).contains(&wasm_fraction),
-        "{wasm_fraction}% is not between 40% and 52%",
+        (35..=52).contains(&wasm_fraction),
+        "{wasm_fraction}% is not between 35% and 52%",
     );
 }
 

--- a/engine-tests/src/tests/repro.rs
+++ b/engine-tests/src/tests/repro.rs
@@ -27,7 +27,7 @@ fn repro_GdASJ3KESs() {
         block_timestamp: 1_645_717_564_644_206_730,
         input_path: "src/tests/res/input_GdASJ3KESs.hex",
         evm_gas_used: 706_713,
-        near_gas_used: 83,
+        near_gas_used: 78,
     });
 }
 
@@ -52,7 +52,7 @@ fn repro_8ru7VEA() {
         block_timestamp: 1_648_829_935_343_349_589,
         input_path: "src/tests/res/input_8ru7VEA.hex",
         evm_gas_used: 1_732_181,
-        near_gas_used: 143,
+        near_gas_used: 132,
     });
 }
 
@@ -72,7 +72,7 @@ fn repro_FRcorNv() {
         block_timestamp: 1_650_960_438_774_745_116,
         input_path: "src/tests/res/input_FRcorNv.hex",
         evm_gas_used: 1_239_721,
-        near_gas_used: 120,
+        near_gas_used: 111,
     });
 }
 
@@ -89,7 +89,7 @@ fn repro_5bEgfRQ() {
         block_timestamp: 1_651_073_772_931_594_646,
         input_path: "src/tests/res/input_5bEgfRQ.hex",
         evm_gas_used: 6_414_105,
-        near_gas_used: 432,
+        near_gas_used: 332,
     });
 }
 
@@ -107,7 +107,7 @@ fn repro_D98vwmi() {
         block_timestamp: 1_651_753_443_421_003_245,
         input_path: "src/tests/res/input_D98vwmi.hex",
         evm_gas_used: 1_035_348,
-        near_gas_used: 123,
+        near_gas_used: 114,
     });
 }
 
@@ -126,7 +126,7 @@ fn repro_Emufid2() {
         block_timestamp: 1_662_118_048_636_713_538,
         input_path: "src/tests/res/input_Emufid2.hex",
         evm_gas_used: 1_156_364,
-        near_gas_used: 129,
+        near_gas_used: 121,
     });
 }
 

--- a/engine-tests/src/tests/sanity.rs
+++ b/engine-tests/src/tests/sanity.rs
@@ -425,8 +425,8 @@ fn test_solidity_pure_bench() {
     );
     let near_gas = profile.all_gas();
     assert!(
-        near_gas > 1200 * 1_000_000_000_000 && near_gas < 1300 * 1_000_000_000_000,
-        "Expected between 1200 and 1300 NEAR TGas to be used, but consumed {}",
+        near_gas > 1050 * 1_000_000_000_000 && near_gas < 1200 * 1_000_000_000_000,
+        "Expected between 1050 and 1200 NEAR TGas to be used, but consumed {}",
         near_gas / 1_000_000_000_000,
     );
 

--- a/engine-tests/src/tests/uniswap.rs
+++ b/engine-tests/src/tests/uniswap.rs
@@ -38,7 +38,7 @@ fn test_uniswap_input_multihop() {
 
     let (_amount_out, _evm_gas, profile) = context.exact_input(&tokens, INPUT_AMOUNT.into());
 
-    assert_eq!(77, profile.all_gas() / 1_000_000_000_000);
+    assert_eq!(72, profile.all_gas() / 1_000_000_000_000);
 }
 
 #[test]
@@ -49,11 +49,11 @@ fn test_uniswap_exact_output() {
 
     let (_result, profile) =
         context.add_equal_liquidity(LIQUIDITY_AMOUNT.into(), &token_a, &token_b);
-    utils::assert_gas_bound(profile.all_gas(), 21);
+    utils::assert_gas_bound(profile.all_gas(), 19);
     let wasm_fraction = 100 * profile.wasm_gas() / profile.all_gas();
     assert!(
-        (45..=55).contains(&wasm_fraction),
-        "{wasm_fraction}% is not between 50% and 60%",
+        (40..=55).contains(&wasm_fraction),
+        "{wasm_fraction}% is not between 40% and 55%",
     );
 
     let (_amount_in, profile) =
@@ -61,8 +61,8 @@ fn test_uniswap_exact_output() {
     utils::assert_gas_bound(profile.all_gas(), 13);
     let wasm_fraction = 100 * profile.wasm_gas() / profile.all_gas();
     assert!(
-        (45..=55).contains(&wasm_fraction),
-        "{wasm_fraction}% is not between 50% and 60%",
+        (40..=55).contains(&wasm_fraction),
+        "{wasm_fraction}% is not between 40% and 55%",
     );
 }
 

--- a/engine-tests/src/utils/rust.rs
+++ b/engine-tests/src/utils/rust.rs
@@ -13,6 +13,14 @@ pub fn compile<P: AsRef<Path>>(manifest_path: P) -> PathBuf {
             .unwrap(),
         ),
         skip_rust_version_check: true,
+        // The newer wasm linker (rust-lld) no longer auto-imports the undefined NEAR host
+        // functions, so we must pass `--import-undefined` explicitly. This overrides
+        // cargo-near-build's default rustflags (`-C link-arg=-s`), which we keep, and
+        // `--cfg near` is still force-appended by the builder afterwards.
+        env: vec![(
+            "RUSTFLAGS".to_string(),
+            "-C link-arg=-s -C link-arg=--import-undefined".to_string(),
+        )],
         ..Default::default()
     };
 

--- a/engine/src/contract_methods/silo/mod.rs
+++ b/engine/src/contract_methods/silo/mod.rs
@@ -18,8 +18,7 @@ const ERC20_FALLBACK_KEY: &[u8] = b"ERC20_FALLBACK_KEY";
 
 /// Return SILO parameters.
 pub fn get_silo_params<I: IO>(io: &I) -> Option<SiloParamsArgs> {
-    let params = get_fixed_gas(io)
-        .and_then(|cost| get_erc20_fallback_address(io).map(|address| (cost, address)));
+    let params = get_fixed_gas(io).zip(get_erc20_fallback_address(io));
 
     params.map(|(cost, address)| SiloParamsArgs {
         fixed_gas: cost,

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.93.0"
+channel = "1.97.0"
 targets = ["wasm32-unknown-unknown"]
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Build & Compatibility**
  - Updated the Rust toolchain to version 1.97.0.
  - Improved WebAssembly builds to support undefined host-function imports with newer linkers.

- **Bug Fixes**
  - Corrected parameter pairing when retrieving Silo configuration.
  - Updated gas usage expectations for contract execution and profiling tests.

- **Tests**
  - Refined deployment, transaction reproduction, and integration test thresholds to reflect current execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->