### PR TITLE
perf(modexp): build the window table only as far as it is used

### DIFF
--- a/engine-modexp/src/mpnat.rs
+++ b/engine-modexp/src/mpnat.rs
@@ -1000,10 +1000,15 @@ fn test_modexp_sparse_exponents() {
         }
 
         // Every window holding the same digit `d`, which walks the largest digit
-        // the exponent reaches through each value it can take for that `w`.
-        for bits in [16usize, 64, 256, 768, 1024] {
+        // the exponent reaches through each value it can take for that `w`. Each
+        // width here is an exact multiple of its own window width and sits inside
+        // its `montgomery_window_width` bracket, so the topmost window cannot run
+        // past `bits` and carry the exponent into the next bracket up. Widths that
+        // do not divide evenly sweep `d` against one `w` while `modpow_montgomery`
+        // picks another, and the digits it sees are then not the ones being swept.
+        for bits in [16usize, 63, 256, 765, 1020] {
             let w = montgomery_window_width(bits);
-            let nbytes = bits.div_ceil(8) + 1;
+            let nbytes = bits.div_ceil(8);
             for d in 1..(1usize << w) {
                 let mut exp = vec![0u8; nbytes];
                 for wi in 0..bits.div_ceil(w) {

--- a/engine-modexp/src/mpnat.rs
+++ b/engine-modexp/src/mpnat.rs
@@ -813,6 +813,25 @@ fn test_modpow_montgomery() {
     );
 }
 
+// `num::BigUint::modpow` panics on a zero modulus, so mirror `modexp`'s
+// convention (empty output) there. Returns big-endian bytes.
+#[cfg(test)]
+fn oracle(base: &[u8], exp: &[u8], modulus: &[u8]) -> Vec<u8> {
+    let m = num::BigUint::from_bytes_be(modulus);
+    if m == num::BigUint::from(0u8) {
+        return Vec::new();
+    }
+    let b = num::BigUint::from_bytes_be(base);
+    let e = num::BigUint::from_bytes_be(exp);
+    b.modpow(&e, &m).to_bytes_be()
+}
+
+#[cfg(test)]
+fn strip(v: &[u8]) -> &[u8] {
+    let i = v.iter().position(|&b| b != 0).unwrap_or(v.len());
+    &v[i..]
+}
+
 // Randomized property test: check `modexp` against an independent oracle
 // (`num::BigUint::modpow`) across many shapes. This exercises the windowed
 // Montgomery path together with the even-modulus (CRT) and power-of-two paths,
@@ -840,23 +859,6 @@ fn test_modexp_random_against_biguint() {
         fn range(&mut self, lo: usize, hi: usize) -> usize {
             lo + (self.next() as usize) % (hi - lo + 1)
         }
-    }
-
-    // `num::BigUint::modpow` panics on a zero modulus, so mirror `modexp`'s
-    // convention (empty output) there. Returns big-endian bytes.
-    fn oracle(base: &[u8], exp: &[u8], modulus: &[u8]) -> Vec<u8> {
-        let m = num::BigUint::from_bytes_be(modulus);
-        if m == num::BigUint::from(0u8) {
-            return Vec::new();
-        }
-        let b = num::BigUint::from_bytes_be(base);
-        let e = num::BigUint::from_bytes_be(exp);
-        b.modpow(&e, &m).to_bytes_be()
-    }
-
-    fn strip(v: &[u8]) -> &[u8] {
-        let i = v.iter().position(|&b| b != 0).unwrap_or(v.len());
-        &v[i..]
     }
 
     // Builds an exponent with exactly `bits` significant bits by pinning the
@@ -941,6 +943,112 @@ fn test_modexp_random_against_biguint() {
                 strip(&got),
                 strip(&want),
                 "wide modexp mismatch: n={n} bits={bits}"
+            );
+        }
+    }
+}
+
+// The randomized test above draws its exponents from random bytes, and a random
+// exponent of any width reaches digit `2^w - 1` in some window with near
+// certainty, so it only ever exercises a full-length window table. These cases
+// hold the largest digit down on purpose, which is what shortens the table. A
+// single set bit is the extreme: every window below the top one is zero, so the
+// table is as short as it can be. Fully deterministic, with no PRNG, so a
+// failure names one reproducible exponent.
+#[test]
+fn test_modexp_sparse_exponents() {
+    for n in [8usize, 32, 64, 128] {
+        let mut modulus: Vec<u8> = (0..n).map(|i| u8::try_from(i % 256).unwrap()).collect();
+        modulus[0] |= 0x80;
+        let last = modulus.len() - 1;
+        modulus[last] |= 1;
+        let base: Vec<u8> = (0..n)
+            .map(|i| u8::try_from((i * 97 + 3) % 256).unwrap())
+            .collect();
+
+        // `2^k`, with `k` inside every `montgomery_window_width` bracket and on
+        // both sides of its boundaries.
+        for k in [
+            0usize, 1, 7, 15, 16, 17, 63, 64, 65, 255, 256, 257, 767, 768, 769,
+        ] {
+            let mut exp = vec![0u8; k / 8 + 1];
+            exp[0] = 1 << (k % 8);
+            let got = crate::modexp(&base, &exp, &modulus);
+            assert_eq!(
+                strip(&got),
+                strip(&oracle(&base, &exp, &modulus)),
+                "single-bit exponent mismatch: n={n} k={k}"
+            );
+        }
+
+        // A few set bits spread through a wide exponent, so the non-zero digits
+        // are far apart and most windows are skipped entirely.
+        for bits in [64usize, 129, 300, 800] {
+            let nbytes = bits.div_ceil(8);
+            let mut exp = vec![0u8; nbytes];
+            // Pin the top bit so `bits` is the exponent's real significant length.
+            exp[0] = 1 << ((bits - 1) % 8);
+            for bit in [1usize, 17, 53].iter().filter(|b| **b < bits - 8) {
+                exp[nbytes - 1 - bit / 8] |= 1 << (bit % 8);
+            }
+            let got = crate::modexp(&base, &exp, &modulus);
+            assert_eq!(
+                strip(&got),
+                strip(&oracle(&base, &exp, &modulus)),
+                "sparse exponent mismatch: n={n} bits={bits}"
+            );
+        }
+
+        // Every window holding the same digit `d`, which walks the largest digit
+        // the exponent reaches through each value it can take for that `w`.
+        for bits in [16usize, 64, 256, 768, 1024] {
+            let w = montgomery_window_width(bits);
+            let nbytes = bits.div_ceil(8) + 1;
+            for d in 1..(1usize << w) {
+                let mut exp = vec![0u8; nbytes];
+                for wi in 0..bits.div_ceil(w) {
+                    for j in 0..w {
+                        let bit = wi * w + j;
+                        if (d >> j) & 1 == 1 && bit / 8 < nbytes {
+                            exp[nbytes - 1 - bit / 8] |= 1 << (bit % 8);
+                        }
+                    }
+                }
+                let got = crate::modexp(&base, &exp, &modulus);
+                assert_eq!(
+                    strip(&got),
+                    strip(&oracle(&base, &exp, &modulus)),
+                    "uniform-digit exponent mismatch: n={n} bits={bits} d={d}"
+                );
+            }
+        }
+
+        // The largest digit sitting in the lowest window, with everything
+        // between it and the top left at zero. A scan that stopped one window
+        // short at either end would size the table off this case.
+        for nbytes in [8usize, 32, 96, 129] {
+            let mut exp = vec![0u8; nbytes];
+            exp[0] = 1;
+            // `0x3f` saturates the lowest window for every `w` the widths table
+            // can pick, since `w` never exceeds 6.
+            exp[nbytes - 1] = 0x3f;
+            let got = crate::modexp(&base, &exp, &modulus);
+            assert_eq!(
+                strip(&got),
+                strip(&oracle(&base, &exp, &modulus)),
+                "low-window exponent mismatch: n={n} nbytes={nbytes}"
+            );
+        }
+
+        // Exponents that turn up in real traffic. RSA verification uses 65537,
+        // whose base-8 digits are `2,0,0,0,0,1` and so reach digit 2 of a
+        // possible 8.
+        for exp in [vec![0x03u8], vec![0x11], vec![0x01, 0x00, 0x01]] {
+            let got = crate::modexp(&base, &exp, &modulus);
+            assert_eq!(
+                strip(&got),
+                strip(&oracle(&base, &exp, &modulus)),
+                "well-known exponent mismatch: n={n} exp={exp:02x?}"
             );
         }
     }

--- a/engine-modexp/src/mpnat.rs
+++ b/engine-modexp/src/mpnat.rs
@@ -390,11 +390,26 @@ impl MPNat {
         if total_bits > 0 {
             let w = montgomery_window_width(total_bits);
 
-            // `table[i]` holds `base^i` in Montgomery form, for `i` in `0..2^w`.
-            // Each entry is stored with exactly `s` digits so it can be used
-            // directly by `monsq`/`monpro` and copied without length juggling.
-            // `x_bar` currently holds `base^0` = Montgomery form of 1.
-            let table_len = 1_usize << w;
+            // `table[i]` holds `base^i` in Montgomery form. Each entry is stored
+            // with exactly `s` digits so it can be used directly by
+            // `monsq`/`monpro` and copied without length juggling. `x_bar`
+            // currently holds `base^0` = Montgomery form of 1.
+            //
+            // The table is a chain: each entry costs one `monpro` over the one
+            // below it, so reaching digit `d` requires building every entry up
+            // to `d`. Only the digits the exponent actually uses need to be
+            // reachable, so stop the chain at the largest one that occurs rather
+            // than filling all `2^w` slots. A sparse exponent such as `65537`
+            // (base-8 digits `2,0,0,0,0,1` at `w = 3`) then builds one entry
+            // instead of six. The scan costs `total_bits` bit reads, negligible
+            // against even a single `monsq`, and a dense exponent reaches
+            // `2^w - 1` anyway and so is unaffected.
+            let num_windows = total_bits.div_ceil(w);
+            let mut max_digit = 1;
+            for wi in 0..num_windows {
+                max_digit = max_digit.max(nth_window(exp, wi * w, w));
+            }
+            let table_len = max_digit + 1;
             let mut table: Vec<Self> = Vec::with_capacity(table_len);
             table.push(x_bar.clone());
             {
@@ -419,8 +434,8 @@ impl MPNat {
 
             // Scan the exponent's base-`2^w` digits from most to least significant.
             // Seed the accumulator with the top window, which avoids `w` squarings
-            // of Montgomery(1).
-            let num_windows = total_bits.div_ceil(w);
+            // of Montgomery(1). `total_bits` is exact, so the most significant bit
+            // falls inside the top window and `top` is non-zero, hence in range.
             let top = nth_window(exp, (num_windows - 1) * w, w);
             x_bar.digits.copy_from_slice(&table[top].digits);
 


### PR DESCRIPTION
## Description

Follow-up to #1188, which replaced the bit-by-bit binary square-and-multiply in `MPNat::modpow_montgomery` with `2^w`-ary windowed exponentiation. This PR fixes one thing that PR left on the table: the precomputed table was built eagerly.

#1188 filled all `2^w` table slots before looking at the exponent. The table is a chain, so entry `d` costs one `monpro` over entry `d - 1`, and an exponent that never uses a high digit still paid for every entry below it. This PR scans the exponent's base-`2^w` digits first and stops the chain at the largest digit that actually occurs.

The windowing itself, the window widths, and the exact-bit-length handling from #1188 are all unchanged. The only difference is how far the chain is built.

For `e = 65537` (base-8 digits `2,0,0,0,0,1` at `w = 3`) the table drops from six Montgomery multiplications to one. That case matters because 65537 is the usual RSA public exponent and RSA signature verification is EIP-198's main application.

## Performance / NEAR gas cost considerations

**No gas test changes are needed in this PR.** Both tests #1188 re-baselined still pass unchanged:

- `repro_Emufid2`: still 117 TGas, EVM gas unchanged
- `bench_modexp` and `bench_modexp_standalone`: still pass, Aurora still the least-gas implementation

Worth stating precisely: the assertion truncates (`profile.all_gas() / 1_000_000_000_000`), so at 117 TGas this shows the change is below one TGas of resolution rather than exactly zero. That is consistent with dense exponents measuring 1.00x, since `Emufid2` is not a sparse-exponent workload.

Costs below are counted two ways. Multiply-equivalents are deterministic: a squaring is counted at 0.75 of a multiply, because `big_sq` is ~1.5s^2 word multiplies against `monpro`'s 2s^2. Wall clock is min of 9 interleaved rounds, release + LTO.

Sparse exponents, which are the ones that were overpaying:

| case | before (#1188) | after | speedup |
|---|---|---|---|
| `e = 65537`, 2048-bit modulus | 19.2 mul-equiv | 14.2 mul-equiv | 0.77-0.81x |
| `e = 65537`, 1024-bit modulus | 19.2 mul-equiv | 14.2 mul-equiv | 0.81-0.83x |

This also removes a regression against the pre-windowing binary method at exponent lengths just past a window-width threshold, where the table grew but the exponent had not grown to pay for it:

| case | binary (pre-#1188) | #1188 eager | this PR |
|---|---|---|---|
| `e = 2^64` (L=65, w=4) | 56.0 mul-equiv | 63.0, **1.08x slower** | 49.0, 0.88x |
| `e = 2^256` (L=257, w=5) | 200.0 mul-equiv | 222.2, **1.08x slower** | 193.2, 0.96x |
| `e = 2^768` (L=769, w=6) | 584.0 mul-equiv | 639.0, **1.07x slower** | 577.0, 0.98x |

Dense exponents reach `2^w - 1` regardless and are unchanged, measured at 1.00x for both a 2048-bit and a 1024-bit dense exponent. The added scan is `total_bits` bit reads, negligible against even a single `monsq`.

Measurements come from a harness that builds the pre-#1188 binary loop, the #1188 eager-table version, and this version into one crate sharing byte-identical `arith` code, so the exponentiation loop is the only variable.

## Testing

Outputs are unchanged. Verified byte-identical against both the windowing eager version and the pre windowing binary one over **14,510 differential cases**, every one also cross-checked against `num::BigUint::modpow`:

- exponent bit lengths straddling every window-width threshold (1, 2, 3, 7, 8, 9, 15, 16, 17, 18, 31, 32, 63, 64, 65, 66, 127, 128, 255, 256, 257, 258, 511, 512, 767, 768, 769, 770, 1024) at five bit patterns each, including hamming-weight-1, top-and-bottom-bit, dense, random, and sparse-masked
- odd, even, power-of-two, one and zero moduli across ten modulus sizes
- zero bases and zero exponents

The crate's 19 unit tests pass, including `test_modexp_random_against_biguint` added in #1188. `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings -D clippy::as_conversions` are clean for the crate.

## How should this be reviewed

The load-bearing question is whether every table index the main loop reads is actually built.

`max_digit` starts at 1, so entries 0 and 1 are always present, and `table_len >= 2` keeps the `2..table_len` build loop well-formed. The scan runs over `0..num_windows`, which is exactly the set of window indices the main loop reads: `num_windows - 1` for the seed and `0..num_windows - 1` for the body. So no digit read can exceed `max_digit`.

Also worth checking: `top` is non-zero. `total_bits` is exact, and `(num_windows - 1) * w <= total_bits - 1`, so the most significant bit falls inside the top window. That is why `table[top]` is always in range even though the chain no longer runs to `2^w - 1`.

Two follow-ups deliberately left out of this PR:

`montgomery_window_width` is mistuned at the low end of its range. Against the optimal fixed `w` for dense exponents, `L = 22` runs about 13.8% over, and `L = 17`, `L = 20` and `L = 69` are also several percent over. This is worth fixing separately and, importantly, worth re-deriving *after* this PR rather than alongside it: the cost model that justified the current thresholds assumed a table costing `2^w`, and once the chain stops at `max_digit` that model no longer describes sparse exponents.

Sub-quadratic (Karatsuba) multiplication, noted as a natural follow-up in #1188, is still open and unaffected by this change.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved modular exponentiation efficiency for sparse exponents by constructing only the intermediate values required.
  * Dense exponents retain their existing performance characteristics, while memory usage is reduced for sparse inputs.

* **Correctness**
  * Refined exponent window handling to correctly process the most significant bits and edge cases across supported window sizes.
  * Expanded validation across sparse, uniform, single-bit, and common exponent patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->