### PR TITLE
fix: link issue with rust 1.97.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,7 @@ panic = "abort"
 incremental = false
 codegen-units = 1
 rpath = false
+strip = "symbols"
 
 [profile.dev]
 # Due to a strange bug, setting this to 3 will cause test failures
@@ -139,6 +140,7 @@ panic = "abort"
 incremental = false
 codegen-units = 1
 rpath = false
+strip = "symbols"
 
 [profile.bench]
 # lto must be enabled in the bench profile as well for

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -7,7 +7,7 @@ CARGO = "cargo"
 CARGO_TARGET = "wasm32-unknown-unknown"
 CARGO_FEATURES_BUILD = "contract"
 CARGO_FEATURES_BUILD_TEST = "contract,integration-test"
-RUSTC_FLAGS_BUILD = "-C link-arg=-s -C link-arg=--import-undefined"
+RUSTC_FLAGS_BUILD = "-C link-arg=-s"
 WASM_FILE = "aurora-engine.wasm"
 WASM_FILE_TEST = "aurora-engine-test.wasm"
 XCC_ROUTER_WASM_FILE = "aurora-xcc-router.wasm"
@@ -259,7 +259,7 @@ dependencies = [
 
 [tasks.build-xcc-router-inner]
 category = "Build"
-env = { "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS" = "-C strip=symbols --remap-path-prefix ${HOME}=/path/to/home/ --remap-path-prefix ${PWD}=/path/to/source/ -C link-arg=--import-undefined", "RELEASE" = "--release", "TARGET_DIR" = "release" }
+env = { "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS" = "-C strip=symbols --remap-path-prefix ${HOME}=/path/to/home/ --remap-path-prefix ${PWD}=/path/to/source/", "RELEASE" = "--release", "TARGET_DIR" = "release" }
 script = '''
 cd etc/xcc-router
 cargo build --target ${CARGO_TARGET} --release
@@ -305,12 +305,12 @@ category = "Build"
 run_task = "wasm-opt-common"
 
 [tasks.build]
-env = { "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS" = "-C strip=symbols --remap-path-prefix ${HOME}=/path/to/home/ --remap-path-prefix ${PWD}=/path/to/source/ -C link-arg=--import-undefined", "CARGO_FEATURES" = "${CARGO_FEATURES_BUILD}", "RELEASE" = "--release", "TARGET_DIR" = "release" }
+env = { "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS" = "-C strip=symbols --remap-path-prefix ${HOME}=/path/to/home/ --remap-path-prefix ${PWD}=/path/to/source/", "CARGO_FEATURES" = "${CARGO_FEATURES_BUILD}", "RELEASE" = "--release", "TARGET_DIR" = "release" }
 category = "Build"
 run_task = "build-engine-flow"
 
 [tasks.build-docker-inner]
-env = { "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS" = "-C strip=symbols --remap-path-prefix ${HOME}=/path/to/home/ --remap-path-prefix ${PWD}=/path/to/source/ -C link-arg=--import-undefined", "CARGO_FEATURES" = "${CARGO_FEATURES_BUILD}", "RELEASE" = "--release", "TARGET_DIR" = "release" }
+env = { "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS" = "-C strip=symbols --remap-path-prefix ${HOME}=/path/to/home/ --remap-path-prefix ${PWD}=/path/to/source/", "CARGO_FEATURES" = "${CARGO_FEATURES_BUILD}", "RELEASE" = "--release", "TARGET_DIR" = "release" }
 category = "Build"
 run_task = "build-engine-flow-docker"
 
@@ -321,7 +321,7 @@ docker run --volume $PWD:/host -w /host -i --rm nearprotocol/contract-builder:ma
 '''
 
 [tasks.build-xcc-router-docker-inner]
-env = { "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS" = "-C strip=symbols --remap-path-prefix ${HOME}=/path/to/home/ --remap-path-prefix ${PWD}=/path/to/source/ -C link-arg=--import-undefined", "CARGO_FEATURES" = "${CARGO_FEATURES_BUILD}", "RELEASE" = "--release", "TARGET_DIR" = "release" }
+env = { "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS" = "-C strip=symbols --remap-path-prefix ${HOME}=/path/to/home/ --remap-path-prefix ${PWD}=/path/to/source/", "CARGO_FEATURES" = "${CARGO_FEATURES_BUILD}", "RELEASE" = "--release", "TARGET_DIR" = "release" }
 category = "Build"
 run_task = "build-xcc-router-flow-docker"
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -7,7 +7,7 @@ CARGO = "cargo"
 CARGO_TARGET = "wasm32-unknown-unknown"
 CARGO_FEATURES_BUILD = "contract"
 CARGO_FEATURES_BUILD_TEST = "contract,integration-test"
-RUSTC_FLAGS_BUILD = "-C link-arg=-s"
+RUSTC_WASM32_BUILD_FLAGS = "--remap-path-prefix ${HOME}=/path/to/home/ --remap-path-prefix ${PWD}=/path/to/source/ -C link-arg=--allow-undefined"
 WASM_FILE = "aurora-engine.wasm"
 WASM_FILE_TEST = "aurora-engine-test.wasm"
 XCC_ROUTER_WASM_FILE = "aurora-xcc-router.wasm"
@@ -173,7 +173,7 @@ echo "    CARGO_FEATURES:       ${CARGO_FEATURES}"
 echo "    WASM_FILE:            ${WASM_FILE}"
 echo "    SIZE_WASM_FILE:       $(wc -c bin/${WASM_FILE} | awk '{print $1}')"
 echo "    TARGET_DIR:           ${TARGET_DIR}"
-echo "    RUSTFLAGS:            ${RUSTFLAGS}"
+echo "    RUSTFLAGS:            ${RUSTC_WASM32_BUILD_FLAGS}"
 echo "    Extra build args:     ${RELEASE} ${@}"
 '''
 
@@ -186,7 +186,7 @@ echo "    CARGO_FEATURES:       ${CARGO_FEATURES}"
 echo "    WASM_FILE:            ${XCC_ROUTER_WASM_FILE}"
 echo "    SIZE_WASM_FILE:       $(wc -c bin/${XCC_ROUTER_WASM_FILE} | awk '{print $1}')"
 echo "    TARGET_DIR:           ${TARGET_DIR}"
-echo "    RUSTFLAGS:            ${RUSTFLAGS}"
+echo "    RUSTFLAGS:            ${RUSTC_WASM32_BUILD_FLAGS}"
 echo "    Extra build args:     ${RELEASE} ${@}"
 '''
 
@@ -259,7 +259,7 @@ dependencies = [
 
 [tasks.build-xcc-router-inner]
 category = "Build"
-env = { "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS" = "-C strip=symbols --remap-path-prefix ${HOME}=/path/to/home/ --remap-path-prefix ${PWD}=/path/to/source/", "RELEASE" = "--release", "TARGET_DIR" = "release" }
+env = { "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS" = "${RUSTC_WASM32_BUILD_FLAGS}", "RELEASE" = "--release", "TARGET_DIR" = "release" }
 script = '''
 cd etc/xcc-router
 cargo build --target ${CARGO_TARGET} --release
@@ -281,7 +281,7 @@ category = "Build"
 alias = "build-xcc-router"
 
 [tasks.build-test]
-env = { "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS" = "${RUSTC_FLAGS_BUILD}", "CARGO_FEATURES" = "${CARGO_FEATURES_BUILD_TEST}", "WASM_FILE" = "${WASM_FILE_TEST}", "RELEASE" = "--release", "TARGET_DIR" = "release" }
+env = { "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS" = "${RUSTC_WASM32_BUILD_FLAGS}", "CARGO_FEATURES" = "${CARGO_FEATURES_BUILD_TEST}", "WASM_FILE" = "${WASM_FILE_TEST}", "RELEASE" = "--release", "TARGET_DIR" = "release" }
 category = "Build"
 run_task = "build-engine-flow"
 
@@ -305,12 +305,12 @@ category = "Build"
 run_task = "wasm-opt-common"
 
 [tasks.build]
-env = { "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS" = "-C strip=symbols --remap-path-prefix ${HOME}=/path/to/home/ --remap-path-prefix ${PWD}=/path/to/source/", "CARGO_FEATURES" = "${CARGO_FEATURES_BUILD}", "RELEASE" = "--release", "TARGET_DIR" = "release" }
+env = { "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS" = "${RUSTC_WASM32_BUILD_FLAGS}", "CARGO_FEATURES" = "${CARGO_FEATURES_BUILD}", "RELEASE" = "--release", "TARGET_DIR" = "release" }
 category = "Build"
 run_task = "build-engine-flow"
 
 [tasks.build-docker-inner]
-env = { "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS" = "-C strip=symbols --remap-path-prefix ${HOME}=/path/to/home/ --remap-path-prefix ${PWD}=/path/to/source/", "CARGO_FEATURES" = "${CARGO_FEATURES_BUILD}", "RELEASE" = "--release", "TARGET_DIR" = "release" }
+env = { "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS" = "${RUSTC_WASM32_BUILD_FLAGS}", "CARGO_FEATURES" = "${CARGO_FEATURES_BUILD}", "RELEASE" = "--release", "TARGET_DIR" = "release" }
 category = "Build"
 run_task = "build-engine-flow-docker"
 
@@ -321,7 +321,7 @@ docker run --volume $PWD:/host -w /host -i --rm nearprotocol/contract-builder:ma
 '''
 
 [tasks.build-xcc-router-docker-inner]
-env = { "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS" = "-C strip=symbols --remap-path-prefix ${HOME}=/path/to/home/ --remap-path-prefix ${PWD}=/path/to/source/", "CARGO_FEATURES" = "${CARGO_FEATURES_BUILD}", "RELEASE" = "--release", "TARGET_DIR" = "release" }
+env = { "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS" = "${RUSTC_WASM32_BUILD_FLAGS}", "CARGO_FEATURES" = "${CARGO_FEATURES_BUILD}", "RELEASE" = "--release", "TARGET_DIR" = "release" }
 category = "Build"
 run_task = "build-xcc-router-flow-docker"
 

--- a/engine-sdk/src/exports.rs
+++ b/engine-sdk/src/exports.rs
@@ -1,4 +1,5 @@
 #[allow(unused)]
+#[link(wasm_import_module = "env")]
 unsafe extern "C" {
     // #############
     // # Registers #


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebAssembly build compatibility by explicitly specifying the import module used for resolving functions.
  * Updated WebAssembly build linker flag configuration to use dedicated WASM-target settings, reducing unsupported linker behavior.
* **Build & Release**
  * Enabled symbol stripping in both development and release build profiles to reduce output size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->