### PR TITLE
Chore: Remove `clone` from EIP-7702 transaction

### DIFF
--- a/engine-transactions/src/lib.rs
+++ b/engine-transactions/src/lib.rs
@@ -142,19 +142,22 @@ impl TryFrom<EthTransactionKind> for NormalizedEthTransaction {
                 access_list: tx.transaction.access_list,
                 authorization_list: vec![],
             },
-            Eip7702(tx) => Self {
-                address: tx.sender()?,
-                chain_id: Some(tx.transaction.chain_id),
-                nonce: tx.transaction.nonce,
-                gas_limit: tx.transaction.gas_limit,
-                max_priority_fee_per_gas: tx.transaction.max_priority_fee_per_gas,
-                max_fee_per_gas: tx.transaction.max_fee_per_gas,
-                to: Some(tx.transaction.to),
-                value: tx.transaction.value,
-                data: tx.transaction.data.clone(),
-                access_list: tx.transaction.access_list.clone(),
-                authorization_list: tx.authorization_list()?,
-            },
+            Eip7702(tx) => {
+                let authorization_list = tx.authorization_list()?;
+                Self {
+                    address: tx.sender()?,
+                    chain_id: Some(tx.transaction.chain_id),
+                    nonce: tx.transaction.nonce,
+                    gas_limit: tx.transaction.gas_limit,
+                    max_priority_fee_per_gas: tx.transaction.max_priority_fee_per_gas,
+                    max_fee_per_gas: tx.transaction.max_fee_per_gas,
+                    to: Some(tx.transaction.to),
+                    value: tx.transaction.value,
+                    data: tx.transaction.data,
+                    access_list: tx.transaction.access_list,
+                    authorization_list,
+                }
+            }
         })
     }
 }

--- a/engine-transactions/src/lib.rs
+++ b/engine-transactions/src/lib.rs
@@ -143,7 +143,6 @@ impl TryFrom<EthTransactionKind> for NormalizedEthTransaction {
                 authorization_list: vec![],
             },
             Eip7702(tx) => {
-                let authorization_list = tx.authorization_list()?;
                 Self {
                     address: tx.sender()?,
                     chain_id: Some(tx.transaction.chain_id),
@@ -155,7 +154,7 @@ impl TryFrom<EthTransactionKind> for NormalizedEthTransaction {
                     value: tx.transaction.value,
                     data: tx.transaction.data,
                     access_list: tx.transaction.access_list,
-                    authorization_list,
+                    authorization_list: tx.authorization_list()?,
                 }
             }
         })

--- a/engine-transactions/src/lib.rs
+++ b/engine-transactions/src/lib.rs
@@ -143,8 +143,10 @@ impl TryFrom<EthTransactionKind> for NormalizedEthTransaction {
                 authorization_list: vec![],
             },
             Eip7702(tx) => {
+                let address = tx.sender()?;
+                let authorization_list = tx.authorization_list()?;
                 Self {
-                    address: tx.sender()?,
+                    address,
                     chain_id: Some(tx.transaction.chain_id),
                     nonce: tx.transaction.nonce,
                     gas_limit: tx.transaction.gas_limit,
@@ -154,7 +156,7 @@ impl TryFrom<EthTransactionKind> for NormalizedEthTransaction {
                     value: tx.transaction.value,
                     data: tx.transaction.data,
                     access_list: tx.transaction.access_list,
-                    authorization_list: tx.authorization_list()?,
+                    authorization_list,
                 }
             }
         })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved normalization of EIP-7702 transactions by preserving transaction data and access-list information consistently.
  * Maintained reliable sender extraction and authorization-list error reporting.
  * Reduced unnecessary duplication while keeping normalized transaction details unchanged.
  * Improved consistency when preparing EIP-7702 transactions for downstream processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->